### PR TITLE
Copy files to workdir quietly instead of using tar

### DIFF
--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -45,7 +45,11 @@ namespace :package do
 
     # Transfer all the files and symlinks into the working directory...
     install = install.select {|x| File.file?(x) or File.symlink?(x) }
-    sh "tar c #{install} | tar x -C #{workdir}"
+
+    install.each do |file|
+      mkpath(File.dirname( File.join(workdir, file) ), :verbose => false)
+      cp_p(file, File.join(workdir, file), :verbose => false)
+    end
 
     tar_excludes = @tar_excludes.nil? ? [] : @tar_excludes.split(' ')
     tar_excludes << "ext/#{@packaging_repo}"


### PR DESCRIPTION
Previously the tar task passed the list of files to be installed in a tarball
on the commandline to tar and piped it to tar x to get a list of files. That
would fail on large lists of files. This commit addresses that by looping over
all of the files and copying each file into the correct path in the workdir.
Verbose is set to false for both calls, so the output should be minimal.
