### PR TITLE
(RE-1138) support versions less than zero as RC

### DIFF
--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -182,6 +182,8 @@ module Pkg::Util::Version
           ret = is_rc?
         when "odd_even"
           ret = is_odd?
+        when "zero_based"
+          ret = is_less_than_one?
         when nil
           ret = is_rc?
       end
@@ -215,6 +217,20 @@ module Pkg::Util::Version
     # '0.7.1-63-dirty'
     def is_odd?
       return TRUE if get_dash_version.match(/^\d+\.(\d+)\.\d+/)[1].to_i.odd?
+      return FALSE
+    end
+
+    # the pre-1.0 strategy (node classifier)
+    # final:
+    # '1.8.0'
+    # '1.8.0-63'
+    # '1.8.1-63-dirty'
+    # development:
+    # '0.7.0'
+    # '0.7.0-63'
+    # '0.7.1-63-dirty'
+    def is_less_than_one?
+      return TRUE if get_dash_version.match(/^(\d+)\.\d+\.\d+/)[1].to_i.zero?
       return FALSE
     end
 

--- a/spec/lib/packaging/util/version_spec.rb
+++ b/spec/lib/packaging/util/version_spec.rb
@@ -18,4 +18,50 @@ describe "Pkg::Util::Version" do
       Pkg::Util::Version.versionbump
     end
   end
+
+  context "#is_less_than_one?" do
+    context "with a version that starts with '0'" do
+      it "should return true" do
+        Pkg::Util::Version.stub(:get_dash_version).and_return("0.0.1")
+        Pkg::Util::Version.is_less_than_one?.should be(true)
+      end
+    end
+
+    context "with a version that starts with '1' or greater" do
+      it "should return false" do
+        Pkg::Util::Version.stub(:get_dash_version).and_return("1.0.0")
+        Pkg::Util::Version.is_less_than_one?.should be(false)
+      end
+    end
+  end
+
+  context "#is_final?" do
+
+    context "with version_strategy 'rc_final'" do
+      it "should use 'is_rc?' and return the opposite" do
+        Pkg::Util::Version.stub(:is_rc?).and_return(false)
+        Pkg::Config.stub(:version_strategy).and_return("rc_final")
+        Pkg::Util::Version.should_receive(:is_rc?)
+        Pkg::Util::Version.is_final?.should be(true)
+      end
+    end
+
+    context "with version_strategy 'odd_even'" do
+      it "should use 'is_odd?' and return the opposite" do
+        Pkg::Util::Version.stub(:is_odd?).and_return(false)
+        Pkg::Config.stub(:version_strategy).and_return("odd_even")
+        Pkg::Util::Version.should_receive(:is_odd?)
+        Pkg::Util::Version.is_final?.should be(true)
+      end
+    end
+
+    context "with version_strategy 'zero_based'" do
+      it "should use 'is_less_than_one?' and return the opposite" do
+        Pkg::Util::Version.stub(:is_less_than_one?).and_return(false)
+        Pkg::Config.stub(:version_strategy).and_return("zero_based")
+        Pkg::Util::Version.should_receive(:is_less_than_one?)
+        Pkg::Util::Version.is_final?.should be(true)
+      end
+    end
+  end
 end

--- a/spec/tasks/00_utils_spec.rb
+++ b/spec/tasks/00_utils_spec.rb
@@ -14,6 +14,7 @@ describe "00_utils" do
       :get_rpmrelease             => '1',
       :is_rc?                     => false,
       :is_odd?                    => true,
+      :is_less_than_one?          => true,
     },
     '0.8.0rc10'                   => {
       :git_describe_version       => %w{0.8.0rc10},
@@ -25,6 +26,7 @@ describe "00_utils" do
       :get_rpmrelease             => '0.1rc10',
       :is_rc?                     => true,
       :is_odd?                    => false,
+      :is_less_than_one?          => true,
     },
     '0.7.0-rc1'                   => {
       :git_describe_version       => %w{0.7.0 rc1},
@@ -36,6 +38,7 @@ describe "00_utils" do
       :get_rpmrelease             => '0.1rc1',
       :is_rc?                     => true,
       :is_odd?                    => true,
+      :is_less_than_one?          => true,
     },
     '0.4.0-rc1-63-ge391f55'       => {
       :git_describe_version       => %w{0.4.0 rc1 63},
@@ -47,6 +50,7 @@ describe "00_utils" do
       :get_rpmrelease             => '0.1rc1.63',
       :is_rc?                     => true,
       :is_odd?                    => false,
+      :is_less_than_one?          => true,
     },
     '0.6.0-rc1-63-ge391f55-dirty' => {
       :git_describe_version       => %w{0.6.0 rc1 63 dirty},
@@ -58,6 +62,7 @@ describe "00_utils" do
       :get_rpmrelease             => '0.1rc1.63dirty',
       :is_rc?                     => true,
       :is_odd?                    => false,
+      :is_less_than_one?          => true,
 
     },
     '0.7.0-63-ge391f55'           => {
@@ -70,6 +75,7 @@ describe "00_utils" do
       :get_rpmrelease             => '1',
       :is_rc?                     => false,
       :is_odd?                    => true,
+      :is_less_than_one?          => true,
 
     },
     '0.7.0-63-ge391f55-dirty'     => {
@@ -82,6 +88,30 @@ describe "00_utils" do
       :get_rpmrelease             => '1',
       :is_rc?                     => false,
       :is_odd?                    => true,
+      :is_less_than_one?          => true,
+    },
+    '1.7.0'                       => {
+      :is_less_than_one?          => false,
+    },
+    '1.8.0rc10'                   => {
+      :is_less_than_one?          => false,
+    },
+    '1.7.0-rc1'                   => {
+      :is_less_than_one?          => false,
+    },
+    '1.4.0-rc1-63-ge391f55'       => {
+      :is_less_than_one?          => false,
+    },
+    '1.6.0-rc1-63-ge391f55-dirty' => {
+      :is_less_than_one?          => false,
+
+    },
+    '1.7.0-63-ge391f55'           => {
+      :is_less_than_one?          => false,
+
+    },
+    '1.7.0-63-ge391f55-dirty'     => {
+      :is_less_than_one?          => false,
     },
   }
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -69,10 +69,10 @@ namespace :pl do
   if Pkg::Config.build_gem
     desc "Ship built gem to rubygems"
     task :ship_gem do
-      # Even if a project builds a gem, if it uses the odd_even strategy, we only
-      # want to ship final gems because otherwise a development gem would be
-      # preferred over the last final gem
-      if Pkg::Config.version_strategy != "odd_even" || Pkg::Util::Version.is_final?
+      # Even if a project builds a gem, if it uses the odd_even or zero-based
+      # strategies, we only want to ship final gems because otherwise a
+      # development gem would be preferred over the last final gem
+      if Pkg::Config.version_strategy !~ /odd_even|zero_based/ || Pkg::Util::Version.is_final?
         FileList["pkg/#{Pkg::Config.gem_name}-#{Pkg::Config.gemversion}*.gem"].each do |f|
           puts "Shipping gem #{f} to rubygems"
           ship_gem(f)


### PR DESCRIPTION
Currently, a project must be either tagged with 'rc' or have an odd minor
version and specify odd_even versioning to get into the RC repos. We have a
request to support a project versioned with major less than 1 as RC repos as
well. This commit adds a new version strategy called 'zero_based' in which a
project that has a major version of 0 will always be considered not-final. This
is opt-in, which prevents breaking any existing usage.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
