### PR TITLE
Open the jenkins windows in your browser when it makes sense

### DIFF
--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -97,6 +97,11 @@ namespace :pl do
 
       if curl_form_data(trigger_url, curl_args)
         print_url_info("#{@build.jenkins_build_host}/job/#{name}")
+        # If you're on a mac, why not open the jenkins job?
+        if ( (RUBY_PLATFORM =~ /darwin/ )  and  (`hostname` !~ /builder/ ) )
+          local_url = "#{@build.jenkins_build_host}/job/#{name}"
+          sh "/usr/bin/open 'http://#{local_url}'"
+        end
         puts "Your packages will be available at #{@build.distribution_server}:#{@build.jenkins_repo_path}/#{@build.project}/#{@build.ref}"
       else
         fail "An error occurred submitting the job to jenkins. Take a look at the preceding http response for more info."


### PR DESCRIPTION
When using the packaging repo to kick off dynamic jobs, you may wish to
view the jobs in Jenkins. In fact, every time I do this, the next step
is copypasta the url into my browser. Since the packaging repo moves all
packaging exercises to a remote system, we can run these packaging
systems on our workstaion machines. Thus, if the system now detects you
are on a mac (and not a hostname with builder in it) it will attempt to
run the 'open' command to bring up the jenkins fun in a browser tab.
