### PR TITLE
Fix hardlinking in signing

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -56,7 +56,7 @@ namespace :pl do
     # Now we hardlink them back in
     Dir["pkg/*/*/*/i386/*.noarch.rpm"].each do |rpm|
       cd File.dirname(rpm) do
-        ln rpm, File.join("..","x86_64")
+        ln File.basename(rpm), File.join("..","x86_64"), :force => true
       end
     end
   end


### PR DESCRIPTION
Currently we cd into the dir containing the rpm and then try to hardlink it
as the a relative path established at RAKE_ROOT, which doesn't work.

E.g.  cd pkg/el/5/devel/i386 && \
        ln pkg/el/5/devel/i386/foo.rpm ../x86_64

This commit updates this to link the file only without the path,

E.g.  cd pkg/el/5/devel/i386 && \
        ln foo.rpm ../x86_64

It also sets the force flag to true for ln, because in the jenkins workflow,
we're going to download rpms in both arch directories, and when we try to
hardlink the signed version in, we'll get the error that the target already
exists. We want to hardlink in the signed version, so we should overwrite the
previous one with :force => true.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
