### PR TITLE
Add package:vendor_gems tasks

### DIFF
--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -1,0 +1,7 @@
+namespace :package do
+  desc "vendor gems required by project"
+  task :vendor_gems do
+    sh "bundle install --without development test"
+    sh "bundle package"
+  end
+end


### PR DESCRIPTION
Prior to this commit, the packaging repo had no way of vendoring gems to
be included in a source tarball. This commit add such a task so that
prior to running `rake package:tar` a package builder can run `rake
package:vendor_gems` and the necessary gems for the project will be
pulled down and stored in `vendor/cache`.

NOTE: Later steps in the build process will be required for making use
of these cached gems. Those later steps might look something like:

```
bundle install --local --deployment
rm -rf vendor/cache
bundle exec rake assets:precompile
```

Additionally, if upgrade

```
bundle exec rake db:migrate
```

If install

```
bundle exec rake db:schema:load
```
