### PR TITLE
Ensure we have PE_VER when kicking of jenkins debs

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -271,6 +271,7 @@ if @build.build_pe
       # DOSing it with our packaging.
       desc "Queue pe:deb_all on jenkins builder"
       task :deb_all => "pl:fetch" do
+        check_var("PE_VER", @build.pe_version)
         @build.cows.split(' ').each do |cow|
           @build.default_cow = cow
           invoke_task("pl:jenkins:post_build", "pe:local_deb")


### PR DESCRIPTION
Currently the pe version is required when doing a deb build, but we don't check
that the PE version has been set when we kick off a jenkins deb build. This
causes delayed failures after the jenkins jobs kick off and no PE version is
present. This commit ensures the PE version has been provided before we kick
off the jenkins deb_all build.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
