### PR TITLE
Use `pkg` instead of `tmp` as the temporary dir prefix

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -92,7 +92,7 @@ def git_sha_or_tag
 end
 
 def get_temp
-  temp = `mktemp -d -t tmpXXXXXX`.strip
+  temp = `mktemp -d -t pkgXXXXXX`.strip
 end
 
 def remote_ssh_cmd target, command


### PR DESCRIPTION
This change allows temp dirs created by the packaging repo to be more
easily identifiable, which will make it simpler to clean temp
directories left over from failed builds.
