### PR TITLE
Ship debs to incoming/unified and rsync out of dist

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -21,8 +21,8 @@ if @build_pe
         STDERR.puts "The 'pkg/pe/deb/#{dist}' directory has no packages. Did you run rake pe:deb?"
         exit 1
       else
-        target_path = ENV['APT_REPO'] ? ENV['APT_REPO'] : "#{@apt_repo_path}/#{@pe_version}/repos/incoming/disparate/"
-        rsync_to("pkg/pe/deb/", @apt_host, target_path)
+        target_path = ENV['APT_REPO'] ? ENV['APT_REPO'] : "#{@apt_repo_path}/#{@pe_version}/repos/incoming/unified/"
+        rsync_to("pkg/pe/deb/#{dist}/", @apt_host, target_path)
         if @team == 'release'
           Rake::Task["pe:remote:freight"].invoke
         end


### PR DESCRIPTION
Currently the pe:all task calls pe:deb followed by pe:ship_debs (and ships to
disparate). This means that when packages are build in /pkg/pe/deb/squeeze,
they get rsynced to repos/incoming/disparate and then they also get shipped to
only the squeeze repo. This commit changes where they ship to unified and
doesn't ship the $dist directory with the ship. This ensures that the package
gets freighted to all the dists for the PE version.
