### PR TITLE
Only sign rpms if there are rpms

### DIFF
--- a/tasks/pe_sign.rake
+++ b/tasks/pe_sign.rake
@@ -20,8 +20,8 @@ namespace :pe do
         end
       end
     end
-    sign_el5(old_rpms)
-    sign_modern(modern_rpms)
+    sign_el5(old_rpms) unless old_rpms.empty?
+    sign_modern(modern_rpms) unless modern_rpms.empty?
   end
 end
 

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -37,10 +37,15 @@ namespace :pl do
   task :sign_rpms do
     el5_rpms    = Dir["pkg/el/5/**/*.rpm"].join(' ')
     modern_rpms = (Dir["pkg/el/6/**/*.rpm"] + Dir["pkg/fedora/**/*.rpm"]).join(' ')
-    puts "Signing el5 rpms..."
-    sign_el5 el5_rpms
-    puts "Signing el6 and fedora rpms..."
-    sign_modern modern_rpms
+    unless el5_rpms.empty?
+      puts "Signing el5 rpms..."
+      sign_el5(el5_rpms)
+    end
+
+    unless modern_rpms.empty?
+      puts "Signing el6 and fedora rpms..."
+      sign_modern(modern_rpms)
+    end
   end
 
   desc "Sign ips package, Defaults to PL Key, pass KEY to override"


### PR DESCRIPTION
Previously the sign task would mysteriously print "no files to sign" after
asking for the passphrase. This updates the tasks to only try to sign if there
are rpms to sign.
