### PR TITLE
(maint) Consolidate two methods into one

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -412,19 +412,13 @@ def git_pull(remote, branch)
   sh "git pull #{remote} #{branch}"
 end
 
-def create_rpm_repo(dir)
-  check_tool('createrepo')
-  cd dir do
-    sh "createrepo --checksum=sha --database ."
-  end
-end
-
 def update_rpm_repo(dir)
   check_tool('createrepo')
   cd dir do
     sh "createrepo --checksum=sha --database --update ."
   end
 end
+alias :create_rpm_repo :update_rpm_repo
 
 def empty_dir?(dir)
   File.exist?(dir) and File.directory?(dir) and Dir["#{dir}/**/*"].empty?


### PR DESCRIPTION
create_rpm_repo and update_rpm_repo are almost identical methods except for the
passing of --update, which will still work when creating a repo. This commit
collapses the two methods into one by aliasing create_rpm_repo to
update_rpm_repo, so that only one method needs maintenance.
