### PR TITLE
Allow passing envvars to remote rpm and deb builds

### DIFF
--- a/tasks/remote_build.rake
+++ b/tasks/remote_build.rake
@@ -18,25 +18,25 @@ if File.exist?("#{ENV['HOME']}/.packaging/#{@builder_data_file}")
     desc "Execute release_deb_rc full build set on remote debian build host"
     task :remote_deb_rc => ['pl:fetch', 'pl:load_extras'] do
       Rake::Task["pl:remote_build"].reenable
-      Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:release_deb_rc")
+      Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:release_deb_rc COW=#{@cows}")
     end
 
     desc "Execute release_deb_final full build set on remote debian build host"
     task :remote_deb_final => ['pl:fetch', 'pl:load_extras'] do
       Rake::Task["pl:remote_build"].reenable
-      Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:release_deb_final")
+      Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:release_deb_final COW=#{@cows}")
     end
 
     desc "Execute release_rpm_rc full build set on remote rpm build host"
     task :remote_rpm_rc => ['pl:fetch', 'pl:load_extras'] do
       Rake::Task["pl:remote_build"].reenable
-      Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:release_rpm_rc")
+      Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:release_rpm_rc MOCK=#{@rc_mocks}")
     end
 
     desc "Execute release_deb_final full build set on remote rpm build host"
     task :remote_rpm_final => ['pl:fetch', 'pl:load_extras'] do
       Rake::Task["pl:remote_build"].reenable
-      Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:release_rpm_final")
+      Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:release_rpm_final MOCK=#{@final_mocks}")
     end
 
     desc "Execute pl:ips on remote ips build host"


### PR DESCRIPTION
This PR adds support for passing cows and mocks to the remote builds. Helps along the path to building with jenkins.
