### PR TITLE
(maint) Don't try to ship debs if there are none

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -39,7 +39,9 @@ namespace :pl do
   desc "Ship cow-built debs to #{@build.apt_host}"
   task :ship_debs do
     retry_on_fail(:times => 3) do
-      rsync_to('pkg/deb/', @build.apt_host, @build.apt_repo_path)
+      if File.directory?("pkg/deb")
+        rsync_to('pkg/deb/', @build.apt_host, @build.apt_repo_path)
+      end
     end
   end
 


### PR DESCRIPTION
Previously the ship_debs task would fail hard if the pkg/deb directory didn't
exist, which makes sense. This commit updates the ship_debs task to not bother
rsyncing debs if there is no pkg/deb directory to rsync, as is the case for
pe-razor-server currently.
