### PR TITLE
Switch to tags or shas instead of just shas

### DIFF
--- a/spec/tasks/build_object_spec.rb
+++ b/spec/tasks/build_object_spec.rb
@@ -78,7 +78,7 @@ describe Build::BuildInstance do
                   :rpm_build_host,
                   :rpmrelease,
                   :rpmversion,
-                  :sha,
+                  :ref,
                   :sign_tar,
                   :sles_build_host,
                   :sles_repo_path,

--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -68,9 +68,27 @@ def git_co(ref)
   end
 end
 
+def git_describe
+  %x{git describe}.strip
+end
+
 # return the sha of HEAD on the current branch
 def git_sha
-  %x{git rev-parse HEAD}
+  %x{git rev-parse HEAD}.strip
+end
+
+# Return the ref type of HEAD on the current branch
+def git_ref_type
+  %x{git cat-file -t #{git_describe}}.strip
+end
+
+# If HEAD is a tag, return the tag. Otherwise return the sha of HEAD.
+def git_sha_or_tag
+  if git_ref_type == "tag"
+    git_describe
+  else
+    git_sha
+  end
 end
 
 def get_temp

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -81,7 +81,7 @@ module Build
                       :rpm_build_host,
                       :rpmrelease,
                       :rpmversion,
-                      :sha,
+                      :ref,
                       :sign_tar,
                       :sles_build_host,
                       :sles_repo_path,
@@ -103,7 +103,7 @@ module Build
 
     def initialize
       @task = { :task => $*[0], :args => $*[1..-1] }
-      @sha = git_sha.strip
+      @ref = git_sha_or_tag
     end
 
     ##
@@ -144,7 +144,7 @@ module Build
     # Write all build parameters to a yaml file in a temporary location. Print
     # the path to the file and return it as a string. Accept an argument for
     # the write target directory. The name of the params file is the current
-    # git commit sha.
+    # git commit sha or tag.
     #
     def params_to_yaml(output_dir=nil)
       dir = output_dir.nil? ? get_temp : output_dir
@@ -152,7 +152,7 @@ module Build
         warn "#{dir} does not exist or is not writable, skipping build params write. Exiting.."
         exit 1
       end
-      params_file = File.join(dir, "#{git_sha.strip}.yaml")
+      params_file = File.join(dir, "#{self.ref}.yaml")
       File.open(params_file, 'w') do |f|
         f.puts params.to_yaml
       end
@@ -177,7 +177,7 @@ namespace :pl do
   desc "Build from a build params file"
   task :build_from_params do
     check_var('PARAMS_FILE', ENV['PARAMS_FILE'])
-    git_co(@build.sha)
+    git_co(@build.ref)
     Rake::Task[@build.task[:task]].invoke(@build.task[:args])
   end
 end

--- a/tasks/deb_repos.rake
+++ b/tasks/deb_repos.rake
@@ -14,7 +14,7 @@ namespace :pl do
     task :deb_repos => "pl:fetch" do
 
       # First, we test that artifacts exist and set up the repos directory
-      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, git_sha.strip)
+      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, @build.ref)
 
       cmd = 'echo " Checking for deb build artifacts. Will exit if not found.." ; '
       cmd << "[ -d #{artifact_directory}/artifacts/deb ] || exit 0 ; "
@@ -68,13 +68,13 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
     # pl-$project-$sha.list, and can be placed in /etc/apt/sources.list.d to
     # enable clients to install these packages.
     #
-    desc "Create apt repository configs for package repos for this sha on the distribution server"
+    desc "Create apt repository configs for package repos for this sha/tag on the distribution server"
     task :deb_repo_configs => "pl:fetch" do
 
       # This is the standard path to all build artifacts on the distribution
       # server for this commit
       #
-      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, git_sha.strip)
+      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, @build.ref)
 
       # We obtain the list of distributions in the debian repository with some hackery.
       #
@@ -92,12 +92,12 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
       #
       mkdir_p File.join("pkg", "repo_configs", "deb")
       dists.each do |dist|
-        repoconfig = ["# Packages for #{@build.project} built from commit #{git_sha.strip}",
-                      "deb http://#{@build.builds_server}/#{@build.project}/#{git_sha.strip}/repos/apt/#{dist} #{dist} main"]
-        config = File.join("pkg", "repo_configs", "deb", "pl-#{@build.project}-#{git_sha.strip}-#{dist}.list")
+        repoconfig = ["# Packages for #{@build.project} built from ref #{@build.ref}",
+                      "deb http://#{@build.builds_server}/#{@build.project}/#{@build.ref}/repos/apt/#{dist} #{dist} main"]
+        config = File.join("pkg", "repo_configs", "deb", "pl-#{@build.project}-#{@build.ref}-#{dist}.list")
         File.open(config, 'w') { |f| f.puts repoconfig }
       end
-      puts "Wrote apt repo configs for #{@build.project} at #{git_sha.strip} to pkg/repo_configs/deb."
+      puts "Wrote apt repo configs for #{@build.project} at #{@build.ref} to pkg/repo_configs/deb."
     end
   end
 end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -174,7 +174,7 @@ namespace :pl do
       #
       if curl_form_data(trigger_url, args)
         puts "Build submitted. To view your build results, go to #{job_url}"
-        puts "Your packages will be available at #{@build.distribution_server}:#{@build.jenkins_repo_path}/#{@build.project}/#{git_sha}"
+        puts "Your packages will be available at #{@build.distribution_server}:#{@build.jenkins_repo_path}/#{@build.project}/#{@build.ref}"
       else
         warn "An error occurred submitting the job to jenkins. Take a look at the preceding http response for more info."
       end
@@ -317,11 +317,11 @@ namespace :pl do
       end
 
       # Assemble the JSON string for the JSON parameter
-      json = JSON.generate("parameter" => [{ "name" => "SHA", "value"  => "#{git_sha.strip}" }])
+      json = JSON.generate("parameter" => [{ "name" => "SHA", "value"  => "#{@build.ref}" }])
 
       # Assemble our arguments to the post
       args = [
-      "-Fname=SHA", "-Fvalue=#{git_sha.strip}",
+      "-Fname=SHA", "-Fvalue=#{@build.ref}",
       "-Fjson=#{json.to_json}",
       "-FSubmit=Build"
       ]

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -2,9 +2,9 @@
 # This task is intended to retrieve packages from the distribution server that
 # have been built by jenkins and placed in a specific location,
 # /opt/jenkins-builds/$PROJECT/$SHA where $PROJECT is the build project as
-# established in project_data.yaml and $SHA is the git sha of the project that
+# established in project_data.yaml and $SHA is the git sha/tag of the project that
 # was built into packages. The current day is assumed, but an environment
-# variable override exists to retrieve packages from another day. The sha is
+# variable override exists to retrieve packages from another day. The sha/tag is
 # assumed to be the current project's HEAD, e.g.  to retrieve packages for a
 # release of 3.1.0, checkout 3.1.0 locally before retrieving.
 #
@@ -16,7 +16,7 @@ namespace :pl do
       target = args.target || "artifacts"
       invoke_task("pl:fetch")
       mkdir_p 'pkg'
-      rsync_from("#{@build.jenkins_repo_path}/#{@build.project}/#{git_sha.strip}/#{target}/", @build.distribution_server, "pkg/")
+      rsync_from("#{@build.jenkins_repo_path}/#{@build.project}/#{@build.ref}/#{target}/", @build.distribution_server, "pkg/")
       puts "Packages staged in pkg"
     end
   end

--- a/tasks/rpm_repos.rake
+++ b/tasks/rpm_repos.rake
@@ -16,7 +16,7 @@ namespace :pl do
       # Formulate our command string, which will just find directories with rpms
       # and create and update repositories.
       #
-      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, git_sha.strip)
+      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, @build.ref)
 
       ##
       # Test that the artifacts directory exists on the distribution server.
@@ -56,13 +56,13 @@ namespace :pl do
     # pl-$project-$sha.conf, and can be placed in /etc/yum.repos.d to enable
     # clients to install these packages.
     #
-    desc "Create yum repository configs for package repos for this sha on the distribution server"
+    desc "Create yum repository configs for package repos for this sha/tag on the distribution server"
     task :rpm_repo_configs => "pl:fetch" do
 
       # This is the standard path to all build artifacts on the distribution
       # server for this commit
       #
-      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, git_sha.strip)
+      artifact_directory = File.join(@build.jenkins_repo_path, @build.project, @build.ref)
       # First check if the artifacts directory exists
       #
       cmd = "[ -d #{artifact_directory} ] || exit 0 ; "
@@ -108,19 +108,19 @@ namespace :pl do
 
           # Create an array of lines that will become our yum config
           #
-          config = ["[pl-#{@build.project}-#{git_sha.strip}]"]
-          config << ["name=PL Repo for #{@build.project} at commit #{git_sha.strip}"]
-          config << ["baseurl=http://#{@build.builds_server}/#{@build.project}/#{git_sha.strip}/repos/#{dist}/#{version}/#{subdir}/#{arch}"]
+          config = ["[pl-#{@build.project}-#{@build.ref}]"]
+          config << ["name=PL Repo for #{@build.project} at commit #{@build.ref}"]
+          config << ["baseurl=http://#{@build.builds_server}/#{@build.project}/#{@build.ref}/repos/#{dist}/#{version}/#{subdir}/#{arch}"]
           config << ["enabled=1"]
           config << ["gpgcheck=0"]
 
           # Write the new config to a file under our repo configs dir
           #
-          config_file = File.join("pkg", "repo_configs", "rpm", "pl-#{@build.project}-#{git_sha.strip}-#{dist}-#{version}-#{arch}-#{subdir}.repo")
+          config_file = File.join("pkg", "repo_configs", "rpm", "pl-#{@build.project}-#{@build.ref}-#{dist}-#{version}-#{arch}-#{subdir}.repo")
           File.open(config_file, 'w') { |f| f.puts config }
         end
         rm File.join("pkg","rpm_configs")
-        puts "Wrote yum configuration files for #{@build.project} at #{git_sha.strip} to pkg/repo_configs/rpm"
+        puts "Wrote yum configuration files for #{@build.project} at #{@build.ref} to pkg/repo_configs/rpm"
       end
     end
   end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -97,7 +97,7 @@ namespace :pl do
     task :ship, :target do |t, args|
       invoke_task("pl:fetch")
       target = args.target || "artifacts"
-      artifact_dir = "#{@build.jenkins_repo_path}/#{@build.project}/#{git_sha.strip}/#{target}"
+      artifact_dir = "#{@build.jenkins_repo_path}/#{@build.project}/#{@build.ref}/#{target}"
       remote_ssh_cmd(@build.distribution_server, "mkdir -p #{artifact_dir}")
       rsync_to("pkg/", @build.distribution_server, "#{artifact_dir}/ --exclude repo_configs")
     end


### PR DESCRIPTION
The problem with using the sha as the defining attribute used to determine
build artifact locations on the distribution server, is that we want to
separate out final tagged builds from the same builds prior to the tag, because
we version based off of data including the tag. Thus, tagged and untagged
packages make it into the same artifact directory with different versions and
no easy way to separate them. This commit updates everywhere we use the git sha
and replaces it with the use of the git sha OR the git tag, if the ref type of
HEAD is a tag. This allows us to separate out the builds. This commit also
updates the usage everywhere to use the build object instance variable we set
up but never used, and renames it more appropriately to @build.ref.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
