### PR TITLE
Stop adding to 00_utils!!

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -1,3 +1,28 @@
+#######################################################################
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#                  !  DO NOT ADD TO THIS FILE  !                      #
+#                                                                     #
+#   Usage of this file to store utilities is deprecated. Any new      #
+#   utilities should be added to new or existing classes in           #
+#   lib/packaging/util. Any modified utilities should be migrated     #
+#   to new or existing classes in lib/packaging/util as well.         #
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#                                                                     #
+#######################################################################
+
+
+
+
+
 # Utility methods used by the various rake tasks
 
 def check_var(varname,var=nil)


### PR DESCRIPTION
For the foreseeable future, we want to discontinue use of 00_utils.rake, in
favor of testable classes in lib/packaging/util. This commit adds a warning to
stop adding to 00_utils.rake for anything.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
