### PR TITLE
(RE-384) Tie downstream jobs to downstream label

### DIFF
--- a/templates/downstream.xml.erb
+++ b/templates/downstream.xml.erb
@@ -13,7 +13,8 @@ When DOWNSTREAM_JOB is passed to the packaging repo, this job is created to wrap
     </jenkins.plugins.hipchat.HipChatNotifier_-HipChatJobProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
-  <canRoam>true</canRoam>
+  <assignedNode>downstream</assignedNode>
+  <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>


### PR DESCRIPTION
Currently the downstream job is executed on any slave. This presents a problem,
since the downstream job calls curl, which isn't available on every platform by
default (I'm looking at you solaris 10). This commit updates the downstream job
template to assign the job to only nodes with the label 'downstream', which has
already been set up on the jenkins server and assigned to various sane linux
hosts.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
