### PR TITLE
require 'yaml' in object specs

### DIFF
--- a/spec/tasks/build_object_spec.rb
+++ b/spec/tasks/build_object_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 load_task '00_utils.rake'
 load_task 'build.rake'
+require 'yaml'
 
 describe Build::BuildInstance do
   Build_Params = [:apt_host,


### PR DESCRIPTION
Not all versions of ruby/rspec/rake will load yaml by default, and we don't
explictly require it in the build object specs, which cause the specs to fail
on some hosts. This commit addresses this by requiring yaml before beginning.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
