### PR TITLE
(FACT-186) Know about bundle_platform

### DIFF
--- a/spec/tasks/build_object_spec.rb
+++ b/spec/tasks/build_object_spec.rb
@@ -18,6 +18,7 @@ describe Build::BuildInstance do
                   :build_ips,
                   :build_pe,
                   :builder_data_file,
+                  :bundle_platforms,
                   :certificate_pem,
                   :cows,
                   :db_table,

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -19,6 +19,7 @@ module Build
                       :build_pe,
                       :builder_data_file,
                       :builds_server,
+                      :bundle_platforms,
                       :certificate_pem,
                       :cows,
                       :db_table,


### PR DESCRIPTION
Per https://github.com/puppetlabs/facter/pull/591, in order to make
project_data.yaml the single source of truth for gem dependencies, we need to
support some form of mapping between ruby platforms and their bundler
counterparts for the purposes of composing a Gemfile. The suggested approach
was a key, bundle_platforms, that contains this mapping, but in order to avoid
printing a warning about unknown build parameters, we need to add it here as
well. This commit does so.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
