### PR TITLE
Use "pe:remote:<task>"instead of "pe:local_<task>"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,7 @@ for developer use for building test packages; the `pe:deb` task creates a
   `ext/build_defaults.yaml` after `final_mocks:`.  For PE, the mocks are
   formatted as `pupent-<peversion>-<distversion>-<arch>`, e.g.
   `pupent-2.7-el5-i386`. To build for a specific target, set `MOCK=<mock>` to
-  the mock that matches the target. The `pe:deb` and `pe:mock` tasks work by
-  using the `:remote` tasks for building on a remote builder using the current
-  committed state of the source repository. To forego remote building and build
-  on the local station (e.g., by ssh-ing into a remote builder first), the
-  tasks `pe:local_mock` and `pe:local_deb` build using the local host.
+  the mock that matches the target.
 
 ## `:remote:` tasks
 There are also sub-namespaces of `:pl` and `:pe` that are

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -227,10 +227,7 @@ namespace :pl do
 end
 
 ##
-# If this is a PE project, we want PE tasks as well. However, because the
-# PE tasks use :remote as their default (e.g., not namespaced under remote)
-# we have to explicily use the "local" tasks, since these will be local
-# builds on jenkins agents.
+# If this is a PE project, we want PE tasks as well.
 #
 if @build.build_pe
   namespace :pe do
@@ -239,7 +236,7 @@ if @build.build_pe
         desc "Queue pe:#{build_task} build on jenkins builder"
         task build_task => "pl:fetch" do
           check_var("PE_VER", @build.pe_version)
-          invoke_task("pl:jenkins:post_build", "pe:local_#{build_task}")
+          invoke_task("pl:jenkins:post_build", "pe:#{build_task}")
         end
       end
 
@@ -252,7 +249,7 @@ if @build.build_pe
         check_var("PE_VER", @build.pe_version)
         @build.cows.split(' ').each do |cow|
           @build.default_cow = cow
-          invoke_task("pl:jenkins:post_build", "pe:local_deb")
+          invoke_task("pl:jenkins:post_build", "pe:deb")
           sleep 5
         end
       end
@@ -262,7 +259,7 @@ if @build.build_pe
       task :mock_all => "pl:fetch" do
         @build.final_mocks.split(' ').each do |mock|
           @build.default_mock = mock
-          invoke_task("pl:jenkins:post_build", "pe:local_mock")
+          invoke_task("pl:jenkins:post_build", "pe:mock")
           sleep 5
         end
       end

--- a/tasks/pe_deb.rake
+++ b/tasks/pe_deb.rake
@@ -1,14 +1,12 @@
-# For PE, the natural default tasks are the remote tasks, rather than
-# the local ones, in reflection of which will be most ideal for PE devs.
-# e.g., pe:local_deb is the task to build a deb on the local host,
-# while pe:deb is the task for building on the remote builder host
-
+# "Alias" tasks for PE - these just point at the standard pl: tasks. They exist
+# for ease of aggregation with PE-specific tasks that _are_ actually different
+# from their "pl" counterparts
 if @build.build_pe
   namespace :pe do
     desc "Create a PE deb from this repo using the default cow #{@build.default_cow}."
-    task :local_deb => "pl:deb"
+    task :deb => "pl:deb"
 
     desc "Create PE debs from this git repository using all cows specified in build_defaults yaml"
-    task :local_deb_all => "pl:deb_all"
+    task :deb_all => "pl:deb_all"
   end
 end

--- a/tasks/pe_remote.rake
+++ b/tasks/pe_remote.rake
@@ -1,44 +1,39 @@
-# For PE, the natural default tasks are the remote tasks, rather than
-# the local ones, in reflection of which will be most ideal for PE devs.
-# e.g., pe:local_deb is the task to build a deb on the local host,
-# while pe:deb is the task for building on the remote builder host
-
+# PE remote tasks
+# We keep these around for backwards compatibility and as a backup in case the
+# jenkins infrastructure fails. We hide them to reduce task clutter
 if @build.build_pe
   namespace :pe do
-    desc "Execute remote debian build using default cow on builder and retrieve package"
-    task :deb => 'pl:fetch' do
-      ENV['PE_VER'] ||= @build.pe_version
-      check_var('PE_VER', ENV['PE_VER'])
-      Rake::Task["pl:remote:build"].reenable
-      Rake::Task["pl:remote:build"].invoke(@build.deb_build_host, 'HEAD', "pe:local_deb PE_BUILD=#{@build.build_pe} TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
-    end
+    namespace :remote do
+      task :deb => 'pl:fetch' do
+        ENV['PE_VER'] ||= @build.pe_version
+        check_var('PE_VER', ENV['PE_VER'])
+        Rake::Task["pl:remote:build"].reenable
+        Rake::Task["pl:remote:build"].invoke(@build.deb_build_host, 'HEAD', "pe:deb PE_BUILD=#{@build.build_pe} TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
+      end
 
-    desc "Execute remote debian build using ALL cows on builder and retrieve packages"
-    task :deb_all => 'pl:fetch' do
-      ENV['PE_VER'] ||= @build.pe_version
-      check_var('PE_VER', ENV['PE_VER'])
-      Rake::Task["pl:remote:build"].reenable
-      Rake::Task["pl:remote:build"].invoke(@build.deb_build_host, 'HEAD', "pe:local_deb_all PE_BUILD=#{@build.build_pe} COW='#{@build.cows}' TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
-    end
+      task :deb_all => 'pl:fetch' do
+        ENV['PE_VER'] ||= @build.pe_version
+        check_var('PE_VER', ENV['PE_VER'])
+        Rake::Task["pl:remote:build"].reenable
+        Rake::Task["pl:remote:build"].invoke(@build.deb_build_host, 'HEAD', "pe:deb_all PE_BUILD=#{@build.build_pe} COW='#{@build.cows}' TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
+      end
 
-    desc "Execute remote rpm build using default mock on builder and retrieve package"
-    task :mock => 'pl:fetch' do
-      ENV['PE_VER'] ||= @build.pe_version
-      Rake::Task["pl:remote:build"].reenable
-      Rake::Task["pl:remote:build"].invoke(@build.rpm_build_host, 'HEAD', "pe:local_mock PE_BUILD=#{@build.build_pe} TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
-    end
+      task :mock => 'pl:fetch' do
+        ENV['PE_VER'] ||= @build.pe_version
+        Rake::Task["pl:remote:build"].reenable
+        Rake::Task["pl:remote:build"].invoke(@build.rpm_build_host, 'HEAD', "pe:mock PE_BUILD=#{@build.build_pe} TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
+      end
 
-    desc "Execute remote rpm build with ALL mocks on builder and retrieve packages"
-    task :mock_all => 'pl:fetch' do
-      ENV['PE_VER'] ||= @build.pe_version
-      Rake::Task["pl:remote:build"].reenable
-      Rake::Task["pl:remote:build"].invoke(@build.rpm_build_host, 'HEAD', "pe:local_mock_all PE_BUILD=#{@build.build_pe} MOCK='#{@build.final_mocks}' TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
-    end
+      task :mock_all => 'pl:fetch' do
+        ENV['PE_VER'] ||= @build.pe_version
+        Rake::Task["pl:remote:build"].reenable
+        Rake::Task["pl:remote:build"].invoke(@build.rpm_build_host, 'HEAD', "pe:mock_all PE_BUILD=#{@build.build_pe} MOCK='#{@build.final_mocks}' TEAM=#{@build.team} PE_VER=#{ENV['PE_VER']}")
+      end
 
-    desc "Execute remote debian, and el builds, sign, and ship pkgs"
-    task :all => ['clean', 'pl:fetch'] do
-      ['pe:deb_all', 'pe:mock_all', 'pe:ship_rpms', 'pe:ship_debs'].each do |task|
-        Rake::Task[task].execute
+      task :all => ['clean', 'pl:fetch'] do
+        ['pe:remote:deb_all', 'pe:remote:mock_all', 'pe:ship_rpms', 'pe:ship_debs'].each do |task|
+          Rake::Task[task].execute
+        end
       end
     end
   end

--- a/tasks/pe_rpm.rake
+++ b/tasks/pe_rpm.rake
@@ -1,17 +1,17 @@
 if @build.build_pe
   namespace :pe do
     desc "Build a PE rpm using rpmbuild (requires all BuildRequires, rpmbuild, etc)"
-    task :local_rpm => "package:rpm"
+    task :rpm => "package:rpm"
 
     desc "Build rpms using ALL final mocks in build_defaults yaml, keyed to PL infrastructure, pass MOCK to override"
-    task :local_mock_all => ["pl:fetch", "pl:mock_all"] do
+    task :mock_all => ["pl:fetch", "pl:mock_all"] do
       if @build.team == 'release'
         Rake::Task["pe:sign_rpms"].invoke
       end
     end
 
     desc "Build a PE rpm using the default mock"
-    task :local_mock => ["pl:fetch", "pl:mock"] do
+    task :mock => ["pl:fetch", "pl:mock"] do
       if @build.team == 'release'
         Rake::Task["pe:sign_rpms"].invoke
       end

--- a/tasks/pe_tar.rake
+++ b/tasks/pe_tar.rake
@@ -1,5 +1,5 @@
 ##
 # An alias from pe:tar to package:tar, for easier automation in jenkins.rake
 namespace :pe do
-  task :local_tar => ["package:tar"]
+  task :tar => ["package:tar"]
 end


### PR DESCRIPTION
On some historic Bad Idea Monday we decided that PE devs would find it easier
to just do "pe:deb" instead of "pe:remote:deb", even though the remote task is
what they would be doing. To accommadate this, we made "pe:deb" and such point
to the remote tasks that operate over ssh, and the local tasks we called
"pe:local_<task>". This diverged completely from the paradigm established for
foss, and was also completely nonsensical. This commit rips all that trash out,
and updates the pe tasks to either be local (pe:deb) or remote (pe:remote:deb).
This will help enormously in porting the new jenkins-dynamic workflow over to
PE, as well as helping me recover my sanity every time I look at these tasks.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
