### PR TITLE
(maint) Use gem_name when pushing

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -73,7 +73,7 @@ namespace :pl do
       # want to ship final gems because otherwise a development gem would be
       # preferred over the last final gem
       if @build.version_strategy != "odd_even" || is_final?
-        FileList["pkg/#{@build.project}-#{@build.gemversion}*.gem"].each do |f|
+        FileList["pkg/#{@build.gem_name}-#{@build.gemversion}*.gem"].each do |f|
           puts "Shipping gem #{f} to rubygems"
           ship_gem(f)
         end


### PR DESCRIPTION
Previously if a project name did not match the gem name, it would not get
pushed automatically during a pl:ship_gem. This commit updates the task to use
the gem_name instead of project name to avoid this problem. gem_name defaults
to project name if it is not set.
