### PR TITLE
(RE-448) Don't try to ship or set immutable nonexistent files

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -4,9 +4,11 @@ namespace :pl do
     ["el", "fedora"].each do |dist|
       retry_on_fail(:times => 3) do
         pkgs = Dir["pkg/#{dist}/**/*.rpm"].map { |f| "'#{f.gsub("pkg/#{dist}/", "#{@build.yum_repo_path}/#{dist}/")}'"}
-        rsync_to("pkg/#{dist}", @build.yum_host, @build.yum_repo_path)
-        remote_set_immutable(@build.yum_host, pkgs)
-      end
+        unless pkgs.empty?
+          rsync_to("pkg/#{dist}", @build.yum_host, @build.yum_repo_path)
+          remote_set_immutable(@build.yum_host, pkgs)
+        end
+      end if File.directory?("pkg/#{dist}")
     end
   end
 


### PR DESCRIPTION
When shipping, either via uber_ship or other ships, if any of the el or fedora
top level directories don't exist or are empty, the ship will fail either when
rsyncing or when chattring the files post ship. This commit updates the
ship_rpms task to only invoke the rsync and chattr if the directory exists and
has rpms in it.
