### PR TITLE
Don't delete packaging any more on success

### DIFF
--- a/templates/repo.xml.erb
+++ b/templates/repo.xml.erb
@@ -67,10 +67,6 @@ pushd project
   popd
 popd
 
-# Delete the upstream project now that repos have been created. This is largely
-# to avoid clutter and reclaim space
-#
-curl -i -X POST <%= "http://#{@build.jenkins_build_host}/job/#{@build.project}-packaging-#{@build.build_date}-#{@build.ref}" %>/doDelete
 </command>
     </hudson.tasks.Shell>
   </builders><% if ENV['DOWNSTREAM_JOB'] %>


### PR DESCRIPTION
With the creation of better jenkins job reaping in puppetlabs-modules, we no
longer need to delete the packaging job when the repo job succeeds. This commit
removes that deletion, since having the job around is slightly useful to
confirm it all finished successfully.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
