### PR TITLE
Don't try to rm nothingness

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -19,6 +19,7 @@
 # pkg/el-5-i386/*.rpm
 
 def mock(mock_config, srpm)
+  configdir = nil
   unless mock = find_tool('mock')
     warn "mock is required for building rpms with mock. Please install mock and try again."
     exit 1
@@ -39,7 +40,7 @@ def mock(mock_config, srpm)
   end
   sh "#{mock} -r #{mock_config} #{srpm}"
   # Clean up the configdir
-  rm_r configdir
+  rm_r configdir unless configdir.nil?
 
   basedir
 end


### PR DESCRIPTION
Currently if we don't use random mockroot, we try to rm an uninitialized
variable, which breaks in funny ways depending on your ruby version. Here we
explicitly set confdir to nil and then rm it later only it isn't nil.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
