### PR TITLE
Break templating erbs out into its own task

### DIFF
--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -8,9 +8,7 @@ namespace :package do
     FileList[@files.split(' ')].each do |f|
       cp_pr(f, workdir)
     end
-    erb("#{workdir}/ext/redhat/#{@name}.spec.erb", "#{workdir}/ext/redhat/#{@name}.spec")
-    erb("#{workdir}/ext/debian/changelog.erb", "#{workdir}/ext/debian/changelog")
-    rm_rf(FileList["#{workdir}/ext/debian/*.erb", "#{workdir}/ext/redhat/*.erb"])
+    Rake::Task["package:template"].invoke(workdir)
     cd "pkg" do
       sh "#{tar} --exclude=.gitignore --exclude=ext/#{@packaging_repo} -zcf #{@name}-#{@version}.tar.gz #{@name}-#{@version}"
     end

--- a/tasks/template.rake
+++ b/tasks/template.rake
@@ -1,0 +1,10 @@
+# utility task to lay down packaging artifact files from erb templates
+namespace :package do
+  task :template, :workdir do |t, args|
+    workdir = args.workdir
+    erb("#{workdir}/ext/redhat/#{@name}.spec.erb", "#{workdir}/ext/redhat/#{@name}.spec")
+    erb("#{workdir}/ext/debian/changelog.erb", "#{workdir}/ext/debian/changelog")
+    rm_rf(FileList["#{workdir}/ext/debian/*.erb", "#{workdir}/ext/redhat/*.erb"])
+  end
+end
+


### PR DESCRIPTION
Currently erbs are layed down as part of tarball
generation. In some cases (e.g., using a source repo's
existing tar task), we may want to utilize just the erb
functionality. This commit breaks this out into its own
task.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
