### PR TITLE
(Maint) Don't abort if gembuilddir doesn't exist

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -75,7 +75,7 @@ if @build.build_gem
       gem_task.define
       Rake::Task[:gem].reenable
       Rake::Task[:gem].invoke
-      rm_r File.join("pkg", gembuilddir)
+      rm_rf File.join("pkg", gembuilddir)
     end
     puts "Finished building in: #{bench}"
   end


### PR DESCRIPTION
Previously, running `rake package:gem` from facter would fail with the
error:

```
$ rake package:gem
rm -rf pkg
mkdir -p pkg
WARNING:  no rubyforge_project specified
mv facter-1.7.4.38.gem pkg/facter-1.7.4.38.gem
rm -r pkg/facter-1.7.4.38
rake aborted!
No such file or directory - pkg/facter-1.7.4.38
```

This changes the gem task to rm -rf pkg/facter-1.7.4.38 instead. I don't
know why the same error doesn't occur when creating a puppet gem.
