### PR TITLE
exclude junk files from tar

### DIFF
--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -9,6 +9,22 @@ namespace :package do
     # The list of files to install in the tarball
     install = FileList.new
 
+    # It is nice to use arrays in YAML to represent array content, but we used
+    # to support a mode where a space-separated string was used.  Support both
+    # to allow a gentle migration to a modern style...
+    patterns =
+      case @files
+      when String
+        STDERR.puts "warning: `files` should be an array, not a string"
+        @files.split(' ')
+
+      when Array
+        @files
+
+      else
+        raise "`files` must be a string or an array!"
+      end
+
     # We need to add our list of file patterns from the configuration; this
     # used to be a list of "things to copy recursively", which would install
     # editor backup files and other nasty things.
@@ -19,7 +35,7 @@ namespace :package do
     # Eventually, when all our projects are migrated to the new standard, we
     # can drop this in favour of just pushing the patterns directly into the
     # FileList and eliminate many lines of code and comment.
-    patterns = @files.split(' ').each do |pattern|
+    patterns.each do |pattern|
       if File.directory?(pattern)
         install.add(pattern + "/**/*")
       else


### PR DESCRIPTION
The previous generation rake package:tar task would include editor backups and other junk in the tarball, because it created it from a recursive copy of directories in the typical case.

This moves to using the rake FileList class, which gives good default exclusions, and a cleaner interface to explicit exclusion later if required.
