### PR TITLE
Update cow-deb shipping to all cows

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -16,13 +16,12 @@ if @build.build_pe
 
     desc "Ship PE debs to #{@build.apt_host}"
     task :ship_debs => "pl:fetch" do
-      dist = @build.default_cow.split('-')[1]
-      if empty_dir?("pkg/pe/deb/#{dist}")
-        STDERR.puts "The 'pkg/pe/deb/#{dist}' directory has no packages. Did you run rake pe:deb?"
+      if empty_dir?("pkg/pe/deb")
+        STDERR.puts "The 'pkg/pe/deb' directory has no packages!"
         exit 1
       else
-        target_path = ENV['APT_REPO'] ? ENV['APT_REPO'] : "#{@build.apt_repo_path}/#{@build.pe_version}/repos/incoming/unified/"
-        rsync_to("pkg/pe/deb/#{dist}/", @build.apt_host, target_path)
+        target_path = ENV['APT_REPO'] ? ENV['APT_REPO'] : "#{@build.apt_repo_path}/#{@build.pe_version}/repos/incoming/disparate/"
+        rsync_to("pkg/pe/deb/", @build.apt_host, target_path)
         if @build.team == 'release'
           Rake::Task["pe:remote:freight"].invoke
         end


### PR DESCRIPTION
Currently we just assume the default cow was built and ship to 'unified', but
we swapped workflows awhile back to build all cows. This means we were just
missing most of the dists in the actual freight. Now, we just ship to disparate
with all the different distributions we built for.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
