### PR TITLE
Maint/master/parallelize

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -227,7 +227,10 @@ namespace :pl do
       uber_tasks = ["jenkins:deb_all", "jenkins:mock_all", "jenkins:tar"]
       uber_tasks << "jenkins:dmg" if @build.build_dmg
       uber_tasks << "jenkins:gem" if @build.build_gem
-      uber_tasks.map { |t| "pl:#{t}" }.each { |t| invoke_task(t) }
+      uber_tasks.map { |t| "pl:#{t}" }.each do |t|
+        invoke_task(t)
+        sleep 5
+      end
     end
 
     desc "Retrieve packages built by jenkins, sign, and ship all!"
@@ -263,6 +266,7 @@ if @build.build_pe
         check_var("PE_VER", @build.pe_version)
         ["deb_all", "mock_all", "sles"].each do |task|
           invoke_task("pe:jenkins:#{task}")
+          sleep 5
         end
       end
 


### PR DESCRIPTION
This PR introduces concurrent builds of mocks and debs in the jenkins workflows. Currently, all cows (usually about 10 per arch) are built serially, and the same goes for mocks. With this PR, cows/mocks are built in parallel, as many builders/executors as we have available. In repeated testing with facter 1.6.x, a "deb_all", e.g. a build of all cows, completed in approximately two minutes from rake invocation.
