### PR TITLE
Use @tar_host for shipping tarballs, not @yum_host

### DIFF
--- a/spec/tasks/build_object_spec.rb
+++ b/spec/tasks/build_object_spec.rb
@@ -88,6 +88,7 @@ describe Build::BuildInstance do
                   :sles_arch_repos,
                   :summary,
                   :tar_excludes,
+                  :tar_host,
                   :tarball_path,
                   :team,
                   :version,

--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -78,8 +78,14 @@ end
 # For backwards compatibilty, we set build:@name to build:@project. @name was
 # renamed to @project in an effort to align the variable names with what has
 # been supported for parameter names in the params files.
-#
 @build.name = @build.project
+# We also set @tar_host to @yum_host if @tar_host is not set. This is in
+# another effort to fix dumb mistakes. Early on, we just assumed tarballs would
+# go to @yum_host (why? probably just laziness) but this is not ideal and does
+# not make any sense when looking at the code. Now there's a @tar_host
+# variable, but for backwards compatibility, we'll default back to @yum_host if
+# @tar_host isn't set.
+@build.tar_host ||= @build.yum_host
 
 if @build.debug
   @build.print_params

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -90,6 +90,7 @@ module Build
                       :sles_arch_repos,
                       :summary,
                       :tar_excludes,
+                      :tar_host,
                       :tarball_path,
                       :task,
                       :team,

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -67,9 +67,9 @@ namespace :pl do
       rsync_to('pkg/apple/*.dmg', @build.yum_host, @build.dmg_path)
     end if @build.build_dmg
 
-    desc "ship tarball and signature to #{@build.yum_host}"
+    desc "ship tarball and signature to #{@build.tar_host}"
     task :ship_tar => 'pl:fetch' do
-      rsync_to("pkg/#{@build.project}-#{@build.version}.tar.gz*", @build.yum_host, @build.tarball_path)
+      rsync_to("pkg/#{@build.project}-#{@build.version}.tar.gz*", @build.tar_host, @build.tarball_path)
     end
 
     desc "UBER ship: ship all the things in pkg"


### PR DESCRIPTION
This is in another effort to fix dumb mistakes. Early on, we just assumed
tarballs would go to @yum_host (why? probably just laziness) but this is not
ideal and does not make any sense when looking at the code. Now there's a
@tar_host variable, but for backwards compatibility, we'll default back to
@yum_host if @tar_host isn't set.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
