### PR TITLE
Build all debs with pe:all, not just one

### DIFF
--- a/tasks/pe_remote.rake
+++ b/tasks/pe_remote.rake
@@ -44,7 +44,7 @@ if @build.build_pe
 
     desc "Execute remote debian, el, and sles builds, sign, and ship pkgs"
     task :all => ['clean', 'pl:fetch'] do
-      ['pe:deb', 'pe:mock_all', 'pe:sles', 'pe:ship_rpms', 'pe:ship_debs'].each do |task|
+      ['pe:deb_all', 'pe:mock_all', 'pe:sles', 'pe:ship_rpms', 'pe:ship_debs'].each do |task|
         Rake::Task[task].execute
       end
     end


### PR DESCRIPTION
Currently, just one dist is build with pe:all, which we gave up doing awhile
ago (we now build for all the things). Because it is less used than the jenkins
tasks, the pe:all remote task was not updated. This commit fixes this.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
