### PR TITLE
Add support for rpm signing retries, looping

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -387,3 +387,20 @@ def hostname
   require 'socket'
   host = Socket.gethostname
 end
+
+# Loop a shell command up to the number of attempts given, exiting when we receive success
+# or max attempts is reached. Raise an exception unless we've succeeded.
+def loop_shell_command(command, max_attempts = 5)
+  success = FALSE
+  attempts = 0
+  while attempts < max_attempts
+    %x{#{command}}
+    if $?.success?
+      success = TRUE
+      break
+    end
+    attempts += 1
+  end
+  raise "Failed! command was: #{command}" unless success
+end
+

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -1,9 +1,11 @@
 def sign_el5(rpm)
-  %x{rpm --define '%_gpg_name #{@gpg_name}' --define '%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha1 --batch --no-verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}' --addsign #{rpm} > /dev/null}
+  # Try this up to 5 times, to allow for incorrect passwords
+  # loop_shell_command will raise an exception unless it recieves success
+  loop_shell_command("rpm --define '%_gpg_name #{@gpg_name}' --define '%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha1 --batch --no-verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}' --addsign #{rpm} > /dev/null", 5)
 end
 
 def sign_modern(rpm)
-  %x{rpm --define '%_gpg_name #{@gpg_name}' --addsign #{rpm} > /dev/null}
+  loop_shell_command("rpm --define '%_gpg_name #{@gpg_name}' --addsign #{rpm} > /dev/null", 5)
 end
 
 def rpm_has_sig(rpm)


### PR DESCRIPTION
This commit adds a 5-limit retry for rpm signing password failures,
via a new utility method, loop_shell_command. It also raises an
exception instead of failing silently and just continuing, as the
current methods do, which has resulted in accidentally shipping
unsigned rpms.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
