### PR TITLE
Allow externally specified bundle for signing environment

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -360,9 +360,9 @@ def rand_string
   rand.to_s.split('.')[1]
 end
 
-def git_bundle(treeish)
-  temp = get_temp
-  appendix = rand_string
+def git_bundle(treeish, appendix=nil, output_dir=nil)
+  temp = output_dir || get_temp
+  appendix ||= rand_string
   sh "git bundle create #{temp}/#{@build.project}-#{@build.version}-#{appendix} #{treeish} --tags"
   cd temp do
     sh "tar -czf #{@build.project}-#{@build.version}-#{appendix}.tar.gz #{@build.project}-#{@build.version}-#{appendix}"
@@ -371,12 +371,14 @@ def git_bundle(treeish)
   "#{temp}/#{@build.project}-#{@build.version}-#{appendix}.tar.gz"
 end
 
-# We take a tar argument for cases where `tar` isn't best, e.g. Solaris
-def remote_bootstrap(host, treeish, tar_cmd=nil)
+# We take a tar argument for cases where `tar` isn't best, e.g. Solaris.  We
+# also take an optional argument of the tarball containing the git bundle to
+# use.
+def remote_bootstrap(host, treeish, tar_cmd=nil, tarball=nil)
   unless tar = tar_cmd
     tar = 'tar'
   end
-  tarball = git_bundle(treeish)
+  tarball ||= git_bundle(treeish)
   tarball_name = File.basename(tarball).gsub('.tar.gz','')
   rsync_to(tarball, host, '/tmp')
   appendix = rand_string

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -112,6 +112,14 @@ namespace :pl do
       #
       @build.params_to_yaml('pkg')
 
+
+      # Sadly, the packaging repo cannot yet act on its own, without living
+      # inside of a packaging-repo compatible project. This means in order to
+      # use the packaging repo for shipping and signing (things that really
+      # don't require build automation, specifically) we still need the project
+      # clone itself.
+      git_bundle('HEAD', 'signing_bundle', 'pkg')
+
       retry_on_fail(:times => 3) do
         remote_ssh_cmd(@build.distribution_server, "mkdir -p #{artifact_dir}")
       end

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -109,11 +109,17 @@ namespace :pl do
       # Because rpms and debs are laid out differently in PE under pkg/ they
       # have a different sign task to address this. Rather than create a whole
       # extra :jenkins task for signing PE, we determine which sign task to use
-      # based on if we're building PE
+      # based on if we're building PE.
+      # We also listen in on the environment variable SIGNING_BUNDLE. This is
+      # _NOT_ intended for public use, but rather with the internal promotion
+      # workflow for Puppet Enterprise. SIGNING_BUNDLE is the path to a tarball
+      # containing a git bundle to be used as the environment for the packaging
+      # repo in a signing operation.
+      signing_bundle = ENV['SIGNING_BUNDLE']
       rpm_sign_task = @build.build_pe ? "pe:sign_rpms" : "pl:sign_rpms"
       deb_sign_task = @build.build_pe ? "pe:sign_deb_changes" : "pl:sign_deb_changes"
       sign_tasks    = ["pl:sign_tar", rpm_sign_task, deb_sign_task]
-      remote_repo   = remote_bootstrap(@build.distribution_server, 'HEAD')
+      remote_repo   = remote_bootstrap(@build.distribution_server, 'HEAD', nil, signing_bundle)
       build_params  = remote_buildparams(@build.distribution_server, @build)
       rsync_to('pkg', @build.distribution_server, remote_repo)
       remote_ssh_cmd(@build.distribution_server, "cd #{remote_repo} ; rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}")


### PR DESCRIPTION
For the internal PE promotion workflow we have a use case for signing external
to the project. This commit updates the packaging repo to create and ship a
tarball containing the git bundle in the jenkins ship. This allows us to pull
that in later, external to the packaging repo, and use it when doing a remote
signing. We update the bundle methods to take optional parameters for name,
so that we can differentiate between the normal tarball that gets created and
the git bundle we ship.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
