### PR TITLE
(maint) Always print root mock log on mock failure

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -41,12 +41,11 @@ def mock_artifact(mock_config, cmd_args)
     root_log  = File.join(basedir, mock_config, 'result', 'root.log')
     content   = File.read(build_log) if File.readable?(build_log)
 
+    if File.readable?(root_log)
+      STDERR.puts File.read(root_log)
+    end
     if content and content.lines.count > 2
       STDERR.puts content
-    else
-      if File.readable?(root_log)
-        STDERR.puts File.read(root_log)
-      end
     end
 
     # Any useful info has now been gleaned from the logs in the case of a


### PR DESCRIPTION
Previously we would only print the root log if the build log was empty on a
mock failure. The root log often has valuable information in debugging mock
failures, so we should _always_ print it out in a build failure.
