### PR TITLE
(packaging) add signing and shipping tasks for solaris

### DIFF
--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -35,6 +35,8 @@ begin
   @rc_mocks       = ENV['MOCK']         || @pkg_defaults['rc_mocks']
   @gpg_name       = ENV['GPG_NAME']     || @pkg_defaults['gpg_name']
   @gpg_key        = ENV['GPG_KEY']      || @pkg_defaults['gpg_key']
+  @certificate_pem= ENV['CERT_PEM']     || @pkg_defaults['certificate_pem']
+  @privatekey_pem = ENV['PRIVATE_PEM']  || @pkg_defaults['privatekey_pem']
   @build_gem      = ENV['GEM']          || @pkg_defaults['build_gem']
   @build_dmg      = ENV['DMG']          || @pkg_defaults['build_dmg']
   @yum_host       = @pkg_defaults['yum_host']
@@ -43,6 +45,8 @@ begin
   @apt_repo_url   = @pkg_defaults['apt_repo_url']
   @apt_repo_path  = @pkg_defaults['apt_repo_path']
   @ips_repo       = @pkg_defaults['ips_repo']
+  @ips_store      = @pkg_defaults['ips_store']
+  @ips_host       = @pkg_defaults['ips_host']
 rescue
   STDERR.puts "There was an error loading the packaging defaults from the 'ext/build_defaults.yaml' file."
   exit 1

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -15,6 +15,14 @@ namespace :pl do
     rsync_to('pkg/deb/', @apt_host, @apt_repo_path)
   end
 
+  desc "Update remote ips repository on #{@ips_host}"
+  task :update_ips_repo do
+    rsync_to('pkg/ips/pkgs', @ips_host, @ips_store)
+    remote_ssh_cmd(@ips_host, "pkgrecv -s #{@ips_store}/pkgs/#{@name}@#{@ipsversion}.p5p -d #{@ips_repo} \\*")
+    remote_ssh_cmd(@ips_host, "pkgrepo refresh -s #{@ips_repo}")
+    remote_ssh_cmd(@ips_host, "/usr/sbin/svcadm restart svc:/application/pkg/server")
+  end
+
   if @build_gem == TRUE or @build_gem == 'true' or @build_gem == 'TRUE'
     desc "Ship built gem to rubygems"
     task :ship_gem do

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -15,6 +15,13 @@ def sign_deb_changes(file)
   %x{debsign --re-sign -k#{@gpg_key} #{file}}
 end
 
+# requires atleast a self signed prvate key and certificate pair
+def sign_ips(pkg)
+  %x{pkgsign -s pkg/ips/repo/  -k #{@privatekey_pem} -c #{@certificate_pem} #{@name}@#{@ipsversion}}
+  %x{rm -f #{pkg}}
+  %x{pkgrecv -s pkg/ips/repo -a -d #{pkg} #{@name}@#{@ipsversion}}
+end
+
 namespace :pl do
   desc "Sign the tarball, defaults to PL key, pass GPG_KEY to override or edit build_defaults"
   task :sign_tar do
@@ -33,6 +40,13 @@ namespace :pl do
     sign_el5 el5_rpms
     puts "Signing el6 and fedora rpms..."
     sign_modern modern_rpms
+  end
+
+  desc "Sign ips package, Defaults to PL Key, pass KEY to override"
+  task :sign_ips do
+    ips_pkgs    = Dir["pkg/ips/pkgs/*.p5p"].join(' ')
+    puts "Signing ips packages..."
+    sign_ips ips_pkgs
   end
 
   desc "Check if all rpms are signed"


### PR DESCRIPTION
This patch adds signing and shipping tasks to solaris ips. We need atleast
a self signed certificate and its key to use the task in pem format.

This patch also assumes that the user that built the package in the current
system is present in the ips repository and we have permissions to sync.
