### PR TITLE
Add a re-try option, initially to cow-building

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -234,3 +234,28 @@ def x(v)
   print %x[#{v}]
 end
 
+def ask_yes_or_no
+  answer = STDIN.gets.downcase.chomp
+  case answer
+    when /^y$|^yes$/
+      answer = TRUE
+    when /^n$|^no$/
+      answer = FALSE
+    else
+      puts "Nope, try something like yes or no or y or n, etc:"
+      ask_yes_or_no
+  end
+  answer
+end
+
+def handle_method_failure(method, args)
+  STDERR.puts "There was an error running the method #{method} with the arguments:"
+  args.each { |param, arg| STDERR.puts "\t#{param} => #{arg}\n" }
+  STDERR.puts "The rake session is paused. Would you like to retry #{method} with these args and continue where you left off? [y,n]"
+  if ask_yes_or_no
+    send(method, args)
+  else
+    exit 1
+  end
+end
+

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -5,9 +5,9 @@ def pdebuild args
   set_cow_envs(cow)
   begin
     sh "pdebuild --configfile #{@pbuild_conf} --buildresult #{results_dir} --pbuilder cowbuilder -- --override-config --othermirror=\"deb #{@apt_repo_url} #{ENV['DIST']} main dependencies #{devel_repo}\" --basepath /var/cache/pbuilder/#{cow}/"
-  rescue
-    STDERR.puts "Something went wrong. Hopefully the backscroll or #{results_dir}/#{@name}_#{@debversion}.build file has a clue."
-    exit 1
+  rescue Exception => e
+    puts e
+    handle_method_failure('pdebuild', args)
   end
 end
 
@@ -55,13 +55,9 @@ task :build_deb, :deb_command, :cow, :devel do |t,args|
   Rake::Task[:prep_deb_tars].invoke(work_dir)
   cd "#{work_dir}/#{@name}-#{@debversion}" do
     mv 'ext/debian', '.'
-    begin
-      send(deb_build, deb_args)
-      cp FileList["#{work_dir}/*.deb", "#{work_dir}/*.dsc", "#{work_dir}/*.changes", "#{work_dir}/*.debian.tar.gz", "#{work_dir}/*.orig.tar.gz"], dest_dir
-      rm_rf "#{work_dir}/#{@name}-#{@debversion}"
-    rescue
-      STDERR.puts "Something went wrong. Hopefully the backscroll or #{work_dir}/#{@name}_#{@debversion}.build file has a clue."
-    end
+    send(deb_build, deb_args)
+    cp FileList["#{work_dir}/*.deb", "#{work_dir}/*.dsc", "#{work_dir}/*.changes", "#{work_dir}/*.debian.tar.gz", "#{work_dir}/*.orig.tar.gz"], dest_dir
+    rm_rf "#{work_dir}/#{@name}-#{@debversion}"
     rm_rf work_dir
   end
 end


### PR DESCRIPTION
currently, building for a set of cows is one of the
longest packaging tasks, and a failure in any one
essentially requires the whole set be redone. This
commit adds a rescue to the cow building method that
pauses the rake task and prompts the user for a 'retry'
if desired, allowing us to fix any issues with the
current cow and pick up where we left off. Since its
a utility function, this can be added to other areas
in packaging as well.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
