### PR TITLE
(RE-246) Make build extras optional

### DIFF
--- a/tasks/20_setupextravars.rake
+++ b/tasks/20_setupextravars.rake
@@ -10,8 +10,7 @@ namespace :pl do
     unless ENV['PARAMS_FILE'] && ENV['PARAMS_FILE'] != ''
       tempdir = args.tempdir
       raise "pl:load_extras requires a directory containing extras data" if tempdir.nil?
-      @build.set_params_from_file("#{tempdir}/team/#{@build.builder_data_file}")
-      @build.set_params_from_file("#{tempdir}/project/#{@build.builder_data_file}")
+      @build.set_params_from_file("#{tempdir}/#{@build.builder_data_file}")
       # Overrideable
       @build.build_pe   = boolean_value(ENV['PE_BUILD']) if ENV['PE_BUILD']
       # right now, puppetdb is the only one to override these, because it needs


### PR DESCRIPTION
If the extra build data file in github.com/puppetlabs/build-data doesn't exist
for a project, it probably means we don't need it. We should avoid failing if
  its not there. This commit updates the packaging repo to do just this. Its a
  bit of an overreach, but curl returns 22 when the url isn't found or some
  other issue where a server returns 400 or above, so we'll go with it. There's
  enough curl error codes to handle most of the common network failures, that
  I'm fairly confident this is a safe move.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
