### PR TITLE
(maint) tar_host defaults to yum_host

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -156,7 +156,7 @@ module Pkg::Params
   # in case it is not set.
   #
   REASSIGNMENTS = [{:oldvar => :name,                   :newvar => :project},
-                   {:oldvar => :tar_host,               :newvar => :yum_host},
+                   {:oldvar => :yum_host,               :newvar => :tar_host},
                    {:oldvar => :gem_devel_dependencies, :newvar => :gem_development_dependencies},
                    {:oldvar => :pe_name,                :newvar => :project},
                    {:oldvar => :project,                :newvar => :gem_name}]

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -214,6 +214,14 @@ describe "Pkg::Config" do
     end
   end
 
+  describe "#issue_reassignments" do
+    it "should set tar_host to yum_host" do
+      Pkg::Config.config_from_hash({ :yum_host => 'foo' })
+      Pkg::Config.issue_reassignments
+      Pkg::Config.tar_host.should eq("foo")
+    end
+  end
+
   describe "#config_to_hash" do
     it "should return a hash object" do
       hash = Pkg::Config.config_to_hash


### PR DESCRIPTION
Previously, the REASSIGNMENT for tar_host was inverted, so if tar_host were
absent, it would not be reassigned. This commit fixes that error and adds a
test case to catch a regression in the behavior.
