### PR TITLE
Remove unnecessary require rspec/core/rake_task

### DIFF
--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -1,6 +1,3 @@
-require 'rubygems'
-require 'rubygems/package_task'
-require 'rspec/core/rake_task'
 require 'yaml'
 require 'erb'
 


### PR DESCRIPTION
We don't use rspec/core/rake_task directly in the
packaging repo, so we shouldn't require it. We should
also only require rubygems and rubygems/package_task
if we're building gems, otherwise we don't need it.
This commit adjusts the requires as such.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
