### PR TITLE
Fix stub method mismatch in rspec-expectations

### DIFF
--- a/spec/tasks/00_utils_spec.rb
+++ b/spec/tasks/00_utils_spec.rb
@@ -7,25 +7,25 @@ describe "00_utils" do
     '0.7.0'                   => {
       :git_describe_version   => %w{0.7.0},
       :get_dash_version       => '0.7.0',
-      :get_ips_version        => '0.7.0,12.2.0-0',
+      :get_ips_version        => '0.7.0,3.14159-0',
       :get_dot_version        => '0.7.0'
     },
     '0.7.0rc1'                => {
       :git_describe_version   => %w{0.7.0rc1},
       :get_dash_version       => '0.7.0rc1',
-      :get_ips_version        => '0.7.0rc1,12.2.0-0',
+      :get_ips_version        => '0.7.0rc1,3.14159-0',
       :get_dot_version        => '0.7.0rc1'
     },
     '0.7.0-63-ge391f55'       => {
       :git_describe_version   => %w{0.7.0 63},
       :get_dash_version       => '0.7.0-63',
-      :get_ips_version        => '0.7.0,12.2.0-63',
+      :get_ips_version        => '0.7.0,3.14159-63',
       :get_dot_version        => '0.7.0.63'
     },
     '0.7.0-63-ge391f55-dirty' => {
       :git_describe_version   => %w{0.7.0 63 dirty},
       :get_dash_version       => '0.7.0-63-dirty',
-      :get_ips_version        => '0.7.0,12.2.0-63-dirty',
+      :get_ips_version        => '0.7.0,3.14159-63-dirty',
       :get_dot_version        => '0.7.0.63.dirty'
     },
   }
@@ -34,11 +34,14 @@ describe "00_utils" do
     results = TestVersions[input]
     results.keys.sort_by(&:to_s).each do |method|
       it "using #{method} #{input.inspect} becomes #{results[method].inspect}" do
-        self.stub(:uname_r     => "12.2.0")
-        self.stub(:is_git_repo => true)
+        # We have to call the `stub!` alias because we are trying to stub on
+        # `self`, and in the scope of an rspec block that is overridden to
+        # return a new double, not to stub a method!
+        self.stub!(:uname_r) { "3.14159" }
+        self.stub!(:is_git_repo) { true }
         self.should_receive(:run_git_describe_internal).and_return(input)
 
-        send(method).should == results[method]
+        self.send(method).should == results[method]
       end
     end
   end


### PR DESCRIPTION
Because we are trying to test methods defined at global scope, the overlap
between `stub` as "give me a mock object" and `stub` as "stub this method" on
the rspec test block caused the stub to fail.

This fixes that by using `stub!` to cause a real stub to happen...

Signed-off-by: Daniel Pittman daniel@rimspace.net
