### PR TITLE
(maint) Refactor, improve pe_ship.rake

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -128,14 +128,14 @@ if Pkg::Config.build_pe
     namespace :remote do
       desc "Update remote rpm repodata for PE on #{Pkg::Config.yum_host}"
       task :update_yum_repo => "pl:fetch" do
+        repo_base_path = File.join(Pkg::Config.yum_repo_path, Pkg::Config.pe_version, "repos")
+        mock_paths = Pkg::Config.final_mocks.split.map {|mock| "#{mock_el_family(mock)}-#{mock_el_ver(mock)}"}
 
         # This entire command is going to be passed across SSH, but it's unwieldy on a
         # single line. By breaking it into a series of concatenated strings, we can maintain
         # a semblance of formatting and structure (nevermind readability).
-        command  = %{for dir in $(find #{Pkg::Config.apt_repo_path}/#{Pkg::Config.pe_version}/repos/{sles,el}* -type d | grep -v repodata | grep -v cache | xargs); do}
-        command += %{  pushd $dir; }
-        command += %{  sudo createrepo --checksum=sha --quiet --database --update . ; }
-        command += %{  popd &> /dev/null ; }
+        command  = %{for dir in #{repo_base_path}/{#{mock_paths.join(",")}}-*; do}
+        command += %{  sudo createrepo --checksum=sha --quiet --database --update $dir; }
         command += %{done; }
         command += %{sync}
 


### PR DESCRIPTION
Previously the pe:update_yum_repo task was hardcoded to update el and sles
repos. In a world where eos is a valid platform, those hardcoded assumptions
break down. This commit updates the task to use the final_mocks as the first
and second elements of the platform tag to iterate over. Arch is left off the
tag, because the hardlinking we do for noarch packages means that noarch
packages only have an i386 mock, even when they are built for both i386 and
x86_64.
This refactor also removes the find and pushd from the shell snippet. The find
is not necessary because we know the names of the platform tags ahead of time.
The pushd is not needed because createrepo takes a $dir argument.
