### PR TITLE
(RE-279) Send a bundle of the packaging repo to distribution server

### DIFF
--- a/packaging.rake
+++ b/packaging.rake
@@ -2,7 +2,8 @@
 
 # These are ordered
 
-PACKAGING_PATH = File.join(File.dirname(__FILE__), 'tasks')
+PACKAGING_ROOT = File.expand_path(File.dirname(__FILE__))
+PACKAGING_TASK_DIR = File.join(PACKAGING_ROOT, 'tasks')
 
 @using_loader = true
 
@@ -41,5 +42,5 @@ PACKAGING_PATH = File.join(File.dirname(__FILE__), 'tasks')
   'update.rake',
   'vendor_gems.rake',
   'version.rake',
-  'z_data_dump.rake'].each { |t| load File.join(PACKAGING_PATH, t)}
+  'z_data_dump.rake'].each { |t| load File.join(PACKAGING_TASK_DIR, t)}
 


### PR DESCRIPTION
Let's also make a git bundle of the packaging repo that we're using when we
invoke pl:jenkins:ship. We can have a reasonable level of confidence, later on,
that the git bundle on the distribution server was, in fact, the git bundle
used to create the associated packages. This is because this ship task is
automatically called upon completion each cell of the pl:jenkins:uber_build,
and we have --ignore-existing set below. As such, the only git bundle that
should possibly be on the distribution is the one used to create the packages.
We're bundling the packaging repo because it allows us to keep an
archive of the packaging source that was used to create the packages,
so that later on if we need to rebuild an older package to audit it or
for some other reason we're assured that the new package isn't
different by virtue of the packaging automation.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
