### PR TITLE
(RE-372) Make chattr in ship more targeted

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -128,9 +128,10 @@ namespace :pl do
         rsync_to("pkg/", @build.distribution_server, "#{artifact_dir}/ #{ignore_existing} --exclude repo_configs")
       end
       # If we just shipped a tagged version, we want to make it immutable
-      
-      remote_ssh_cmd(@build.distribution_server, "find #{artifact_dir} -type f | xargs sudo chattr +i")
-     
+      files = Dir.glob("pkg/**/*").select { |f| File.file?(f) }.map do |file|
+        "#{artifact_dir}/#{file.sub(/^pkg\//,'')}"
+      end
+      remote_set_immutable(@build.distribution_server, files)
     end
 
     desc "Ship generated repository configs to the distribution server"


### PR DESCRIPTION
Prior to this commit, we were just chattr'ing everything in the
artifacts directory, kind of willy-nilly. This commit targets the
chattr so that we're only calling it on files we actually shipped,
thereby preventing the potential for a race condition and, ultimately,
for build failures.
