### PR TITLE
(RE-998) Enable pre-tasks

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -77,6 +77,7 @@ module Pkg::Params
                   :pe_version,
                   :pg_major_version,
                   :pre_tar_task,
+                  :pre_tasks,
                   :privatekey_pem,
                   :project_root,
                   :random_mockroot,

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -8,6 +8,7 @@ module Pkg::Util
   require 'packaging/util/file'
   require 'packaging/util/version'
   require 'packaging/util/serialization'
+  require 'packaging/util/rake_utils'
 
   def self.boolean_value(var)
     return TRUE if (var == TRUE || ( var.is_a?(String) && ( var.downcase == 'true' || var.downcase =~ /^y$|^yes$/ )))

--- a/lib/packaging/util/rake_utils.rb
+++ b/lib/packaging/util/rake_utils.rb
@@ -1,0 +1,57 @@
+# Utility methods for working with rake tasks. These utilities will not work
+# if the packaging repo was loaded as a library unless rake has been required
+# explicitly.
+
+module Pkg::Util::RakeUtils
+  class << self
+    def using_rake?
+      defined?(Rake::Task)
+    end
+
+    def task_defined?(task_name)
+      if using_rake?
+        Rake::Task.task_defined?(task_name)
+      end
+    end
+
+    #  Return the Rake::Task object associated with a task name
+    #
+    def get_task(task_name)
+      if using_rake? and task_defined?(task_name)
+        Rake::Task[task_name]
+      end
+    end
+
+    #  Add a dependency to a rake task. "depender" must be an instance of
+    #  Rake::Task, but dependency can be either a Rake::Task instance, or a String
+    #  referring to the name of a Rake::Task instance.
+    #
+    def add_dependency(depender, dependency)
+      if using_rake?
+        if !task_defined?(depender)
+          fail "Could not locate a Rake task named '#{depender.to_s}' to add a dependency of '#{dependency.to_s}' to"
+        elsif !task_defined?(dependency)
+          fail "Could not locate a Rake task named '#{dependency.to_s}' to add as a dependency of '#{depender.to_s}'"
+        else
+          depender_task = Rake::Task[depender]
+          depender_task.enhance([dependency])
+        end
+      end
+    end
+
+    #  Evaluate any pre-tasks known by the configuration of this invocation.
+    #  Again, this is quite pointless if the user has not invoked the packaging
+    #  repo via rake, so we're just not going to do anything.
+    #
+    def evaluate_pre_tasks
+      if using_rake? and Pkg::Config.pre_tasks
+        unless Pkg::Config.pre_tasks.is_a?(Hash)
+          fail "The 'pre_tasks' key must be a Hash of depender => dependency pairs"
+        end
+        Pkg::Config.pre_tasks.each do |depender, dependency|
+          add_dependency(depender, dependency)
+        end
+      end
+    end
+  end
+end

--- a/packaging.rake
+++ b/packaging.rake
@@ -46,3 +46,4 @@ PACKAGING_TASK_DIR = File.join(PACKAGING_ROOT, 'tasks')
   'version.rake',
   'z_data_dump.rake'].each { |t| load File.join(PACKAGING_TASK_DIR, t)}
 
+Pkg::Util::RakeUtils.evaluate_pre_tasks

--- a/spec/fixtures/util/pre_tasks.yaml
+++ b/spec/fixtures/util/pre_tasks.yaml
@@ -1,0 +1,4 @@
+---
+pre_tasks:
+  foo: 'bar'
+

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -78,6 +78,7 @@ describe "Pkg::Config" do
                   :pe_version,
                   :pg_major_version,
                   :pre_tar_task,
+                  :pre_tasks,
                   :privatekey_pem,
                   :random_mockroot,
                   :rc_mocks,
@@ -253,8 +254,8 @@ describe "Pkg::Config" do
       it "should set the project root to nil" do
         orig = Pkg::Config.project_root
         Pkg::Config.project_root = 'foo'
-        expect(Pkg::Config).to receive(:project_root=).with(nil)
         Pkg::Config.load_default_configs
+        expect(Pkg::Config.project_root).to be(nil)
         Pkg::Config.project_root = orig
       end
     end

--- a/spec/lib/packaging/util/rake_utils_spec.rb
+++ b/spec/lib/packaging/util/rake_utils_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe "Pkg::Util::RakeUtils" do
+  let(:foo_defined?) { Rake::Task.task_defined?(:foo) }
+  let(:bar_defined?) { Rake::Task.task_defined?(:bar) }
+  let(:define_foo)   { body = proc{}; Rake::Task.define_task(:foo, &body) }
+  let(:define_bar)   { body = proc{}; Rake::Task.define_task(:bar, &body) }
+
+  before(:each) do
+    if foo_defined?
+      Rake::Task[:foo].clear_prerequisites
+    end
+  end
+
+  describe "#task_defined?" do
+    context "given a Rake::Task task name" do
+      it "should return true if the task exists" do
+        Rake::Task.stub(:task_defined?).with(:foo) {true}
+        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be_true
+      end
+      it "should return false if the task does not exist" do
+        Rake::Task.stub(:task_defined?).with(:foo) {false}
+        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be_false
+      end
+    end
+  end
+
+  describe "#get_task" do
+    it "should return a task object for a named task" do
+      foo = nil
+      if !foo_defined?
+        foo = define_foo
+      else
+        foo = Rake::Task[:foo]
+      end
+      task = Pkg::Util::RakeUtils.get_task(:foo)
+      expect(task).to be_a(Rake::Task)
+      expect(task).to be(foo)
+    end
+  end
+
+  describe "#add_dependency" do
+    it "should add a dependency to a given rake task" do
+      foo = nil
+      bar = nil
+      if !foo_defined?
+        foo = define_foo
+      else
+        foo = Rake::Task[:foo]
+      end
+      if !bar_defined?
+        bar = define_bar
+      else
+        bar = Rake::Task[:bar]
+      end
+      Pkg::Util::RakeUtils.add_dependency(foo, bar)
+      expect(Rake::Task["foo"].prerequisites).to include(bar)
+    end
+  end
+
+  describe "#evaluate_pre_tasks" do
+    context "Given a data file with :pre_tasks defined" do
+      it "should, for each k=>v pair, add v as a dependency to k" do
+        Pkg::Config.config_from_yaml(File.join(FIXTURES, 'util', 'pre_tasks.yaml'))
+        expect(Pkg::Util::RakeUtils).to receive(:add_dependency)
+        Pkg::Util::RakeUtils.evaluate_pre_tasks
+      end
+    end
+  end
+end


### PR DESCRIPTION
We created a system for allowing you to specify a task defined in a project to
run prior to the tarball creation task ("package:tar"). However, this isn't
versatile enough to handle all of the potential use cases for task inserting
dependencies. We may want to define project-specific tasks at other points in
the dependency chain, and conditionally depending on the build target.  The
specific use case is our apple packaging. We would like to specify in puppet
and facter a task to execute prior to the "package:apple" task - namely the
retrieval of vendored software like 'rgen' or 'CFPropertyList'.  To support
this, we need to create a new system that allows you to name tasks and insert
them as dependencies of tasks you name. That is what this commit tries to do.
It adds a new set of utilities for interacting with Rake::Task objects,
including searching for and adding dependencies. It enables usage of this via
a new 'pre_tasks' parameter of the Pkg::Config object. Usage should be
via build_defaults.yaml or project_data.yaml, in the form:

pre_tasks:
  'dependency_task':'depender_task'

or for our use facter case (assuming a task to retrieve CFPropertyList named
'retrieve_cfp'):

pre_tasks:
  'retrieve_cfp': 'package:apple'

Signed-off-by: Moses Mendoza moses@puppetlabs.com
