### PR TITLE
Add support for dashboard-style version file

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -147,7 +147,13 @@ def get_rpmversion
 end
 
 def get_version_file_version
-  File.open( @version_file ) {|io| io.grep(/VERSION = /)}[0].split()[-1]
+  # Match version files containing 'VERSION = "x.x.x"' and just x.x.x
+  contents = IO.read(@version_file)
+  if version_string = contents.match(/VERSION =.*/)
+    version_string.to_s.split()[-1]
+  else
+    contents
+  end
 end
 
 def get_debrelease

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -6,8 +6,10 @@ namespace :package do
     new_version = '"' + @version.to_s.strip + '"'
     if contents.match("VERSION = #{old_version}")
       contents.gsub!("VERSION = #{old_version}", "VERSION = #{new_version}")
-    else
+    elsif contents.match("#{@name.upcase}VERSION = #{old_version}")
       contents.gsub!("#{@name.upcase}VERSION = #{old_version}", "#{@name.upcase}VERSION = #{new_version}")
+    else
+      contents.gsub!(old_version, @version)
     end
     file = File.open(@version_file, 'w')
     file.write contents


### PR DESCRIPTION
Puppet dashboard drops a version file containing just the
version string, not "VERSION = " or "$PROJECTVERSION = "
like the others. This commit adds checks for this as well
in packaging for the automatic version_bump.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
