### PR TITLE
(RE-520) Log mock errors to console

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -30,7 +30,23 @@ def mock_artifact(mock_config, cmd_args)
     configdir_arg = " --configdir #{configdir}"
   end
 
-  sh "#{mock} -r #{mock_config} #{configdir_arg} #{cmd_args}"
+  begin
+    sh "#{mock} -r #{mock_config} #{configdir_arg} #{cmd_args}"
+  rescue RuntimeError => error
+    build_log = File.join(basedir, mock_config, 'result', 'build.log')
+    root_log  = File.join(basedir, mock_config, 'result', 'root.log')
+    content   = File.read(build_log) if File.readable?(build_log)
+
+    if content and content.lines.count > 2
+      STDERR.puts content
+    else
+      if File.readable?(root_log)
+        STDERR.puts File.read(root_log)
+      end
+    end
+    raise error
+  end
+
   # Clean up the configdir
   rm_r configdir unless configdir.nil?
 


### PR DESCRIPTION
Currently when a package build fails, the mock error is locked away in a temp
dir on an arbitrary rpm build host. This makes tracking down build failures
very tedious and manual. This commit rescues any exceptions when running mock,
and then prints the build or root log (root log if build is empty), to stderr.
This will make the errors immediately obvious in the jenkins job, so that
manual intervention to retrieve build errors will be unnecessary.
