### PR TITLE
Add pe:jenkins:retrieve task

### DIFF
--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -31,3 +31,15 @@ namespace :pl do
     end
   end
 end
+
+if @build.build_pe
+  namespace :pe do
+    namespace :jenkins do
+      desc "Retrieve packages from the distribution server\. Check out commit to retrieve"
+      task :retrieve, :target do |t, args|
+        target = args.target || "artifacts"
+        invoke_task("pl:jenkins:retrieve", target)
+      end
+    end
+  end
+end


### PR DESCRIPTION
So that pe projects don't have to switch over to the 'pl:' namespace to
retrieve. It's confusing.
