### PR TITLE
Update signing for el4 and el7 packages

### DIFF
--- a/tasks/pe_sign.rake
+++ b/tasks/pe_sign.rake
@@ -10,14 +10,14 @@ if Pkg::Config.build_pe
       # Find x86_64 noarch rpms that have been created as hard links and remove them
       rm_r Dir["pkg/pe/rpm/*-*-x86_64/*.noarch.rpm"]
       # We'll sign the remaining noarch
-      sign_dists = 'el5', 'el6', 'sles11'
+      sign_dists = 'el4', 'el5', 'el6', 'el7', 'sles11'
       ['i386', 'x86_64'].each do |arch|
         sign_dists.each do |dist|
           family=dist[/[a-z]+/]
           version=dist[/[0-9]+/]
           rpm_stagedir        = "pkg/pe/rpm/#{family}-#{version}-#{arch}/*.rpm"
           srpm_stagedir       = "pkg/pe/rpm/#{family}-#{version}-srpms/*.rpm"
-          if family == 'el' and version == '6'
+          if family == 'el' and version >= '6'
             modern_rpms += FileList[rpm_stagedir] + FileList[srpm_stagedir]
           else
             old_rpms += FileList[rpm_stagedir] + FileList[srpm_stagedir]


### PR DESCRIPTION
Prior, we were very particular about the packages that we would sign.
Specifically, we would only sign el5, el6 and fedora packages. This was
great and all until we realized that we would love to add in el4 and
el7. It was at that point, that we became sad, because there was no
el4/el7 signing love. They were abandoned, left adrift in the world of
unsigned packages. This commit brings them into the loving arms of a
family they never had, making them a part of the big family of signed
packages.
