### PR TITLE
(maint) Rsync the deb into the directory

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -45,7 +45,7 @@ if @build.build_pe
       retry_on_fail(:times => 3) do
         cd "pkg/pe/deb" do
           Dir["**/*.deb"].each do |deb|
-            rsync_to(deb, @build.apt_host, "#{target_path}/#{File.dirname(deb)}")
+            rsync_to(deb, @build.apt_host, "#{target_path}/#{File.dirname(deb)}/")
           end
         end
       end


### PR DESCRIPTION
The previous rsync call would copy the deb package to the dirname as a file, so
when the reprepro call was made, they was no wheezy directory to traverse into,
but a wheezy file, which is unexpected and breaks the ship. This commit updates
the rsync call to ship the deb package into the dist directory so wheezy would
be a directory containing packages instead of a package renamed to wheezy.
