### PR TITLE
Allow PE_VER to set @build.pe_version

### DIFF
--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -53,6 +53,7 @@ else
   @build.yum_repo_path   = ENV['YUM_REPO']                if ENV['YUM_REPO']
   @build.apt_host        = ENV['APT_HOST']                if ENV['APT_HOST']
   @build.apt_repo_path   = ENV['APT_REPO']                if ENV['APT_REPO']
+  @build.pe_version      = ENV['PE_VER']                  if ENV['PE_VER']
 end
 
 ##


### PR DESCRIPTION
Currently we only set @build.pe_version with the value of ENV['PE_VER'] in
pl:load_extras. We should set this always if present, otherwise it breaks
pe:local_deb.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
