### PR TITLE
(maint) Ensure pe-puppet-server never ships on EL4

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -3,6 +3,8 @@ if @build.build_pe
     desc "ship PE rpms to #{@build.yum_host}"
     task :ship_rpms => "pl:fetch" do
       empty_dir?("pkg/pe/rpm") and fail "The 'pkg/pe/rpm' directory has no packages. Did you run rake pe:deb?"
+      # We don't want to ship pe-puppet-server on el4. So let's blow it away first.
+      rm_rf(FileList["pkg/pe/rpm/el-4-*/pe-puppet-server-*.rpm"]) if @build.project == "pe-puppet"
       target_path = ENV['YUM_REPO'] ? ENV['YUM_REPO'] : "#{@build.yum_repo_path}/#{@build.pe_version}/repos/"
       retry_on_fail(:times => 3) do
         rsync_to('pkg/pe/rpm/', @build.yum_host, target_path)


### PR DESCRIPTION
We don't support the pe-puppet-server on EL4, so we never want to include it in
a build. This commit addresses this need by removing any el4 pe-puppet-server
rpms before shipping.
