### PR TITLE
Don't try to overwrite existing tagged artifacts

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -108,7 +108,8 @@ namespace :pl do
         remote_ssh_cmd(@build.distribution_server, "mkdir -p #{artifact_dir}")
       end
       retry_on_fail(:times => 3) do
-        rsync_to("pkg/", @build.distribution_server, "#{artifact_dir}/ --exclude repo_configs")
+        ignore_existing = "--ignore-existing" if git_ref_type == "tag"
+        rsync_to("pkg/", @build.distribution_server, "#{artifact_dir}/ #{ignore_existing} --exclude repo_configs")
       end
       # If we just shipped a tagged version, we want to make it immutable
       if git_ref_type == "tag"


### PR DESCRIPTION
We currently will try to overwrite existing artifacts with rsync if they're
changed when we ship. However, we don't want to do this with tagged
artifacts, because they're immutable.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
