### PR TITLE
Add deb_all and mock_all tasks to the pe:jenkins namespace

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -252,7 +252,8 @@ end
 if @build.build_pe
   namespace :pe do
     namespace :jenkins do
-      tasks << "sles"
+      tasks << "sles" << "deb_all" << "mock_all"
+
       tasks.each do |build_task|
         desc "Queue pe:#{build_task} build on jenkins builder"
         task build_task => "pl:fetch" do


### PR DESCRIPTION
pe:jenkins tries to call out to deb_all and mock_all, which didn't previously
exist in the pe:jenkins namespace. This commit adds them to the list of tasks
to be dynamically generated in the pe:jenkins namespace to avoid this problem.
