### PR TITLE
Correct package:<version> tasks (for backward compatibility)

### DIFF
--- a/tasks/version.rake
+++ b/tasks/version.rake
@@ -56,7 +56,7 @@ namespace :package do
   # A set of tasks for printing the version
   [:version, :rpmversion, :rpmrelease, :debversion, :release].each do |task|
     task "#{task}" do
-      STDOUT.puts self.instance_variable_get("@#{task}")
+      STDOUT.puts Pkg::Config.instance_variable_get("@#{task}")
     end
   end
 end


### PR DESCRIPTION
When the build system data moved under Pkg::Config, it was no longer accessible
as instance variables of the Rake invocation, thank heavens. However, this
broke references to `self` attempting to access this data, including these rake
package:<version> tasks. This commit updates them. Note, however, that these
are DEPRECATED in favor of doing `rake pl:print_build_param[:param]` which give
access to _all_ Pkg::Config data, not just these select few. However, since to
print a warning would be backwards incompatible, we're kind of stuck with these
for now.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
