### PR TITLE
Stop templating osx erbs outside of apple tasks

### DIFF
--- a/tasks/template.rake
+++ b/tasks/template.rake
@@ -3,7 +3,7 @@ namespace :package do
   task :template, :workdir do |t, args|
     workdir = args.workdir
 
-    FileList["#{workdir}/ext/**/*.erb"].exclude(/#{workdir}\/ext\/packaging/).each do |template|
+    FileList["#{workdir}/ext/**/*.erb"].exclude(/#{workdir}\/ext\/(packaging|osx)/).each do |template|
       # process the template, stripping off the ERB extension
       erb(template, template[0..-5])
       rm_f(template)


### PR DESCRIPTION
Currently we template the osx erb files even when doing a tarball, which
results in malformed scripts because the osx tasks have data in them that
isn't available unless you're calling them specifically. This commit offers
the bandaid of not templating them in the template task. We template them
directly in the apple task, to this should only have the effect of preventing
malformed templates in our other packages.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
