### PR TITLE
Only replace first underscore in command

### DIFF
--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -116,7 +116,7 @@ return labelMap.get(binding.getVariables().get(&quot;command&quot;));</groovyScr
 # automatically makes directories with the names of the matrix cell (in this
 # case $command) if https://github.com/technomancy/leiningen/issues/891 is ever
 # resolved, this dirty hack can be removed.
-command=$(echo $command | sed 's/_/:/g')
+command=$(echo $command | sed 's/_/:/1')
 
 [ -f &quot;PROJECT_BUNDLE&quot; ] || exit 1
 mkdir project &amp;&amp; tar -xzf PROJECT_BUNDLE -C project/


### PR DESCRIPTION
Because we have other variables that sometimes include underscores, replacing
all underscores with colons is problematic. This commit updates the sed call in
the jenkins build script to only replace the first occurence of an underscore
with a colon, instead of all of them.
Before:
`echo 'pl_mock MOCK=x86_64' | sed 's/_/:/g'
pl:mock MOCK=x86:64`
After
`echo 'pl_mock MOCK=x86_64' | sed 's/_/:/1'
pl:mock MOCK=x86_64`
