### PR TITLE
Always remove lock file even if repo creation fails

### DIFF
--- a/tasks/deb_repos.rake
+++ b/tasks/deb_repos.rake
@@ -49,9 +49,12 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
       #
       cmd << "reprepro=$(which reprepro) ; "
       cmd << "$reprepro includedeb $dist ../../deb/$dist/*.deb ; popd ; done ; "
-      cmd << "popd ; popd ; rm .lock"
+      cmd << "popd ; popd "
 
       remote_ssh_cmd(@build.distribution_server, cmd)
+
+      # Always remove the lock file, even if we've failed
+      remote_ssh_cmd(@build.distribution_server, "rm -f #{artifact_directory}/.lock")
 
       # Now that we've created our package repositories, we can generate repo
       # configurations for use with downstream jobs, acceptance clients, etc.

--- a/tasks/rpm_repos.rake
+++ b/tasks/rpm_repos.rake
@@ -37,9 +37,12 @@ namespace :pl do
       cmd << "createrepo=$(which createrepo) ; "
       cmd << 'for repodir in $(find ./ -name "*.rpm" | xargs -I {} dirname {}) ; do '
       cmd << "pushd $repodir && $createrepo -d --update . && popd ; "
-      cmd << "done ; popd ; rm .lock"
+      cmd << "done ; popd "
 
       remote_ssh_cmd(@build.distribution_server, cmd)
+
+      # Always remove the lock file, even if we've failed
+      remote_ssh_cmd(@build.distribution_server, "rm -f #{artifact_directory}/.lock")
 
       # Now that we've created our repositories, we can create the configs for
       # them


### PR DESCRIPTION
Currently if the repo creation fails in some ways, the lock file will not get
removed, stalling the repo creation until it is removed manually. This commit
updates this process to separate the lockfile removal into its own command,
which will be run regardless of the success or failure of the repo creation.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
