### PR TITLE
The great thing about standards for burning in versions...

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -200,16 +200,6 @@ def get_rpmversion
   get_base_pkg_version[0]
 end
 
-def get_version_file_version
-  # Match version files containing 'VERSION = "x.x.x"' and just x.x.x
-  contents = IO.read(@version_file)
-  if version_string = contents.match(/VERSION =.*/)
-    version_string.to_s.split()[-1]
-  else
-    contents
-  end
-end
-
 def get_debrelease
   ENV['RELEASE'] || '1'
 end

--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -58,6 +58,17 @@ namespace :package do
     tar_excludes = @tar_excludes.nil? ? [] : @tar_excludes.split(' ')
     tar_excludes << "ext/#{@packaging_repo}"
     Rake::Task["package:template"].invoke(workdir)
+
+    # This is to support packages that only burn-in the version number in the
+    # release artifact, rather than storing it two (or more) times in the
+    # version control system.  Razor is a good example of that; see
+    # https://github.com/puppetlabs/Razor/blob/master/lib/project_razor/version.rb
+    # for an example of that this looks like.
+    #
+    # If you set this the version will only be modified in the temporary copy,
+    # with the intent that it never change the official source tree.
+    ENV['NEW_STYLE_PACKAGE'] and Rake::Task["package:versionbump"].invoke(workdir)
+
     cd "pkg" do
       sh "#{tar} --exclude #{tar_excludes.join(" --exclude ")} -zcf #{@name}-#{@version}.tar.gz #{@name}-#{@version}"
     end


### PR DESCRIPTION
This adds support for Razor-style versioning:
- never store the version in git, other than as a tag
- never manually modify the version file
- automatically burn in version when building a release package

Very special-snowflake, in that it adds another mechanism without taking any way, but that is the joy of something as unimportant as versioning: everyone thinks their way matters more than everyone else.

I am, naturally, no exception, hence this pull request.
