### PR TITLE
Add a loader with explicit task ordering, remove name ordering

### DIFF
--- a/packaging.rake
+++ b/packaging.rake
@@ -1,0 +1,46 @@
+# Load packaging repo tasks
+
+# These are ordered
+
+PACKAGING_PATH = File.join(File.dirname(__FILE__), 'tasks')
+
+@using_loader = true
+
+[ '00_utils.rake',
+  '10_setupvars.rake',
+  '20_setupextravars.rake',
+  '30_metrics.rake',
+  'apple.rake',
+  'build.rake',
+  'clean.rake',
+  'deb.rake',
+  'deb_repos.rake',
+  'doc.rake',
+  'fetch.rake',
+  'gem.rake',
+  'ips.rake',
+  'jenkins.rake',
+  'mock.rake',
+  'pe_deb.rake',
+  'pe_remote.rake',
+  'pe_rpm.rake',
+  'pe_ship.rake',
+  'pe_sign.rake',
+  'pe_sles.rake',
+  'pe_tar.rake',
+  'pre_tasks.rake',
+  'release.rake',
+  'remote_build.rake',
+  'retrieve.rake',
+  'rpm.rake',
+  'rpm_repos.rake',
+  'ship.rake',
+  'sign.rake',
+  'tag.rake',
+  'tar.rake',
+  'template.rake',
+  'update.rake',
+  'vendor_gems.rake',
+  'version.rake',
+  'z_data_dump.rake'].each { |t| load File.join(PACKAGING_PATH, t)}
+

--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -106,3 +106,13 @@ end
   self.instance_variable_set("@#{param}", value)
 end
 
+##
+# Issue a deprecation warning if the packaging repo wasn't loaded by the loader
+unless @using_loader
+  warn "
+  DEPRECATED: The packaging repo tasks are now loaded by 'packaging.rake'.
+  Please update your Rakefile or loading task to load
+  'ext/packaging/packaging.rake' instead of 'ext/packaging/tasks/*' (25-Jun-2013).
+  "
+end
+


### PR DESCRIPTION
currently, the order in which the rake tasks are loaded is significant, but
load order is managed by alphanumeric file name ordering. Additionally, we
cannot create subdirectories in the packaging repo, because the projects just
blindly load ext/packaging/tasks/*, which of course will try to load
directories and fail. With the explicit loader, we can begin to make some sense
of the layout in the packaging repo. Since this is backwards-incompatible, we
deprecate loading the tasks directly, and will abandon name-ordering after a
suitable period.
