### PR TITLE
Reenable apt repo path in between shipping dists

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -58,6 +58,7 @@ if @build.build_pe
         end
 
         if @build.team == 'release'
+          Rake::Task["pe:remote:apt"].reenable
           Rake::Task["pe:remote:apt"].invoke(target_path, dist)
         end
 


### PR DESCRIPTION
We have to do this in order to actually update the apt repo with every
distribution. Otherwise rake things we've already done it.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
