### PR TITLE
Only ship debs to incoming

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -34,7 +34,7 @@ if @build.build_pe
       #
       puts "Shipping PE debs to apt repo 'incoming' dir on #{@build.apt_host}"
       retry_on_fail(:times => 3) do
-        rsync_to("pkg/pe/deb/", @build.apt_host, target_path)
+        rsync_to("pkg/pe/deb/*/*.deb", @build.apt_host, target_path)
       end
 
       #   We also ship our PE artifacts to directories for archival purposes and to


### PR DESCRIPTION
We used to ship everything to incoming, but with reprepro we're giving up this
practice and just putting the debs in repos. We ship source elsewhere.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
