### PR TITLE
Update deb repos to use wget rather than sshing into distribution server

### DIFF
--- a/tasks/deb_repos.rake
+++ b/tasks/deb_repos.rake
@@ -82,9 +82,8 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
       if wget = find_tool("wget")
         # First test if the directory even exists
         #
-        %x{#{wget} --spider -r -l 1 --no-parent #{base_url} 2>&1}
+        wget_results = %x{#{wget} --spider -r -l 1 --no-parent #{base_url} 2>&1}
         if $?.success?
-          wget_results = %x{#{wget} --spider -r -l 1 --no-parent #{base_url} 2>&1}
           # We want to exclude index and robots files and only include the http: prefixed elements
           repo_urls = wget_results.split.uniq.reject{|x| x=~ /\?|index|robots/}.select{|x| x =~ /http:/}.map{|x| x.chomp('/')}
         else


### PR DESCRIPTION
Currently, generating repo configs for debian requires sshing into the
distribution server and composing a list of available repos. This is not ideal
because not everyone will have the appropriate access. This commit updates the
deb_repo_configs task to use the internally "public" repos with wget instead,
so that anyone on the network can create the configs without special access.
While this was certainly hacky before, it is now still quite hacky. This uses
wget to generate a directory listing of the proposed hash's repos, and then
parse them into usable output with various array and string transformations.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
