### PR TITLE
Don't try to template the packaging dir in the template task

### DIFF
--- a/tasks/template.rake
+++ b/tasks/template.rake
@@ -3,7 +3,7 @@ namespace :package do
   task :template, :workdir do |t, args|
     workdir = args.workdir
 
-    FileList["#{workdir}/ext/**/*.erb"].each do |template|
+    FileList["#{workdir}/ext/**/*.erb"].exclude(/#{workdir}\/ext\/packaging/).each do |template|
       # process the template, stripping off the ERB extension
       erb(template, template[0..-5])
       rm_f(template)


### PR DESCRIPTION
The template task currently tries to template everything in the packaging repo
as well as in the project's ext dir, which means we're evaluating things we
don't necessarily want to. This commit explicitly excludes the packaging repo
from the list of dirs to search for erb templates to evaluate.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
