### PR TITLE
(RE-250) Make tagged builds immutable

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -110,6 +110,12 @@ namespace :pl do
       retry_on_fail(:times => 3) do
         rsync_to("pkg/", @build.distribution_server, "#{artifact_dir}/ --exclude repo_configs")
       end
+      # If we just shipped a tagged version, we want to make it immutable
+      if git_ref_type == "tag"
+        Dir["pkg/*"].each do |f|
+          remote_ssh_cmd(@build.distribution_server, "sudo chattr -R +i #{artifact_dir}/#{File.basename(f)}")
+        end
+      end
     end
 
     desc "Ship generated repository configs to the distribution server"


### PR DESCRIPTION
Currently someone can create a local tag and do an uberbuild, and jenkins will
gladly ship the results to the distribution server and overwrite any existing
builds. After we've shipped to production this isn't really an issue because
also we ship to a separate internal target when we ship to production. The
concern is that between when a tagged build is shipped internally and when it
is pulled in and shipped to production it could be overwritten. This commit
sets the immutable flag on the files from a tagged build, which means they
cannot be overwritten.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
