### PR TITLE
Maint/master/return tar fixes

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -361,3 +361,6 @@ def update_rpm_repo(dir)
   end
 end
 
+def empty_dir?(dir)
+  File.exist?(dir) and File.directory?(dir) and Dir["#{dir}/**/*"].empty?
+end

--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -36,7 +36,7 @@ namespace :package do
     # can drop this in favour of just pushing the patterns directly into the
     # FileList and eliminate many lines of code and comment.
     patterns.each do |pattern|
-      if File.directory?(pattern)
+      if File.directory?(pattern) and not Dir[pattern + "/**/*"].empty?
         install.add(pattern + "/**/*")
       else
         install.add(pattern)
@@ -44,11 +44,15 @@ namespace :package do
     end
 
     # Transfer all the files and symlinks into the working directory...
-    install = install.select {|x| File.file?(x) or File.symlink?(x) }
+    install = install.select { |x| File.file?(x) or File.symlink?(x) or empty_dir?(x) }
 
     install.each do |file|
-      mkpath(File.dirname( File.join(workdir, file) ), :verbose => false)
-      cp_p(file, File.join(workdir, file), :verbose => false)
+      if empty_dir?(file)
+        mkpath(File.join(workdir,file), :verbose => false)
+      else
+        mkpath(File.dirname( File.join(workdir, file) ), :verbose => false)
+        cp_p(file, File.join(workdir, file), :verbose => false)
+      end
     end
 
     tar_excludes = @tar_excludes.nil? ? [] : @tar_excludes.split(' ')


### PR DESCRIPTION
This PR reverts the revert commits earlier that removed many package:tar improvements because of an empty directory handling issue. After adding these back in, this PR fixes the empty directory issue by creating them in the target tarball structure along with the files that are copied in.
