### PR TITLE
Clean up package_repos before rsync call

### DIFF
--- a/tasks/pe_sles.rake
+++ b/tasks/pe_sles.rake
@@ -21,6 +21,7 @@ if @build.build_pe
   namespace :pe do
     # Temporary task to pull down pe dependencies until this is NFS-mounted
     task :retrieve_sles_deps => 'pl:fetch' do
+      rm_rf FileList["#{ENV['HOME']}/package_repos/*"]
       rsync_from("#{@build.sles_repo_path}/#{@build.pe_version}/repos/sles-*", @build.sles_repo_host, "#{ENV['HOME']}/package_repos/")
       FileList["#{ENV['HOME']}/package_repos/*"].each do |f|
         update_rpm_repo(f) if File.directory?(f)


### PR DESCRIPTION
Having multiple versions of the same package in the package_repos directory
causes problems when building. Sles' build automation is not smart about
choosing packages, so it is important to clean up the package directory before
rsyncing into it. This commit adds an rm_rf call to clean up all the files in
~/package_repos before building.
