### PR TITLE
Load keychain earlier in full release tasks

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -163,9 +163,12 @@ def get_rpmrelease
     end
 end
 
-def restart_keychain
-  kill_keychain
-  start_keychain
+def load_keychain
+  unless @keychain_loaded
+    kill_keychain
+    start_keychain
+    @keychain_loaded = TRUE
+  end
 end
 
 def kill_keychain

--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -53,11 +53,12 @@ rescue
   exit 1
 end
 
-@build_root   ||= Dir.pwd
-@version      ||= get_dash_version
-@gemversion   ||= get_dot_version
-@ipsversion   ||= get_ips_version
-@debversion   ||= get_debversion
-@origversion  ||= get_origversion
-@rpmversion   ||= get_rpmversion
-@rpmrelease   ||= get_rpmrelease
+@build_root      ||= Dir.pwd
+@version         ||= get_dash_version
+@gemversion      ||= get_dot_version
+@ipsversion      ||= get_ips_version
+@debversion      ||= get_debversion
+@origversion     ||= get_origversion
+@rpmversion      ||= get_rpmversion
+@rpmrelease      ||= get_rpmrelease
+@keychain_loaded ||= FALSE

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -13,6 +13,7 @@ namespace :pl do
 
   desc "Release deb RCs, e.g. package:tar, pl:{deb_all_rc, sign_deb_changes, ship_debs}"
   task :release_deb_rc do
+    load_keychain
     invoke_task("pl:deb_all_rc")
     invoke_task("pl:sign_deb_changes")
     if confirm_ship(FileList["pkg/deb/**/*"])
@@ -22,6 +23,7 @@ namespace :pl do
 
   desc "Release deb FINALs, e.g. package:tar, pl:{deb_all, sign_deb_changes, ship_debs}"
   task :release_deb_final do
+    load_keychain
     invoke_task("pl:deb_all")
     invoke_task("pl:sign_deb_changes")
     if confirm_ship(FileList["pkg/deb/**/*"])

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -29,6 +29,7 @@ namespace :pl do
       STDERR.puts "No tarball exists. Try rake package:tar?"
       exit 1
     end
+    load_keychain
     gpg_sign_file "pkg/#{@name}-#{@version}.tar.gz"
   end
 
@@ -70,7 +71,7 @@ namespace :pl do
 
   desc "Sign generated debian changes files. Defaults to PL Key, pass KEY to override"
   task :sign_deb_changes do
-    restart_keychain
+    load_keychain
     sign_deb_changes("pkg/deb/*/*.changes") unless Dir["pkg/deb/*/*.changes"].empty?
     sign_deb_changes("pkg/deb/*.changes") unless Dir["pkg/deb/*.changes"].empty?
   end


### PR DESCRIPTION
This commit renames the restart_keychain method
and adds a variable to keep track of if the keychain
has been loaded. This allows us to load the keychain
earlier in the deb building tasks without clobbering
it again later.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
