### PR TITLE
Add full release chains with ship confirmations

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -253,3 +253,15 @@ def handle_method_failure(method, args)
   end
 end
 
+def invoke_task(task, args=nil)
+  Rake::Task[task].reenable
+  Rake::Task[task].invoke(args)
+end
+
+def confirm_ship(files)
+  STDOUT.puts "The following files have been built and are ready to ship:"
+  files.each { |file| STDOUT.puts "\t#{file}\n" }
+  STDOUT.puts "Ship these files??"
+  ask_yes_or_no
+end
+

--- a/tasks/version.rake
+++ b/tasks/version.rake
@@ -1,0 +1,20 @@
+namespace :package do
+  desc "Update the version in #{@version_file} to current and commit."
+  task :versionbump  do
+    old_version =  get_version_file_version
+    contents = IO.read(@version_file)
+    new_version = '"' + @version.to_s.strip + '"'
+    if contents.match("VERSION = #{old_version}")
+      contents.gsub!("VERSION = #{old_version}", "VERSION = #{new_version}")
+    elsif contents.match("#{@name.upcase}VERSION = #{old_version}")
+      contents.gsub!("#{@name.upcase}VERSION = #{old_version}", "#{@name.upcase}VERSION = #{new_version}")
+    else
+      contents.gsub!(old_version, @version)
+    end
+    file = File.open(@version_file, 'w')
+    file.write contents
+    file.close
+    git_commit_file(@version_file)
+  end
+end
+


### PR DESCRIPTION
This commit adds task chains for building and shipping
for gems, debs, and rpms. This commit introduces ship confirmations -
prior to shipping, files are displayed and a confirmation is
requested. This should help prevent inadvertent shipping when
using these simpler, but longer, tasks.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
