### PR TITLE
Clean up bundles after jenkins builds

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -178,6 +178,10 @@ namespace :pl do
       else
         warn "An error occurred submitting the job to jenkins. Take a look at the preceding http response for more info."
       end
+
+      # Clean up after ourselves
+      rm bundle
+      rm properties
     end
   end
 end


### PR DESCRIPTION
We currently create git-bundles of the project when calling 'pl:jenkins:*' but
don't clean them up, or the build_params file. This commit adds that cleanup.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
