### PR TITLE
(maint) Cleanup after gem builds correctly

### DIFF
--- a/tasks/10_setupvars.rake
+++ b/tasks/10_setupvars.rake
@@ -89,6 +89,13 @@ end
 # variable, but for backwards compatibility, we'll default back to @yum_host if
 # @tar_host isn't set.
 @build.tar_host ||= @build.yum_host
+# In gem packaging, we currently use gem_name conditionally to build a gem of
+# name other than the project name. This makes cleanup challenging, because we
+# may need to cleanup the project name or the gem name depending. This alias
+# allows us to unconditionally clean up the gem_name based directory.
+if @build.build_gem
+  @build.gem_name ||= @build.project
+end
 
 # Though undocumented, we had specified gem_devel_dependencies as an allowed
 # parameter for @build, and it was supposed to correspond with

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -82,7 +82,7 @@ if @build.build_gem
 
   def create_default_gem
     spec = create_default_gem_spec
-    create_gem(spec, "#{@build.project}-#{@build.gemversion}")
+    create_gem(spec, "#{@build.gem_name}-#{@build.gemversion}")
   end
 
   def unknown_gems_platform?(platform)
@@ -111,7 +111,7 @@ if @build.build_gem
           spec = add_gem_dependency(:spec => spec, :gem => gem, :version => version, :type => t)
         end
       end
-      create_gem(spec, "#{@build.project}-#{@build.gemversion}-#{platform}")
+      create_gem(spec, "#{@build.gem_name}-#{@build.gemversion}-#{platform}")
     end
   end
 


### PR DESCRIPTION
Previously we would pass in project instead of gem name to the create_gem
method, which would then clean up the project directory after building the gem.
This worked fine as long as gem_name == project, but in mcollective this is not
true. So the first change this commit makes is updating the create_gem
invocations to use gem_name as the builddir for create_gem. This fixes
mcollective, but breaks on platforms that don't set gem_name. So the second
change is to set gem_name to equal project if gem_name isn't set, so that the
change will succeed everywhere.
