### PR TITLE
Curl downstream job url with verbose

### DIFF
--- a/templates/downstream.xml.erb
+++ b/templates/downstream.xml.erb
@@ -37,7 +37,7 @@ else
 fi
 
 # This URI was passed in as an argument to the original rake package call
-curl --fail -i &quot;<%= escape_html(add_param_to_uri(add_param_to_uri(ENV['DOWNSTREAM_JOB'], "PACKAGE_BUILD_STATUS=$UPSTREAM_BUILD_STATUS"), "PACKAGE_BUILD_URL=#{ENV["PACKAGE_BUILD_URL"]}")) %>&quot;</command>
+curl -v --fail -i &quot;<%= escape_html(add_param_to_uri(add_param_to_uri(ENV['DOWNSTREAM_JOB'], "PACKAGE_BUILD_STATUS=$UPSTREAM_BUILD_STATUS"), "PACKAGE_BUILD_URL=#{ENV["PACKAGE_BUILD_URL"]}")) %>&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>


### PR DESCRIPTION
If the downstream job fails to trigger, the curl call will just display the
response code and no additional information. This is not helpful when trying to
debug failures. This commit adds -v to the curl call so that it prints a full
trace of its attempt to trigger the job.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
