### PR TITLE
Update mock task to correctly link noarch rpms

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -49,7 +49,7 @@ def build_rpm_with_mock(is_rc, subdir)
         end
       end
 
-      case rpm
+      case File.basename(rpm)
         when /debuginfo/
           rm_rf(rpm)
         when /src\.rpm/
@@ -60,7 +60,7 @@ def build_rpm_with_mock(is_rc, subdir)
           cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/x86_64")
         when /noarch/
           cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/i386")
-          ln("pkg/#{family}/#{version}/#{subdir}/i386/#{File.basename rpm}", "pkg/#{family}/#{version}/#{subdir}/x86_64/")
+          ln("pkg/#{family}/#{version}/#{subdir}/i386/#{File.basename(rpm)}", "pkg/#{family}/#{version}/#{subdir}/x86_64/")
       end
     end
   end


### PR DESCRIPTION
Previously the mock method would switch on the full path of the rpm, which
would never include noarch. This commit addresses that by switching on
File.basename(rpm) which will limit the switch to the filename, which will have
noarch, i386, x86_64, or src in its contents. It correctly links noarch
packages into i386 and x86_64.
