### PR TITLE
Fixup versioning for release and format

### DIFF
--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -51,8 +51,9 @@ rescue
 end
 
 @build_root   ||= Dir.pwd
-@version      ||= get_version
+@version      ||= get_dash_version
+@gemversion   ||= get_dot_version
 @debversion   ||= get_debversion
 @origversion  ||= get_origversion
 @rpmversion   ||= get_rpmversion
-@release      ||= get_release
+@rpmrelease   ||= get_rpmrelease

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -16,7 +16,7 @@ if @build_gem == TRUE or @build_gem == 'true' or @build_gem == 'TRUE'
 
   spec = Gem::Specification.new do |s|
     s.name = @name
-    s.version = @version
+    s.version = @gemversion
     s.author = @author
     s.email = @email
     s.homepage = @homepage


### PR DESCRIPTION
We started using dashes after the rc in our tags,
e.g. puppet-2.7.19-rc1 but the version determination
in packaging hasn't caught up. This adds support
for the dash version. The old method is kept because
it is required by rubygems. This commit also resolves
an issue where '-1puppetlabs1' is not added to the
deb version string if building an rc. Finally this
commit splits get_release out into rpm_release and
deb_release to avoid using an rpm_release string
in a deb.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
