### PR TITLE
Refactor metrics gathering for local package builds

### DIFF
--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'erb'
 require 'benchmark'
+require 'net/http'
 load File.expand_path('../build.rake', __FILE__)
 
 ##

--- a/tasks/20_setupextravars.rake
+++ b/tasks/20_setupextravars.rake
@@ -27,7 +27,7 @@ namespace :pl do
     end
   end
 end
-if @build.team == 'release'
+if @build.team == 'release' or @build.team == 'dev'
   @build.benchmark = TRUE
 end
 

--- a/tasks/30_metrics.rake
+++ b/tasks/30_metrics.rake
@@ -5,37 +5,57 @@ if @build.benchmark
 
   def add_metrics args
     @metrics << {
-      :bench      => args[:bench],
-      :dist       => ( args[:dist]        || ENV['DIST']       ),
-      :pkg        => ( args[:pkg]         || @build.project    ),
-      :version    => ( args[:version]     || @build.version    ),
-      :pe_version => ( args[:pe_version]  || @build.pe_version ),
-      :date       => ( args[:date]        || timestamp         ),
-      :who        => ( args[:who]         || ENV['USER']       ),
-      :where      => ( args[:where]       || hostname          )
+      :bench        => args[:bench],
+      :dist         => ( args[:dist]         || ENV['DIST']       ),
+      :package_type => ( args[:package_type] || "Not available"   ),
+      :pkg          => ( args[:pkg]          || @build.project    ),
+      :version      => ( args[:version]      || @build.version    ),
+      :pe_version   => ( args[:pe_version]   || @build.pe_version ),
+      :date         => ( args[:date]         || timestamp         ),
+      :who          => ( args[:who]          || ENV['USER']       ),
+      :where        => ( args[:where]        || hostname          ),
+      :success      => ( args[:success]      || false             ),
+      :log          => ( args[:log]          || "Not available"   )
     }
   end
 
   def post_metrics
-    if psql = find_tool('psql')
-      ENV["PGCONNECT_TIMEOUT"]="10"
-
+      metric_server = 'http://localhost:4567/metrics'
       @metrics.each do |metric|
-        date        = metric[:date]
-        pkg         = metric[:pkg]
-        dist        = metric[:dist]
-        bench       = metric[:bench]
-        who         = metric[:who]
-        where       = metric[:where]
-        version     = metric[:version]
-        pe_version  = metric[:pe_version]
-        @pg_major_version ||= %x{/usr/bin/psql --version}.match(/psql \(PostgreSQL\) (\d)\..*/)[1].to_i
-        no_pass_fail = "-w" if @pg_major_version > 8
-        %x{#{psql} #{no_pass_fail} -c "INSERT INTO #{@db_table} \
-        (date, package, dist, build_time, build_user, build_loc, version, pe_version) \
-        VALUES ('#{date}', '#{pkg}', '#{dist}', #{bench}, '#{who}', '#{where}', '#{version}', '#{pe_version}')"}
+        date         = metric[:date]
+        pkg          = metric[:pkg]
+        package_type = metric[:package_type]
+        dist         = metric[:dist]
+        bench        = metric[:bench]
+        who          = metric[:who]
+        where        = metric[:where]
+        version      = metric[:version]
+        pe_version   = metric[:pe_version]
+        success      = metric[:success]
+        log          = metric[:log]
+
+      uri = URI(metric_server)
+      begin
+        res = Net::HTTP.post_form(
+          uri,
+          {
+            'date'                => Time.now.to_s,
+            'package_name'        => pkg,
+            'dist'                => dist,
+            'package_type'        => package_type,
+            'package_build_time'  => bench,
+            'build_user'          => who,
+            'build_loc'           => where,
+            'version'             => version,
+            'pe_version'          => pe_version,
+            'success'             => success,
+            'build_log'           => log,
+          })
+      rescue Exception => e
+        puts e
+        puts "Unable to post metrics"
       end
-      @metrics = []
     end
+    @metrics = []
   end
 end

--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -233,17 +233,22 @@ if @build.build_dmg
   namespace :package do
     desc "Task for building an Apple Package"
     task :apple => [:setup] do
-      bench = Benchmark.realtime do
-        # Test for Packagemaker binary
-        raise "Packagemaker must be installed. Please install XCode Tools" unless \
-          File.exists?(PACKAGEMAKER)
+      begin
+        @build_success = true
+        bench = Benchmark.realtime do
+          # Test for Packagemaker binary
+          raise "Packagemaker must be installed. Please install XCode Tools" unless \
+            File.exists?(PACKAGEMAKER)
 
-        make_directory_tree
-        pack_source
-        build_dmg
+          make_directory_tree
+          pack_source
+          build_dmg
+        end
+      rescue Exception => e
+        @build_success = false
       end
       if @build.benchmark
-        add_metrics({ :dist => 'osx', :bench => bench })
+        add_metrics({ :dist => 'osx', :package_type => 'dmg', :bench => bench, :success => @build_success})
         post_metrics
       end
     end

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -10,6 +10,7 @@ def pdebuild args
                   --basepath /var/cache/pbuilder/#{cow}/"
   rescue Exception => e
     puts e
+    @build_success = false
     handle_method_failure('pdebuild', args)
   end
 end
@@ -28,6 +29,7 @@ def debuild args
     sh "debuild --no-lintian -uc -us"
   rescue
     STDERR.puts "Something went wrong. Hopefully the backscroll or #{results_dir}/#{@build.project}_#{@build.debversion}.build file has a clue."
+    @build_success = false
     exit 1
   end
 end
@@ -44,6 +46,7 @@ end
 
 task :build_deb, :deb_command, :cow do |t,args|
   bench = Benchmark.realtime do
+    @build_success = true
     deb_build = args.deb_command
     cow       = args.cow
     work_dir  = get_temp
@@ -63,13 +66,14 @@ task :build_deb, :deb_command, :cow do |t,args|
     end
   end
   # See 30_metrics.rake to see what this is doing
-  add_metrics({ :dist => ENV['DIST'], :bench => bench }) if @build.benchmark
+  add_metrics({ :dist => ENV['DIST'], :package_type => 'deb', :bench => bench, :success => @build_success}) if @build.benchmark
 end
 
 namespace :package do
   desc "Create a deb from this repo, using debuild (all builddeps must be installed)"
   task :deb => :tar do
     Rake::Task[:build_deb].invoke('debuild')
+    post_metrics if @build.benchmark
   end
 end
 

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -60,13 +60,19 @@ if @build.build_gem
     gem_task = Gem::PackageTask.new(spec)
     desc "Build a gem"
     task :gem => [ "clean" ] do
-      bench = Benchmark.realtime do
-        gem_task.define
-        Rake::Task[:gem].invoke
-        rm_rf "pkg/#{@build.project}-#{@build.gemversion}"
+      begin
+        @build_success = true
+        bench = Benchmark.realtime do
+          gem_task.define
+          Rake::Task[:gem].invoke
+          rm_rf "pkg/#{@build.project}-#{@build.gemversion}"
+        end
+      rescue Exception => e
+        puts e
+        @build_success = false
       end
       if @build.benchmark
-        add_metrics({ :dist => 'gem', :bench => bench })
+        add_metrics({ :dist => 'gem', :package_type => 'gem', :bench => bench, :success => @build_success })
         post_metrics
       end
     end

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -88,70 +88,81 @@ end
 
 def build_rpm_with_mock(mocks)
   mocks.split(' ').each do |mock_config|
-    family  = mock_el_family(mock_config)
-    version = mock_el_ver(mock_config)
-    subdir  = is_rc? ? 'devel' : 'products'
-    bench = Benchmark.realtime do
-      resultdir = mock(mock_config, srpm_file)
-      result  = "#{resultdir}/#{mock_config}/result/*.rpm"
+    begin
+      family  = mock_el_family(mock_config)
+      version = mock_el_ver(mock_config)
+      subdir  = is_rc? ? 'devel' : 'products'
+      @dist   = case family
+        when /el/ then "#{family}#{version}"
+        when /fedora/ then "#{version}"
+      end
+      @build_success = true
+      bench = Benchmark.realtime do
+        resultdir = mock(mock_config, srpm_file)
+        result  = "#{resultdir}/#{mock_config}/result/*.rpm"
 
-      Dir[result].each do |rpm|
-        rpm.strip!
-        unless ENV['RC_OVERRIDE'] == '1'
-          if is_rc? == FALSE and rpm =~ /[0-9]+rc[0-9]+\./
-            puts "It looks like you might be trying to ship an RC to the production repos. Leaving rpm in #{result}. Pass RC_OVERRIDE=1 to override."
-            next
-          elsif is_rc? and rpm !~ /[0-9]+rc[0-9]+\./
-            puts "It looks like you might be trying to ship a production release to the development repos. Leaving rpm in #{result}. Pass RC_OVERRIDE=1 to override."
-            next
+        Dir[result].each do |rpm|
+          rpm.strip!
+          unless ENV['RC_OVERRIDE'] == '1'
+            if is_rc? == FALSE and rpm =~ /[0-9]+rc[0-9]+\./
+              puts "It looks like you might be trying to ship an RC to the production repos. Leaving rpm in #{result}. Pass RC_OVERRIDE=1 to override."
+              next
+            elsif is_rc? and rpm !~ /[0-9]+rc[0-9]+\./
+              puts "It looks like you might be trying to ship a production release to the development repos. Leaving rpm in #{result}. Pass RC_OVERRIDE=1 to override."
+              next
+            end
+          end
+
+          if @build.build_pe
+            %x{mkdir -p pkg/pe/rpm/#{family}-#{version}-{srpms,i386,x86_64}}
+            case File.basename(rpm)
+              when /debuginfo/
+                rm_rf(rpm)
+              when /src\.rpm/
+                cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-srpms")
+              when /i.?86/
+                cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-i386")
+              when /x86_64/
+                cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-x86_64")
+              when /noarch/
+                cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-i386")
+                ln("pkg/pe/rpm/#{family}-#{version}-i386/#{File.basename(rpm)}", "pkg/pe/rpm/#{family}-#{version}-x86_64/")
+            end
+          else
+            %x{mkdir -p pkg/#{family}/#{version}/#{subdir}/{SRPMS,i386,x86_64}}
+            case File.basename(rpm)
+              when /debuginfo/
+                rm_rf(rpm)
+              when /src\.rpm/
+                cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/SRPMS")
+              when /i.?86/
+                cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/i386")
+              when /x86_64/
+                cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/x86_64")
+              when /noarch/
+                cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/i386")
+                ln("pkg/#{family}/#{version}/#{subdir}/i386/#{File.basename(rpm)}", "pkg/#{family}/#{version}/#{subdir}/x86_64/")
+            end
           end
         end
-
-        if @build.build_pe
-          %x{mkdir -p pkg/pe/rpm/#{family}-#{version}-{srpms,i386,x86_64}}
-          case File.basename(rpm)
-            when /debuginfo/
-              rm_rf(rpm)
-            when /src\.rpm/
-              cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-srpms")
-            when /i.?86/
-              cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-i386")
-            when /x86_64/
-              cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-x86_64")
-            when /noarch/
-              cp_pr(rpm, "pkg/pe/rpm/#{family}-#{version}-i386")
-              ln("pkg/pe/rpm/#{family}-#{version}-i386/#{File.basename(rpm)}", "pkg/pe/rpm/#{family}-#{version}-x86_64/")
-          end
-        else
-          %x{mkdir -p pkg/#{family}/#{version}/#{subdir}/{SRPMS,i386,x86_64}}
-          case File.basename(rpm)
-            when /debuginfo/
-              rm_rf(rpm)
-            when /src\.rpm/
-              cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/SRPMS")
-            when /i.?86/
-              cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/i386")
-            when /x86_64/
-              cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/x86_64")
-            when /noarch/
-              cp_pr(rpm, "pkg/#{family}/#{version}/#{subdir}/i386")
-              ln("pkg/#{family}/#{version}/#{subdir}/i386/#{File.basename(rpm)}", "pkg/#{family}/#{version}/#{subdir}/x86_64/")
+        # To avoid filling up the system with our random mockroots, we should
+        # clean up. However, this requires sudo. If we don't have sudo, we'll
+        # just fail and not clean up, but warn the user about it.
+        if @build.random_mockroot
+          %x{sudo -n echo 'Cleaning build root.'}
+          if $?.success?
+            sh "sudo -n rm -r #{resultdir}" unless resultdir.nil?
+          else
+            warn "Couldn't clean #{resultdir} without sudo. Leaving."
           end
         end
       end
-      # To avoid filling up the system with our random mockroots, we should
-      # clean up. However, this requires sudo. If we don't have sudo, we'll
-      # just fail and not clean up, but warn the user about it.
-      if @build.random_mockroot
-        %x{sudo -n echo 'Cleaning build root.'}
-        if $?.success?
-          sh "sudo -n rm -r #{resultdir}" unless resultdir.nil?
-        else
-          warn "Couldn't clean #{resultdir} without sudo. Leaving."
-        end
-      end
+    rescue Exception => e
+      puts e
+      @build_success = false
+      add_metrics({ :dist => "#{@dist}", :package_type => 'rpm', :bench => "N/A", :success => @build_success}) if @build.benchmark
     end
-    add_metrics({ :dist => "#{family}-#{version}", :bench => bench }) if @build.benchmark
+    add_metrics({ :dist => "#{@dist}", :package_type => 'rpm',  :bench => bench, :success => @build_success}) if @build.benchmark and @build_success != false
   end
 end
 

--- a/tasks/pe_sles.rake
+++ b/tasks/pe_sles.rake
@@ -52,6 +52,7 @@ if @build.build_pe
         build_spec        = "#{build_spec_dir}/#{@build.project}.spec"
         if noarch == FALSE
           bench = Benchmark.realtime do
+            @build.success = true
             linux_cmd = arch == 'i586' ? 'linux32' : 'linux64'
             sh "yes | sudo #{linux_cmd} build \
               --rpms        #{deps_repo}:#{ENV['HOME']}/package_repos/sles-11-#{arch} \
@@ -64,6 +65,7 @@ if @build.build_pe
             srpms = FileList["#{build_root}/#{arch}/#{build_dest_dir}/SRPMS/**/*.rpm"]
             if rpms.empty?
               STDERR.puts "No RPMS were built. Perhaps an error occurred?"
+              @build.success = false
               exit 1
             end
             built_arch = arch
@@ -73,7 +75,7 @@ if @build.build_pe
             noarch = rpms.exclude(/noarch/).empty?
           end
           # See 30_metrics.rake to see what this is doing
-          add_metrics({ :dist => 'sles', :bench => bench }) if @build.benchmark
+          add_metrics({ :dist => 'sles', :package_type => 'rpm', :bench => bench, :success => @build.success, :log => '' }) if @build.benchmark
         else
           arches_to_copy_to = @build.sles_arch_repos.keys - [ built_arch ]
           arches_to_copy_to.each do |other_arch|

--- a/tasks/rpm.rake
+++ b/tasks/rpm.rake
@@ -1,37 +1,43 @@
 def build_rpm(buildarg = "-bs")
-  check_tool('rpmbuild')
-  temp = get_temp
-  if dist = el_version
-    if dist.to_i < 6
-      dist_string = "--define \"%dist .el#{dist}"
+  begin
+    check_tool('rpmbuild')
+    temp = get_temp
+    if dist = el_version
+      if dist.to_i < 6
+        dist_string = "--define \"%dist .el#{dist}"
+      end
     end
-  end
-  rpm_define = "#{dist_string} --define \"%_topdir  #{temp}\" "
-  rpm_old_version = '--define "_source_filedigest_algorithm 1" --define "_binary_filedigest_algorithm 1" \
-     --define "_binary_payload w9.gzdio" --define "_source_payload w9.gzdio" \
-     --define "_default_patch_fuzz 2"'
-  args = rpm_define + ' ' + rpm_old_version
-  mkdir_pr temp, 'pkg/srpm', "#{temp}/SOURCES", "#{temp}/SPECS"
-  if buildarg == '-ba'
-    mkdir_p 'pkg/rpm'
-  end
-  if @build.sign_tar
-    Rake::Task["pl:sign_tar"].invoke
-    cp_p "pkg/#{@build.project}-#{@build.version}.tar.gz.asc", "#{temp}/SOURCES"
-  end
-  cp_p "pkg/#{@build.project}-#{@build.version}.tar.gz", "#{temp}/SOURCES"
-  erb "ext/redhat/#{@build.project}.spec.erb", "#{temp}/SPECS/#{@build.project}.spec"
-  sh "rpmbuild #{args} #{buildarg} --nodeps #{temp}/SPECS/#{@build.project}.spec"
-  mv FileList["#{temp}/SRPMS/*.rpm"], "pkg/srpm"
-  if buildarg == '-ba'
-    mv FileList["#{temp}/RPMS/*/*.rpm"], "pkg/rpm"
-  end
-  rm_rf temp
-  puts
-  output = FileList['pkg/*/*.rpm']
-  puts "Wrote:"
-  output.each do | line |
-    puts line
+    rpm_define = "#{dist_string} --define \"%_topdir  #{temp}\" "
+    puts rpm_define
+
+    rpm_old_version = '--define "_source_filedigest_algorithm 1" --define "_binary_filedigest_algorithm 1" \
+       --define "_binary_payload w9.gzdio" --define "_source_payload w9.gzdio" \
+       --define "_default_patch_fuzz 2"'
+    args = rpm_define + ' ' + rpm_old_version
+    mkdir_pr temp, 'pkg/srpm', "#{temp}/SOURCES", "#{temp}/SPECS"
+    if buildarg == '-ba'
+      mkdir_p 'pkg/rpm'
+    end
+    if @build.sign_tar
+      Rake::Task["pl:sign_tar"].invoke
+      cp_p "pkg/#{@build.project}-#{@build.version}.tar.gz.asc", "#{temp}/SOURCES"
+    end
+    cp_p "pkg/#{@build.project}-#{@build.version}.tar.gz", "#{temp}/SOURCES"
+    erb "ext/redhat/#{@build.project}.spec.erb", "#{temp}/SPECS/#{@build.project}.spec"
+    sh "rpmbuild #{args} #{buildarg} --nodeps #{temp}/SPECS/#{@build.project}.spec"
+    mv FileList["#{temp}/SRPMS/*.rpm"], "pkg/srpm"
+    if buildarg == '-ba'
+      mv FileList["#{temp}/RPMS/*/*.rpm"], "pkg/rpm"
+    end
+    rm_rf temp
+    puts
+    output = FileList['pkg/*/*.rpm']
+    puts "Wrote:"
+    output.each do | line |
+      puts line
+    end
+  rescue Exception => e
+    @build_success = false
   end
 end
 
@@ -43,7 +49,16 @@ namespace :package do
 
   desc "Create .rpm from this git repository (unsigned)"
   task :rpm => :tar do
-    build_rpm("-ba")
+    bench = Benchmark.realtime do
+      begin
+        @build_success = true
+        build_rpm("-ba")
+      rescue Exception => e
+        puts e
+        @build_success = false
+      end
+    end
+    add_metrics({ :dist => 'rpm', :package_type => 'rpm', :bench => bench, :success => @build_success}) if @build.benchmark
+    post_metrics if @build.benchmark
   end
 end
-


### PR DESCRIPTION
This commit adds a few additional data points to be gathered
by local package builds, as well as modifying the existing
metrics task to post data to an HTTP listener rather than
storing it directly in a database
