### PR TITLE
Remove sles-11-i586 from package repos

### DIFF
--- a/tasks/pe_sles.rake
+++ b/tasks/pe_sles.rake
@@ -27,6 +27,9 @@ if @build_pe
       end
       cd "#{ENV['HOME']}/package_repos" do
         unless File.symlink?('sles-11-i586')
+          if File.exist?('sles-11-i586')
+            rm_rf 'sles-11-i586'
+          end
           File.symlink('sles-11-i386', 'sles-11-i586')
         end
       end


### PR DESCRIPTION
We should never have a sles-11-i586 in package_repos that is not
a symlink. If we do, it's cruft from an older era. This commit
removes it if it exists and is not a symlink.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
