### PR TITLE
(maint) Unconditionally popd after pushd regardless of job status

### DIFF
--- a/tasks/rpm_repos.rake
+++ b/tasks/rpm_repos.rake
@@ -37,7 +37,8 @@ namespace :pl do
         cmd << "rsync -avxl artifacts/ repos/ ; pushd repos ; "
         cmd << "createrepo=$(which createrepo) ; "
         cmd << 'for repodir in $(find ./ -name "*.rpm" | xargs -I {} dirname {}) ; do '
-        cmd << "pushd ${repodir} && ${createrepo} --checksum=sha --database --update . && popd ; "
+        cmd << "[ -d ${repodir} ] || continue; "
+        cmd << "pushd ${repodir} && ${createrepo} --checksum=sha --database --update . ; popd ; "
         cmd << "done ; popd "
 
         remote_ssh_cmd(Pkg::Config.distribution_server, cmd)


### PR DESCRIPTION
We're encountering a problem where `createrepo` may fail during the
process of generating repo data for platforms. When this happens,
the conditional '&&' is never triggered, so popd is never run.
This leads to a cascade failure due to use of relative paths.

Step one in tracking this down is to remove the conditional '&&'
and unconditionally popd regardless of the exit status of createrepo.
