### PR TITLE
Successfully clean up mock root after builds

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -148,8 +148,16 @@ def build_rpm_with_mock(mocks, is_rc)
         end
       end
       # To avoid filling up the system with our random mockroots, we should
-      # clean up.
-      rm_rf resultdir if @build.random_mockroot
+      # clean up. However, this requires sudo. If we don't have sudo, we'll
+      # just fail and not clean up, but warn the user about it.
+      if @build.random_mockroot
+        %x{sudo -n echo 'Cleaning build root.'}
+        if $?.success?
+          sh "sudo -n rm -r #{resultdir}" unless resultdir.nil?
+        else
+          warn "Couldn't clean #{resultdir} without sudo. Leaving."
+        end
+      end
     end
     add_metrics({ :dist => "#{family}-#{version}", :bench => bench }) if @build.benchmark
   end


### PR DESCRIPTION
Currently we just use rm_rf to clean the random build root, and this poses two
problems. 1) because of the -f flag, we don't see any failures to rm and 2)
because the mock root has files owned by root, we don't actually remove it.
This commit updates mock clean up to attempt a sudo command (in this case, just
echoing a status) and use its success/failure to determine if the user has sudo
privileges. If so, we sudo rm the build root. If not, we print an error that
the build root is not getting cleaned.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
