### PR TITLE
Make git repo check more robust

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -113,7 +113,7 @@ def timestamp
 end
 
 def get_dash_version
-  if File.exists?('.git')
+  if is_git_repo
     %x{git describe}.chomp.split('-')[0..1].join('-').gsub('v','')
   else
     get_pwd_version
@@ -322,3 +322,9 @@ def remote_bootstrap(host, treeish)
   sh "ssh -t #{host} 'tar -zxvf /tmp/#{tarball_name}.tar.gz -C /tmp/ ; git clone /tmp/#{tarball_name} /tmp/#{@name}-#{appendix} ; cd /tmp/#{@name}-#{appendix} ; rake package:bootstrap'"
   "/tmp/#{@name}-#{appendix}"
 end
+
+def is_git_repo
+  %x{git rev-parse --git-dir > /dev/null 2>&1}
+  return $?.success?
+end
+


### PR DESCRIPTION
Currently the git repo check switching on a .git directory
existing in the rake root. This doesn't work if the top-level
Rakefile exists in a subdirectory of the project. Instead, we
can use git rev-parse --git-dir to more effectively determine
if we're in a git repo.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
