### PR TITLE
Flesh out gem caching options

### DIFF
--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -34,7 +34,7 @@ if @build.pre_tar_task == "package:vendor_gems"
         end
 
         def debug?
-          false
+          true
         end
 
         def ask(message)
@@ -78,20 +78,30 @@ if @build.pre_tar_task == "package:vendor_gems"
       end
 
 
+      # Cache all the gems locally without using the shared GEM_PATH
       Bundler.settings[:cache_all] = true
+      Bundler.settings[:local] = true
+      Bundler.settings[:disable_shared_gems] = true
+      # Make sure we cache all the gems, despite what the local config file says...
+      Bundler.settings.without = []
 
+      # Stupid bundler requires this because it's not abstracted out into a library that doesn't need IO
       Bundler.ui = UI.new()
       Bundler.rubygems.ui = ::RGProxy.new(Bundler.ui)
-      Bundler.ui.level = "info"
+      Bundler.ui.level = "debug"
 
+      # Load the the Gemfile and resolve gems using RubyGems.org
       definition = Bundler.definition
       definition.validate_ruby!
       definition.resolve_remotely!
 
       mkdir_p Bundler.app_cache
 
+      # Cache the gems
       definition.specs.each do |spec|
+        # Fetch Rubygem specs
         Bundler::Fetcher.fetch(spec) if spec.source.is_a?(Bundler::Source::Rubygems)
+        # Cache everything but bundler itself...
         spec.source.cache(spec) unless spec.name == "bundler"
       end
 


### PR DESCRIPTION
- Disable shared gems
- Use most verbose output
- Override local 'without' settings (with the unfortunate side effect of overwriting your local config to use all the gems... but useful for the builder machines and for duplicating the builder workflow on the local machine)
