### PR TITLE
Remove ENV['USER'] in rsync/ssh calls

### DIFF
--- a/tasks/00_utils.rb
+++ b/tasks/00_utils.rb
@@ -87,7 +87,7 @@ def rsync_to *args
   target  = args[1]
   dest    = args[2]
   puts "rsyncing #{source} to #{target}"
-  %x{rsync #{flags} #{source} #{ENV['USER']}@#{target}:#{dest}}
+  %x{rsync #{flags} #{source} #{target}:#{dest}}
 end
 
 def rsync_from *args
@@ -97,15 +97,15 @@ def rsync_from *args
   target  = args[1]
   dest    = args[2]
   puts "rsyncing #{source} from #{target} to #{dest}"
-  %x{rsync #{flags} #{ENV['USER']}@#{target}:#{source} #{dest}}
+  %x{rsync #{flags} #{target}:#{source} #{dest}}
 end
 
 def scp_file_from(host,path,file)
-  %x{scp #{ENV['USER']}@#{host}:#{path}/#{file} #{@tempdir}/#{file}}
+  %x{scp #{host}:#{path}/#{file} #{@tempdir}/#{file}}
 end
 
 def scp_file_to(host,path,file)
-  %x{scp #{@tempdir}/#{file} #{ENV['USER']}@#{host}:#{path}}
+  %x{scp #{@tempdir}/#{file} #{host}:#{path}}
 end
 
 def timestamp


### PR DESCRIPTION
By relying on ENV['USER'] in calling to ssh/rsync, we break anyone who has
different usernames on remote hosts. This removes the user prefixes, instead
relying on users to have an appropriately configured ssh config or identical
local and remote user names.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
