### PR TITLE
Add load_extras to remote_dmg task

### DIFF
--- a/tasks/remote_build.rake
+++ b/tasks/remote_build.rake
@@ -38,7 +38,7 @@ if File.exist?("#{ENV['HOME']}/.packaging/#{@builder_data_file}")
     end
 
     desc "Execute package:apple on remote apple build host"
-    task :remote_dmg => :fetch do
+    task :remote_dmg => ['pl:fetch', 'pl:load_extras'] do
       # Because we use rvmsudo for apple, we end up replicating the :remote_build task
       host                    = @osx_build_host
       treeish                 = 'HEAD'


### PR DESCRIPTION
Without this change the remote dmg task will have no way of knowing where to
send build artifacts, so it will fail in various ways, most notably by sshing
to the empty string.
