### PR TITLE
Pull in all the gems in fetch, don't exclude development and test

### DIFF
--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -9,13 +9,11 @@ if @build.pre_tar_task == "package:vendor_gems"
       require 'rubygems'
       require 'rubygems/gem_runner'
 
-      without = [:development, :test]
-
       runner = Gem::GemRunner.new
       definition = Bundler::Definition.build('Gemfile', 'Gemfile.lock', nil)
       resolver = definition.resolve
 
-      lazy_specs = resolver.for(definition.dependencies.reject {|d| (d.groups - without).empty?}, [], false, true).to_a.uniq
+      lazy_specs = resolver.for(definition.dependencies, [], false, true).to_a.uniq
 
       mkdir_p 'vendor/cache'
       cd 'vendor/cache' do


### PR DESCRIPTION
Originally we believed we wouldn't need the development and test groups fetched
into vendor/cache. This is no longer true because we're using the development
group to set up the js dependencies for our asset compilation. This commit
removes the exclusion of these groups.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
