### PR TITLE
Add a crude 'refresh' task

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -328,3 +328,7 @@ def is_git_repo
   return $?.success?
 end
 
+def git_pull(remote, branch)
+  sh "git pull #{remote} #{branch}"
+end
+

--- a/tasks/update.rake
+++ b/tasks/update.rake
@@ -1,0 +1,16 @@
+namespace :package do
+  desc "Update your clone of the packaging repo with `git pull`"
+  task :update do
+    cd 'ext/packaging' do
+      remote = @packaging_url.split(' ')[0]
+      branch = @packaging_url.split(' ')[1].split('=')[1]
+      if branch.nil? or remote.nil?
+        STDERR.puts "Couldn't parse the packaging repo URL from 'ext/build_defaults.yaml'."
+        STDERR.puts "Normally this is a string in the format git@github.com:<User>/<packaging_repo> --branch=<branch>"
+      else
+        git_pull(remote, branch)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This commit adds a task that parses the packaging
repo url and does a git pull on it, pulling in any
changes from the specified remote.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
