### PR TITLE
Add support for excluding files in the tarball task

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ version_file: '/lib/hiera.rb'
 # files and gem_files are space separated lists
 # files to be packaged into a tarball and released with deb/rpm
 files: '[A-Z]* ext lib bin spec acceptance_tests'
+# space separated list of files to *exclude* from the tarball
+# note that each listing in files, above, is recursively copied into the tarball, so
+# 'tar_excludes' only needs to include any undesired subdirectories/files of the 'files'
+# list to exclude
+tar_excludes: 'ext/packaging lib/some_excluded_file'
 # files to be packaged into a gem
 gem_files: '{bin,lib}/**/* CHANGELOG COPYING README.md LICENSE'
 # To exclude specific files from inclusion in a gem:

--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -10,6 +10,7 @@ begin
   @summary                  = @project_specs['summary']
   @description              = @project_specs['description']
   @files                    = @project_specs['files']
+  @tar_excludes             = @project_specs['tar_excludes']
   @version_file             = @project_specs['version_file']
   @gem_files                = @project_specs['gem_files']
   @gem_require_path         = @project_specs['gem_require_path']

--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -8,9 +8,11 @@ namespace :package do
     FileList[@files.split(' ')].each do |f|
       cp_pr(f, workdir)
     end
+    tar_excludes = @tar_excludes.nil? ? [] : @tar_excludes.split(' ')
+    tar_excludes << "ext/#{@packaging_repo}"
     Rake::Task["package:template"].invoke(workdir)
     cd "pkg" do
-      sh "#{tar} --exclude=.gitignore --exclude=ext/#{@packaging_repo} -zcf #{@name}-#{@version}.tar.gz #{@name}-#{@version}"
+      sh "#{tar} --exclude #{tar_excludes.join(" --exclude ")} -zcf #{@name}-#{@version}.tar.gz #{@name}-#{@version}"
     end
     rm_rf(workdir)
     puts


### PR DESCRIPTION
Many projects specifically exclude files from the tarball.
This adds support for this in the packaging repo.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
