### PR TITLE
(RE-399) make build object properties accessible

### DIFF
--- a/tasks/z_data_dump.rake
+++ b/tasks/z_data_dump.rake
@@ -29,5 +29,37 @@ namespace :pl do
   task :print_build_params do
     @build.print_params
   end
+
+  ##
+  # Print a parameter passed as an argument to STDOUT.
+  desc "Print a build parameter"
+  task :print_build_param, :param do |t, args|
+    # We want a string that is the from "@<param name>"
+    if param = args.param
+      getter = param.dup
+      if param[0] == ':'
+        getter = param[1..-1]
+        param[0] = "@"
+      elsif param[0] == "@"
+        getter = param[1..-1]
+      else
+        param.insert(0, "@")
+      end
+
+      # We want to fail if the param passed is bogus, print 'nil' if its not
+      # set, and print the value if its set.
+      if @build.respond_to?(getter)
+        if val = @build.instance_variable_get(param)
+          puts val
+        else
+          puts 'nil'
+        end
+      else
+        fail "Could not locate a build parameter called #{param}. For a list of available parameters, do `rake pl:print_build_params`"
+      end
+    else
+      fail "To print a build parameter, pass the param name as a rake argument. Ex: rake pl:print_build_param[:version]"
+    end
+  end
 end
 


### PR DESCRIPTION
It would be useful to have access from the rake entry point to all of the build
properties individually. This commit makes it so, by creating a new rake task,
pl:print_build_param[:param], where the passed parameter is the one to print.

Various forms of output running this new task:

```
[0] moses@mosesmac:hiera:(redirect)$ rake pl:print_build_param[version]
1.3.1-45-dirty
[0] moses@mosesmac:hiera:(redirect)$ rake pl:print_build_param[:version]
1.3.1-45-dirty
[0] moses@mosesmac:hiera:(redirect)$ rake pl:print_build_param[@version]
1.3.1-45-dirty
[0] moses@mosesmac:hiera:(redirect)$ rake pl:print_build_param[@foo]
rake aborted!
Could not locate a build parameter called @foo. For a list of available parameters, do `rake pl:print_build_params`
/Users/moses/development/hiera/ext/packaging/tasks/z_data_dump.rake:58:in `block (2 levels) in <top (required)>'
Tasks: TOP => pl:print_build_param
(See full trace by running task with --trace)
[1] moses@mosesmac:hiera:(redirect)$ rake pl:print_build_param[foo]
rake aborted!
Could not locate a build parameter called @foo. For a list of available parameters, do `rake pl:print_build_params`
/Users/moses/development/hiera/ext/packaging/tasks/z_data_dump.rake:58:in `block (2 levels) in <top (required)>'
Tasks: TOP => pl:print_build_param
(See full trace by running task with --trace)
[1] moses@mosesmac:hiera:(redirect)$ rake pl:print_build_param[:foo]
rake aborted!
Could not locate a build parameter called @foo. For a list of available parameters, do `rake pl:print_build_params`
/Users/moses/development/hiera/ext/packaging/tasks/z_data_dump.rake:58:in `block (2 levels) in <top (required)>'
Tasks: TOP => pl:print_build_param
(See full trace by running task with --trace)
[1] moses@mosesmac:hiera:(redirect)$ rake pl:print_build_param
rake aborted!
To print a build parameter, pass the param name as a rake argument. Ex: rake pl:print_build_param[:version]
/Users/moses/development/hiera/ext/packaging/tasks/z_data_dump.rake:61:in `block (2 levels) in <top (required)>'
Tasks: TOP => pl:print_build_param
(See full trace by running task with --trace)
[1] moses@mosesmac:hiera:(redirect)$
```

Signed-off-by: Moses Mendoza moses@puppetlabs.com
