### PR TITLE
Make project_data and team_data truly optional

### DIFF
--- a/tasks/20_setupextravars.rake
+++ b/tasks/20_setupextravars.rake
@@ -8,8 +8,8 @@
 namespace :pl do
   task :load_extras do
     begin
-      @team_data = YAML.load_file("#{ENV['HOME']}/.packaging/team/#{@builder_data_file}")
-      @project_data = YAML.load_file("#{ENV['HOME']}/.packaging/project/#{@builder_data_file}")
+      @team_data = YAML.load_file("#{ENV['HOME']}/.packaging/team/#{@builder_data_file}") || {}
+      @project_data = YAML.load_file("#{ENV['HOME']}/.packaging/project/#{@builder_data_file}") || {}
       @pe_name          = @project_data['pe_name']       if @project_data['pe_name']
       @tarball_path     = @project_data['tarball_path']  if @project_data['tarball_path']
       @rpm_build_host   = @team_data['rpm_build_host']   if @team_data['rpm_build_host']


### PR DESCRIPTION
One of the awesome things about ruby hashes, is that nil isn't a hash. So if
you try to grab a value from nil using a key, ruby complains. For example
@project_data['pe_name'] fails horribly if @project_data is nil and not {}. So
this commit makes those instance variables {} if they were nil, so that these
lookups don't cause exceptions, but just return false or nil themselves.
