### PR TITLE
(RE-1044) Add packaging job URL to downstream job url parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,23 +277,32 @@ value, presumably a url to a jenkins job to trigger programmatically.
 
 An important note about `DOWNSTREAM_JOB`: `DOWNSTREAM_JOB` in the dynamic jenkins
 workflow is _always_ invoked if it is passed in as an environment variable.
-However, it is also appended with an additional parameter, `PACKAGE_BUILD_STATUS`,
+However, it is appended with an additional parameter, `PACKAGE_BUILD_STATUS`,
 which will be the string "success" if package and repo builds succeeded, or
 "failure" if package or repo builds failed. By modifying the actual downstream
 jenkins job to accept a string parameter of `PACKAGE_BUILD_STATUS`, one can
 switch on the success or failure of the packaging job, responding
-  appropriately.
+  appropriately. A second parameter, `PACKAGE_BUILD_URL` is also appended to
+  `DOWNSTREAM_JOB`, the value of which is the url of the packaging job itself.
+  This is to assist with tracing failures in a multi-jenkins environment. By
+  modifying the downstream jenkins job to accept a string parameter of
+  `PACKAGE_BUILD_URL`, one can use the value to display the url prominently in
+  case of failure, for example.
 
 E.g., a job url:
 http://jenkins.example.net/job/downstream/buildWithParameters?FOO=bar
 
 in the success case will be transformed into
 
-http://jenkins.example.net/job/downstream/buildWithParameters?FOO=bar&PACKAGE_BUILD_STATUS=success
+http://jenkins.example.net/job/downstream/buildWithParameters?FOO=bar&PACKAGE_BUILD_STATUS=success&PACKAGE_BUILD_URL=http://jenkins.example.net/job/packaging_job
 
 and in the failure case transformed into
 
-http://jenkins.example.net/job/downstream/buildWithParameters?FOO=bar&PACKAGE_BUILD_STATUS=failure
+http://jenkins.example.net/job/downstream/buildWithParameters?FOO=bar&PACKAGE_BUILD_STATUS=failure&PACKAGE_BUILD_URL=http://jenkins.example.net/job/packaging_job
+
+Since jenkins will just drop parameters that are not configured in the job,
+accepting PACKAGE_BUILD_STATUS and PACKAGE_BUILD_URL in the downstream job
+isn't mandatory.
 
 All 3 jobs are configured by default for removal by jenkins after 3 days, to
 avoid clutter.

--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -28,7 +28,7 @@ namespace :pl do
       work_dir           = Pkg::Util::File.mktemp
       template_dir       = File.join(File.dirname(__FILE__), '..', 'templates')
       templates          = ['repo.xml.erb', 'packaging.xml.erb']
-      templates.unshift('downstream.xml.erb') if ENV['DOWNSTREAM_JOB']
+      templates << ('downstream.xml.erb') if ENV['DOWNSTREAM_JOB']
 
       # Generate an XML file for every job configuration erb and attempt to
       # create a jenkins job from that XML config
@@ -43,6 +43,9 @@ namespace :pl do
         else
           retry_on_fail(:times => 3) do
             url = create_jenkins_job(job_name, xml_file)
+            if t == "packaging.xml.erb"
+              ENV["PACKAGE_BUILD_URL"] = url
+            end
             puts "Verifying job created successfully..."
             unless jenkins_job_exists?(job_name)
               raise "Unable to verify Jenkins job, trying again..."

--- a/templates/downstream.xml.erb
+++ b/templates/downstream.xml.erb
@@ -37,7 +37,7 @@ else
 fi
 
 # This URI was passed in as an argument to the original rake package call
-curl --fail -i &quot;<%= escape_html(add_param_to_uri(ENV['DOWNSTREAM_JOB'], "PACKAGE_BUILD_STATUS=$UPSTREAM_BUILD_STATUS")) %>&quot;</command>
+curl --fail -i &quot;<%= escape_html(add_param_to_uri(add_param_to_uri(ENV['DOWNSTREAM_JOB'], "PACKAGE_BUILD_STATUS=$UPSTREAM_BUILD_STATUS"), "PACKAGE_BUILD_URL=#{ENV["PACKAGE_BUILD_URL"]}")) %>&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>


### PR DESCRIPTION
The downstream job URL supplied by the user has 'PACKAGE_BUILD_STATUS'
automatically appended to it as a URL parameter, so that triggered jobs can
act on this information. It would also be useful to users to have the original
packaging job URL appended to the downstream job also, so that any failures are
readily accessible from the callback job.

This commit makes it so, by creating appending PACKAGE_BUILD_URL to the url as
a parameter as well, containing the url of the packaging job. We move the
downstream job to being created last, so that we can be certain the packaging
job has been created and assigned a url before we insert said url into the
downstream job. Turns out it jenkins jobs don't have to be created in order of
downstream,upstream so this is fine.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
