### PR TITLE
Remove explicit othermirror settings

### DIFF
--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -5,7 +5,10 @@ def pdebuild args
   set_cow_envs(cow)
   update_cow(cow, devel_repo)
   begin
-    sh "pdebuild --configfile #{@pbuild_conf} --buildresult #{results_dir} --pbuilder cowbuilder -- --override-config --othermirror=\"deb #{@apt_repo_url} #{ENV['DIST']} main dependencies #{devel_repo}\" --basepath /var/cache/pbuilder/#{cow}/"
+    sh "pdebuild  --configfile #{@pbuild_conf} \
+                  --buildresult #{results_dir} \
+                  --pbuilder cowbuilder -- \
+                  --basepath /var/cache/pbuilder/#{cow}/"
   rescue Exception => e
     puts e
     handle_method_failure('pdebuild', args)


### PR DESCRIPTION
We set the dependency URLs appropriately in the
cowbuilder update, and this includes support for
PE URLs as well. If we remove the explicit other-
mirror settings, we can take advantage of this.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
