### PR TITLE
Replace outdated (and unused) prototype.plist

### DIFF
--- a/static_artifacts/PackageInfo.plist
+++ b/static_artifacts/PackageInfo.plist
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pkg-info followSymLinks="true" minimumSystemVersion="10.6" auth="root"/>
+

--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -68,6 +68,10 @@ def make_directory_tree
     erb 'ext/osx/prototype.plist.erb', "#{@scratch}/prototype.plist"
   end
 
+  if File.exists?('ext/packaging/static_artifacts/PackageInfo.plist')
+    cp 'ext/packaging/static_artifacts/PackageInfo.plist', "#{@scratch}/PackageInfo.plist"
+  end
+
 end
 
 # method:        build_dmg
@@ -86,7 +90,6 @@ def build_dmg
   dmg_format        = "#{dmg_format_code} #{dmg_format_option}"
   dmg_file          = "#{@title}.dmg"
   package_file      = "#{@title}.pkg"
-  package_target_os = '10.4'
 
   # Build .pkg file
   system("sudo #{PKGBUILD} --root #{@working_tree['working']} \
@@ -95,6 +98,7 @@ def build_dmg
     --version #{@version} \
     --install-location / \
     --ownership preserve \
+    --info #{@scratch}/PackageInfo.plist \
     #{@working_tree['payload']}/#{package_file}")
 
   # Build .dmg file


### PR DESCRIPTION
We currently do not actually use the prototype.plist that is generated by
every package, which means the packages we've been shipping have been
generated with mostly defaults. Its just as well anyway, since most of the
contents of the prototype.plist don't even work anymore on Mac OS >= 10.6.

The implications were partially resolved when we switched to making flat
packages using the newer pkgbuild instead of packagemaker, because pkgbuild
allows us to pass in as arguments most of the data we were templating into
the prototype.plist.

The problem is that part of the static data we want to pass into package
builds is the directive to follow symlinks in install targets rather than
overwrite them with directories or normal files, and this is _not_ available
as a flag to pkgbuild. This is probably because in Mac OS >= 10.6, this
behavior is standard - symlinks are not overwritten with our flat packages.
However, the options to restrict minimum OS level don't really work in 10.5,
which means we can't just keep our packages off of 10.5 systems without some
sort of system-introspective preflight script that causes the install to bail
if the host is 10.5 or older.

However, there is an undocumented flag, `-info` to pkgbuild, which allows one
to pass in the path to an additional plist file with additional settings,
including such gems as "followSymLinks". This commit adds the usage of this
flag to the packaging repo, along with a static plist that contains
directives to follow symlinks, require root authorization (as was the
previous setting with prototype.plist) and set a minimum system version of
10.6 (even though this won't be respected in pre-10.6 systems, at least we
can get it documented in the code).

An obsoleted package_target_os variable which is never used is also removed.
