### PR TITLE
Add find_tool, use sh instead of %x in shell calls

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -8,6 +8,11 @@ def check_tool(tool)
   end
 end
 
+def find_tool(tool)
+  location = %x{which #{tool}}.chomp
+  location if $?.success?
+end
+
 def check_file(file)
   unless File.exist?(file)
     STDERR.puts "#{file} file not found...exiting"
@@ -141,8 +146,14 @@ def start_keychain
 end
 
 def gpg_sign_file(file)
-   check_tool('gpg')
-   %x{/usr/bin/gpg --armor --detach-sign -u #{@gpg_key} #{file}}
+  gpg ||= find_tool('gpg')
+  
+  if gpg
+    sh "#{gpg} --armor --detach-sign -u #{@gpg_key} #{file}"
+  else
+    STDERR.puts "No gpg available. Cannot sign tarball. Exiting..."
+    exit 1
+  end
 end
 
 def mkdir_pr *args

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -1,7 +1,7 @@
 
 def mock(mock_config, srpm)
   check_tool('mock')
-  %x{mock -r #{mock_config} #{srpm}}
+  sh "mock -r #{mock_config} #{srpm}"
 end
 
 def srpm_file


### PR DESCRIPTION
This commit adds the find_tool, which checks for the existence of a tool
and returns its location. This allows the tasks to prefer tools and fall
through without failing on the first non-existent tool as would happen
with check_tool. It also moves a few calls from using %x to using sh, as
%x supresses STDOUT, which is helpful when a password prompt is given so
the user knows why the script has paused.
