### PR TITLE
Correct target of shipping of PE debs

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -34,7 +34,11 @@ if @build.build_pe
       #
       puts "Shipping PE debs to apt repo 'incoming' dir on #{@build.apt_host}"
       retry_on_fail(:times => 3) do
-        rsync_to("pkg/pe/deb/*/*.deb", @build.apt_host, target_path)
+        cd "pkg/pe/deb" do
+          Dir["**/*.deb"].each do |deb|
+            rsync_to(deb, @build.apt_host, "#{target_path}/#{File.dirname(deb)}")
+          end
+        end
       end
 
       #   We also ship our PE artifacts to directories for archival purposes and to


### PR DESCRIPTION
Currently we rsync all the debs into the incoming dir without prefixing the
dist. This commit ensures we're shipping to the dist subdirectory of incoming.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
