### PR TITLE
Add a :version task to print version

### DIFF
--- a/tasks/version.rake
+++ b/tasks/version.rake
@@ -52,5 +52,12 @@ namespace :package do
     Rake::Task["package:versionbump"].invoke
     git_commit_file(@version_file, "update to #{ENV['VERSION']}")
   end
+
+  # A set of tasks for printing the version
+  [:version, :rpmversion, :rpmrelease, :debversion, :release].each do |task|
+    task "#{task}" do
+      STDOUT.puts self.instance_variable_get("@#{task}")
+    end
+  end
 end
 


### PR DESCRIPTION
This commit adds simple version tasks for printing various version types of the
project, as introspected via git describe.  We're going to use this in jenkins
to introspect the package-version to be, and pass our version along to
downstream projects.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
