### PR TITLE
(RE-477) Allow any vendor_gems task access to package:vendor_gems

### DIFF
--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -1,6 +1,6 @@
 # This is an optional pre-tar-task, so we only want to present it if we're
 # using it
-if @build.pre_tar_task == "package:vendor_gems"
+if @build.pre_tar_task
   namespace :package do
     desc "vendor gems required by project"
     task :vendor_gems do


### PR DESCRIPTION
For razor we will be invoking bundler from within rake from within jruby to
fetch the dependencies of the Gemfile. This will be accomplished by using an
auxiliary vendor_gems task called package:jruby_vendor_gems. In order for that
task to invoke the package:vendor_gems task, it must be defined even if the
pre_tar_task isn't equal to package:vendor_gems. This commit updates the task
to be defined if any pre_tar_task is defined.
