### PR TITLE
Fix the macro for %dist detection on rpm platforms.

### DIFF
--- a/tasks/rpm.rake
+++ b/tasks/rpm.rake
@@ -1,7 +1,8 @@
 def build_rpm(buildarg = "-bs")
   check_tool('rpmbuild')
   temp = get_temp
-  rpm_define = "--define \"%dist .el5\" --define \"%_topdir  #{temp}\" "
+  dist = find_version
+  rpm_define = "#{dist} --define \"%_topdir  #{temp}\" "
   rpm_old_version = '--define "_source_filedigest_algorithm 1" --define "_binary_filedigest_algorithm 1" \
      --define "_binary_payload w9.gzdio" --define "_source_payload w9.gzdio" \
      --define "_default_patch_fuzz 2"'
@@ -23,6 +24,18 @@ def build_rpm(buildarg = "-bs")
   output.each do | line |
     puts line
   end
+end
+
+def find_version()
+   if File.exists?('/etc/fedora-release')
+      nil
+   elsif File.exists?('/etc/redhat-release')
+      dist = %x{rpm -q --qf \"%{VERSION}\" $(rpm -q --whatprovides /etc/redhat-release )}
+      unless dist > 5
+        return "--define \"%dist .el#{dist}\""
+      end
+      nil
+   end
 end
 
 namespace :package do


### PR DESCRIPTION
Prior to this commit, when building an RPM on EL6, the dist tag would
still be tagged with el5.  This commits dynamically detects the dist
tag.

Dist is provided on all EL and Fedora systems except EL5.  The solution
is to query if it's EL and then see what the major version of the RPM is
that provides that file.

Fixes #50 Pull request as well.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
