### PR TITLE
(RE-241) Add old style rpm signing for el4

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -107,7 +107,7 @@ def mock_defines(mock_config)
   family = mock_el_family(mock_config)
   version = mock_el_ver(mock_config)
   defines = ""
-  if version == "5" or family == "sles"
+  if version =~ /^(4|5)$/ or family == "sles"
     defines = %Q{--define "%dist .#{family}#{version}" \
       --define "_source_filedigest_algorithm 1" \
       --define "_binary_filedigest_algorithm 1" \

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -19,7 +19,7 @@ namespace :pl do
     task :update_yum_repo do
       STDOUT.puts "Really run remote repo update on #{@build.yum_host}? [y,n]"
       if ask_yes_or_no
-        remote_ssh_cmd(@build.yum_host, '/var/lib/gems/1.8/gems/rake-0.9.2.2/bin/rake -f /opt/repository/Rakefile mk_repo')
+        remote_ssh_cmd(@build.yum_host, 'rake -f /opt/repository/Rakefile mk_repo')
       end
     end
 
@@ -28,7 +28,7 @@ namespace :pl do
       STDOUT.puts "Really run remote freight command on #{@build.apt_host}? [y,n]"
       if ask_yes_or_no
         override = "OVERRIDE=1" if ENV['OVERRIDE']
-        remote_ssh_cmd(@build.apt_host, "/var/lib/gems/1.8/gems/rake-0.9.2.2/bin/rake -f /opt/repository/Rakefile freight #{override}")
+        remote_ssh_cmd(@build.apt_host, "rake -f /opt/repository/Rakefile freight #{override}")
       end
     end
   end


### PR DESCRIPTION
EL4 rpms need to be signed, but we can't use the modern el6 v3 signing. We need
to use the v2 method which el5 and sles also use. This commit implements that
by adding version 4 rpms to the list of dists that get special v2 defines.
