### PR TITLE
Add metric gathering parameters to Jenkins tasks

### DIFF
--- a/spec/tasks/build_object_spec.rb
+++ b/spec/tasks/build_object_spec.rb
@@ -62,6 +62,7 @@ describe Build::BuildInstance do
                   :jenkins_packaging_job,
                   :jenkins_repo_path,
                   :metrics,
+                  :metrics_url,
                   :name,
                   :notify,
                   :project,

--- a/tasks/20_setupextravars.rake
+++ b/tasks/20_setupextravars.rake
@@ -27,9 +27,6 @@ namespace :pl do
     end
   end
 end
-if @build.team == 'release'
-  @build.benchmark = TRUE
-end
 
 ##
 # Starting with puppetdb, we'll maintain two separate build-data files, one for

--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -239,6 +239,7 @@ if @build.build_dmg
         add_metrics({ :dist => 'osx', :bench => bench })
         post_metrics
       end
+    puts "Finished building in: #{bench}"
     end
   end
 

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -64,6 +64,7 @@ module Build
                       :jenkins_packaging_job,
                       :jenkins_repo_path,
                       :metrics,
+                      :metrics_url,
                       :name,
                       :notify,
                       :project,

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -59,6 +59,7 @@ task :build_deb, :deb_command, :cow do |t,args|
   end
   # See 30_metrics.rake to see what this is doing
   add_metrics({ :dist => ENV['DIST'], :bench => bench }) if @build.benchmark
+  puts "Finished building in: #{bench}"
 end
 
 namespace :package do

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -69,6 +69,7 @@ if @build.build_gem
         add_metrics({ :dist => 'gem', :bench => bench })
         post_metrics
       end
+      puts "Finished building in: #{bench}"
     end
   end
 

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -115,6 +115,28 @@ namespace :pl do
         when /tar/ then "tar"
         else raise "Could not determine build type for #{build_task}"
       end
+
+      # Create a string of metrics to send to Jenkins for data analysis
+      dist = case build_type
+        when /deb/ then @build.default_cow.split('-')[1]
+        when /rpm/
+          if @build.pe_version
+            @build.final_mocks.split(' ')[0].split('-')[2]
+          else
+            @build.final_mocks.split(' ')[0].split('-')[1..2].join("")
+          end
+        when /dmg/ then "apple"
+        when /gem/ then "gem"
+        when /sles/ then "sles"
+        when /tar/ then "tar"
+        else raise "Could not determine build type for #{build_task}"
+      end
+
+      if @build.pe_version
+        metrics = "#{ENV['USER']}~#{@build.version}~#{@build.pe_version}~#{dist}"
+      else
+        metrics = "#{ENV['USER']}~#{@build.version}~N/A~#{dist}"
+      end
       #
       # Create the data files to send to jenkins
       properties = @build.params_to_yaml
@@ -124,7 +146,8 @@ namespace :pl do
       parameters = [{ "name" => "BUILD_PROPERTIES", "file"  => "file0" },
                     { "name" => "PROJECT_BUNDLE",   "file"  => "file1" },
                     { "name" => "PROJECT",          "value" => "#{@build.project}" },
-                    { "name" => "BUILD_TYPE",       "label" => "#{build_type}" }]
+                    { "name" => "BUILD_TYPE",       "label" => "#{build_type}" },
+                    { "name" => "METRICS",          "value" => "#{metrics}"}]
 
       # Initialize the args array that will hold all of the arguments we pass
       # to the curl utility method.
@@ -149,6 +172,7 @@ namespace :pl do
       "-Fname=PROJECT_BUNDLE"  , "-Ffile1=@#{bundle}",
       "-Fname=PROJECT"         , "-Fvalue=#{@build.project}",
       "-Fname=BUILD_TYPE"      , "-Fvalue=#{build_type}",
+      "-Fname=METRICS"         , "-Fvalue=#{metrics}",
       "-FSubmit=Build",
       "-Fjson=#{json.to_json}",
       ]

--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -65,10 +65,18 @@ namespace :pl do
       properties = @build.params_to_yaml
       bundle = git_bundle('HEAD')
 
+      # Create a string of metrics to send to Jenkins for data analysis
+      if @build.pe_version
+        metrics = "#{ENV['USER']}~#{@build.version}~#{@build.pe_version}"
+      else
+        metrics = "#{ENV['USER']}~#{@build.version}~N/A"
+      end
+
       # Construct the parameters, which is an array of hashes we turn into JSON
       parameters = [{ "name" => "BUILD_PROPERTIES", "file"  => "file0" },
                     { "name" => "PROJECT_BUNDLE",   "file"  => "file1" },
-                    { "name" => "PROJECT",          "value" => "#{@build.project}" }]
+                    { "name" => "PROJECT",          "value" => "#{@build.project}" },
+                    { "name" => "METRICS",          "value" => "#{metrics}"}]
 
       # Contruct the json string
       json = JSON.generate("parameter" => parameters)
@@ -79,6 +87,7 @@ namespace :pl do
       "-Fname=BUILD_PROPERTIES", "-Ffile0=@#{properties}",
       "-Fname=PROJECT_BUNDLE"  , "-Ffile1=@#{bundle}",
       "-Fname=PROJECT"         , "-Fvalue=#{@build.project}",
+      "-Fname=METRICS"         , "-Fvalue=#{metrics}",
       "-FSubmit=Build",
       "-Fjson=#{json.to_json}",
       ]

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -195,6 +195,7 @@ def build_rpm_with_mock(mocks)
       end
     end
     add_metrics({ :dist => "#{family}-#{version}", :bench => bench }) if @build.benchmark
+    puts "Finished building in: #{bench}"
   end
 end
 

--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -82,6 +82,11 @@ return labelMap.get(binding.getVariables().get(&quot;command&quot;));</groovyScr
           <description></description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>METRICS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -140,6 +145,140 @@ popd</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>
+    <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@1.8">
+      <groovyScript>
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+import java.net.HttpURLConnection
+import java.util.Date;
+
+def get_jenkins_build_time() {
+    start_time  = manager.build.getStartTimeInMillis()
+    end_time    = new Date().getTime()
+    return String.valueOf((end_time - start_time)/1000)
+}
+
+// Assemble metrics to post to build metrics server
+
+app_server    = <%= @build.metrics_url %>
+task_metrics  = manager.build.getEnvironment(manager.listener)[&apos;METRICS&apos;]
+charset       = &quot;UTF-8&quot;
+
+// Maintain backwards compatibility
+if ( task_metrics == null) {
+    build_user  = &quot;N/A&quot;
+    version     = &quot;N/A&quot;
+    pe_version  = &quot;N/A&quot;
+} else {
+    build_user  = task_metrics.split(&quot;~&quot;)[0]
+    version     = task_metrics.split(&quot;~&quot;)[1]
+    pe_version  = task_metrics.split(&quot;~&quot;)[2]
+}
+
+matcher = manager.getLogMatcher(/(?:Finished building in:) ([\d]+\.?[\d]*)/)
+if (matcher != null) {
+  package_build_time = matcher[0][1]
+} else {
+  package_build_time = &quot;N/A&quot;
+}
+
+cmd_string  = manager.build.getEnvironment(manager.listener)[&apos;command&apos;]
+if(cmd_string =~ /deb/) {
+  package_type = 'deb'
+} else if(cmd_string =~ /rpm|mock/) {
+  package_type = 'rpm'
+} else if(cmd_string =~ /gem/) {
+  package_type = 'gem'
+} else if(cmd_string =~ /apple/) {
+  package_type = 'dmg'
+} else if(cmd_string =~ /tar/) {
+  package_type = 'tar'
+}  else {
+  package_type = 'N/A'
+}
+
+switch (package_type) {
+  case 'deb':
+    dist = cmd_string.split('-')[1]
+    break
+  case 'rpm':
+    if(pe_version != 'N/A') {
+      dist = cmd_string.split('-')[2]
+    } else {
+      dist = cmd_string.split('-')[1] + cmd_string.split('-')[2]
+    }
+    break
+  case 'gem':
+    dist = 'gem'
+    break
+  case 'dmg':
+    dist = 'apple'
+    break
+  case 'tar':
+    dist = 'tar'
+    break
+  default:
+    dist = 'N/A'
+}
+
+jenkins_build_time  = get_jenkins_build_time()
+package_name        = manager.build.getEnvironment(manager.listener)[&apos;PROJECT&apos;]
+build_loc           = manager.build.getEnvironment(manager.listener)[&apos;NODE_NAME&apos;]
+build_log           = &quot;${manager.build.getEnvironment(manager.listener)[&apos;BUILD_URL&apos;]}&quot; + &quot;consoleText&quot;
+success             = String.valueOf(manager.build.result)
+
+String query = String.format(&quot;package_name=%s&amp;dist=%s&amp;package_type=%s&amp;build_user=%s&amp;build_loc=%s&amp;version=%s&amp;pe_version=%s&amp;success=%s&amp;build_log=%s&amp;jenkins_build_time=%s&amp;package_build_time=%s&quot;,
+     URLEncoder.encode(package_name, charset),
+     URLEncoder.encode(dist, charset),
+     URLEncoder.encode(package_type, charset),
+     URLEncoder.encode(build_user, charset),
+     URLEncoder.encode(build_loc, charset),
+     URLEncoder.encode(version, charset),
+     URLEncoder.encode(pe_version, charset),
+     URLEncoder.encode(success, charset),
+     URLEncoder.encode(build_log, charset),
+     URLEncoder.encode(jenkins_build_time, charset),
+     URLEncoder.encode(package_build_time, charset))
+
+// Make sure the server is listening before attempting to post data
+
+URLConnection connection = null
+serverAlive = false
+try {
+    URL u       = new URL(app_server);
+    connection  = (HttpURLConnection) u.openConnection();
+    connection.setRequestMethod(&quot;GET&quot;);
+    int code    = connection.getResponseCode();
+    serverAlive = true
+    connection.disconnect();
+
+} catch (MalformedURLException e) {
+    serverAlive = false
+    e.printStackTrace()
+
+} catch (IOException e) {
+    serverAlive = false
+    e.printStackTrace()
+
+} finally {
+    if (serverAlive == true) {
+        connection = new URL(app_server).openConnection()
+        connection.setDoOutput(true) // Triggers POST.
+        connection.setRequestProperty(&quot;Accept-Charset&quot;, charset);
+        connection.setRequestProperty(&quot;Content-Type&quot;, &quot;application/x-www-form-urlencoded;charset=&quot; + charset);
+        OutputStream output = null;
+
+        try {
+             output = connection.getOutputStream()
+             output.write(query.getBytes(charset))
+             InputStream response = connection.getInputStream()
+        } finally {
+             if (output != null) try { output.close(); } catch (IOException logOrIgnore) {}
+        }
+    }
+}     </groovyScript>
+      <behavior>0</behavior>
+    </org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>
     <hudson.tasks.ArtifactArchiver>
       <artifacts>**/PROJECT_BUNDLE</artifacts>
       <latestOnly>false</latestOnly>


### PR DESCRIPTION
This commit modifies Jenkins tasks, both standard and dynamic,
to send a new metrics parameter to Jenkins, providing necessary
information for data analysis that could not be collected from Jenkins
itself.
