### PR TITLE
Allow rerun of repo creation job

### DIFF
--- a/templates/repo.xml.erb
+++ b/templates/repo.xml.erb
@@ -50,6 +50,9 @@ set -e
 # and then clone the git_bundle
 
 [ -f &quot;PROJECT_BUNDLE&quot; ] || exit 1
+
+[ -d project ] &amp;&amp; rm -rf project
+
 mkdir project &amp;&amp; tar -xzf PROJECT_BUNDLE -C project/
 
 pushd project


### PR DESCRIPTION
You can't currently 're-run' the packaging or repo creation jobs that the
uber_build dynamically generates via 'rebuild last' or 'matrix reloaded'. For
the packaging job this is because of the way we upload files as triggers, and
that's fairly difficult to address - on a packaging failure, the best option is
just to run the uber_build again, or a job that targets the specific failed
cell, e.g. rake pl:jenkins:deb. However, the downstream repo job can't be
re-run simply because the script isn't idempotent - once run, the files it
leaves behind cause a failure if run again. This commit just updates the script
to remove the directory the job creates before starting, if it exists. This way
at least the repo-jobs can be retriggered.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
