### PR TITLE
fix debian version for non-tag git describes

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -135,7 +135,7 @@ def get_pwd_version
 end
 
 def get_debversion
-  (@version.include?("rc") ? @version.sub(/rc[0-9]+/, '0.1\0') : "#{@version}-1") + "#{@packager}#{get_debrelease}"
+  (@version.include?("rc") ? @version.sub(/rc[0-9]+/, '0.1\0') : "#{@version.gsub('-','.')}-1") + "#{@packager}#{get_debrelease}"
 end
 
 def get_origversion


### PR DESCRIPTION
The git describe version string that does not contain
an rc in it breaks debian tarball building because it
expects an orig tarball to match the odd different
version string parsing by dashes. This commit ensures
that the github describe is joined by dots in the
deb version to compose a correct version string.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
