### PR TITLE
Maint/master/revert changes to tarball task

### DIFF
--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -5,32 +5,9 @@ namespace :package do
     tar = ENV['TAR'] || 'tar'
     workdir = "pkg/#{@name}-#{@version}"
     mkdir_p(workdir)
-
-    # The list of files to install in the tarball
-    install = FileList.new
-
-    # We need to add our list of file patterns from the configuration; this
-    # used to be a list of "things to copy recursively", which would install
-    # editor backup files and other nasty things.
-    #
-    # This handles that case correctly, with a deprecation warning, to augment
-    # our FileList with the right things to put in place.
-    #
-    # Eventually, when all our projects are migrated to the new standard, we
-    # can drop this in favour of just pushing the patterns directly into the
-    # FileList and eliminate many lines of code and comment.
-    patterns = @files.split(' ').each do |pattern|
-      if File.directory?(pattern)
-        install.add(pattern + "/**/*")
-      else
-        install.add(pattern)
-      end
+    FileList[@files.split(' ')].each do |f|
+      cp_pr(f, workdir)
     end
-
-    # Transfer all the files and symlinks into the working directory...
-    install = install.select {|x| File.file?(x) or File.symlink?(x) }
-    sh "tar c #{install} | tar x -C #{workdir}"
-
     tar_excludes = @tar_excludes.nil? ? [] : @tar_excludes.split(' ')
     tar_excludes << "ext/#{@packaging_repo}"
     Rake::Task["package:template"].invoke(workdir)


### PR DESCRIPTION
This pull request reverts three commits that modify the tarball creation process to using FileLists, because of a newly introduced  bug in which empty directories in source intended for packaging are not included in the tarball. Normally these sorts of issues can be handled in packaging (e.g. rpm/deb), but when running directly from a source tarball this is not the case. Once the empty directory case is handled, these commits _should_ be returned to master.
