### PR TITLE
Allow remote building without signing

### DIFF
--- a/tasks/remote_build.rake
+++ b/tasks/remote_build.rake
@@ -21,10 +21,22 @@ if File.exist?("#{ENV['HOME']}/.packaging/#{@builder_data_file}")
       Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:release_deb_rc")
     end
 
+    desc "Execute deb_all_rc build on remote debian build host (no signing)"
+    task :remote_deb_rc_build => ['pl:fetch', 'pl:load_extras'] do
+      Rake::Task["pl:remote_build"].reenable
+      Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:deb_all_rc COW=#{@cows}")
+    end
+
     desc "Execute release_deb_final full build set on remote debian build host"
     task :remote_deb_final => ['pl:fetch', 'pl:load_extras'] do
       Rake::Task["pl:remote_build"].reenable
       Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:release_deb_final")
+    end
+
+    desc "Execute deb_all on remote debian build host (no signing)"
+    task :remote_deb_final_build => ['pl:fetch', 'pl:load_extras'] do
+      Rake::Task["pl:remote_build"].reenable
+      Rake::Task["pl:remote_build"].invoke(@deb_build_host, 'HEAD', "pl:deb_all COW=#{@cows}")
     end
 
     desc "Execute release_rpm_rc full build set on remote rpm build host"
@@ -33,10 +45,22 @@ if File.exist?("#{ENV['HOME']}/.packaging/#{@builder_data_file}")
       Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:release_rpm_rc")
     end
 
-    desc "Execute release_deb_final full build set on remote rpm build host"
+    desc "Execute mock_rc on remote rpm build host (no signing)"
+    task :remote_rpm_rc_build => ['pl:fetch', 'pl:load_extras'] do
+      Rake::Task["pl:remote_build"].reenable
+      Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:mock_rc MOCK=#{@rc_mocks}")
+    end
+
+    desc "Execute release_rpm_final full build set on remote rpm build host"
     task :remote_rpm_final => ['pl:fetch', 'pl:load_extras'] do
       Rake::Task["pl:remote_build"].reenable
       Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:release_rpm_final")
+    end
+
+    desc "Execute mock_final on remote rpm build host (no signing)"
+    task :remote_mock_final => ['pl:fetch', 'pl:load_extras'] do
+      Rake::Task["pl:remote_build"].reenable
+      Rake::Task["pl:remote_build"].invoke(@rpm_build_host, 'HEAD', "pl:mock_final MOCK=#{@final_mocks}")
     end
 
     desc "Execute pl:ips on remote ips build host"


### PR DESCRIPTION
This commit adds tasks that allow remote building of packages without signing.
This will be useful in automating the CI pipeline, allowing us to build from a
central location with jenkins without necessarily acknowledging release-able
status by signing and requiring a person on the other end. It also corrects an
error in one of the remote build task descriptions.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
