### PR TITLE
Add a hardcoded f18 destination, because that's how we roll

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -137,7 +137,7 @@ namespace :pl do
       %x{mkdir -p pkg/pe/rpm/el-{5,6}-{i386,x86_64,srpms}}
     else
       %x{mkdir -p pkg/el/{5,6}/{products,devel,dependencies}/{SRPMS,i386,x86_64}}
-      %x{mkdir -p pkg/fedora/{f16,f17}/{products,devel,dependencies}/{SRPMS,i386,x86_64}}
+      %x{mkdir -p pkg/fedora/{f16,f17,f18}/{products,devel,dependencies}/{SRPMS,i386,x86_64}}
     end
   end
 


### PR DESCRIPTION
Adding f18 to the mocks to build with caused problems because now f18 packages
have no destination to be written to. This commit applies a bandaid to the
gangrenous arm that is the setup of the mock config. There will be a more
robust solution later today.
