### PR TITLE
(15708) use pkgbuild to create mac packages

### DIFF
--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -148,7 +148,7 @@ def pack_source
   # Setup a preinstall script and replace variables in the files with
   # the correct paths.
   if File.exists?("#{@working_tree['scripts']}/preinstall")
-    chmod(0644, "#{@working_tree['scripts']}/preinstall")
+    chmod(0755, "#{@working_tree['scripts']}/preinstall")
     sh "sudo chown root:wheel #{@working_tree['scripts']}/preinstall"
   end
 


### PR DESCRIPTION
Now that PackageMaker is deprecated, update apple task to use pkgbuild instead.

Rename {pre,post}flight scripts to {pre,post}install so they'll work with pkgbuild packages.
Cleanup some unused constants and variables.
