### PR TITLE
(maint) Revert "Merge pull request #232 from shrug/maint/qe-465"

### DIFF
--- a/spec/tasks/build_object_spec.rb
+++ b/spec/tasks/build_object_spec.rb
@@ -81,7 +81,6 @@ describe Build::BuildInstance do
                   :privatekey_pem,
                   :random_mockroot,
                   :rc_mocks,
-                  :redis_hostname,
                   :release,
                   :rpm_build_host,
                   :rpmrelease,

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -83,7 +83,6 @@ module Build
                       :privatekey_pem,
                       :random_mockroot,
                       :rc_mocks,
-                      :redis_hostname,
                       :release,
                       :rpm_build_host,
                       :rpmrelease,

--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -317,20 +317,6 @@ try {
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.3.1">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-<% if @build.redis_hostname -%>
-    <jenkins.plugins.logstash.LogstashBuildWrapper plugin="logstash@0.8.0">
-      <redis>
-        <host><%=@build.redis_hostname%></host>
-        <port>6379</port>
-        <numb>1</numb>
-        <pass></pass>
-        <dataType>list</dataType>
-        <key>logstash</key>
-        <type>jenkins</type>
-      </redis>
-      <useRedis>true</useRedis>
-    </jenkins.plugins.logstash.LogstashBuildWrapper>
-<% end -%>
   </buildWrappers>
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>


### PR DESCRIPTION
This reverts commit afc957cf748f23d7fdd0564312a699dd7175c04b, reversing
changes made to 50e80b26da3bc704a9c785f1c3f225d789d4d021.

We are not really taking advantage of this, and the plugin has been disabled on at least one of the internal jenkins instances. Removing this configuration since it's no longer necessary.
