### PR TITLE
Capture full RC number, not just a single digit

### DIFF
--- a/spec/tasks/00_utils_spec.rb
+++ b/spec/tasks/00_utils_spec.rb
@@ -15,14 +15,14 @@ describe "00_utils" do
       :get_rpmrelease             => '1',
       :is_rc?                     => false,
     },
-    '0.7.0rc1'                    => {
-      :git_describe_version       => %w{0.7.0rc1},
-      :get_dash_version           => '0.7.0rc1',
-      :get_ips_version            => '0.7.0rc1,3.14159-0',
-      :get_dot_version            => '0.7.0rc1',
-      :get_debversion             => '0.7.0-0.1rc1puppetlabs1',
+    '0.7.0rc10'                    => {
+      :git_describe_version       => %w{0.7.0rc10},
+      :get_dash_version           => '0.7.0rc10',
+      :get_ips_version            => '0.7.0rc10,3.14159-0',
+      :get_dot_version            => '0.7.0rc10',
+      :get_debversion             => '0.7.0-0.1rc10puppetlabs1',
       :get_rpmversion             => '0.7.0',
-      :get_rpmrelease             => '0.1rc1',
+      :get_rpmrelease             => '0.1rc10',
       :is_rc?                     => true,
     },
     '0.7.0-rc1'                   => {

--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -202,7 +202,7 @@ def get_base_pkg_version
   dash = get_dash_version
   if dash.include?("rc")
     # Grab the rc number
-    rc_num = dash.match(/rc(\d)+/)[1]
+    rc_num = dash.match(/rc(\d+)/)[1]
     ver = dash.sub(/-?rc[0-9]+/, "-0.#{@build.release}rc#{rc_num}").gsub(/(rc[0-9]+)-(\d+)?-?/, '\1.\2')
   else
     ver = dash.gsub('-','.') + "-#{@build.release}"


### PR DESCRIPTION
Previously the + fell outside the capture, which meant that multi-digit rc
numbers would break. This commit moves the + into the capture, so the full RC
number can be retrieved. It also includes an updated test that fails without
this fix, but passes with the fix.
