### PR TITLE
(RE-534) sudo rm the basedir. Yikes.

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -51,8 +51,12 @@ def mock_artifact(mock_config, cmd_args)
 
     # Any useful info has now been gleaned from the logs in the case of a
     # failure, so we can safely remove basedir if this is a randomized mockroot
-    # build.
-    rm_r basedir if randomize
+    # build. Scarily enough, because of mock permissions, we can't actually
+    # just remove it, we have to sudo remove it.
+
+    if randomize and basedir and File.directory?(basedir)
+      sh "sudo -n rm -r #{basedir}"
+    end
 
     raise error
   ensure


### PR DESCRIPTION
We can't actually just rm -r the basedir, because mock owns it and sets perms
as such. I should have known this, because we already encountered it previously
and adjusted for as much in this very file. This commit updates the rm to do a
sudo rm. Added checks to make sure that the basedir exists and is a directory
are added, because I'm paranoid.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
