### PR TITLE
(RE-552) Pushing gems requires credentials

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -314,6 +314,7 @@ def git_commit_file(file, message=nil)
 end
 
 def ship_gem(file)
+  check_file("#{ENV['HOME']}/.gem/credentials")
   %x{gem push #{file}}
 end
 


### PR DESCRIPTION
Let's verify rubygems credentials actually exist before we try pushing
that gem
