### PR TITLE
(maint) Fix specs to run even after a package bootstrap

### DIFF
--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -216,10 +216,19 @@ describe "Pkg::Config" do
   end
 
   describe "#issue_reassignments" do
+    before :all do
+      prev_tar_host = Pkg::Config.tar_host
+      Pkg::Config.tar_host = nil
+    end
+
     it "should set tar_host to yum_host" do
       Pkg::Config.config_from_hash({ :yum_host => 'foo' })
       Pkg::Config.issue_reassignments
       Pkg::Config.tar_host.should eq("foo")
+    end
+
+    after :all do
+      Pkg::Config.tar_host = prev_tar_host
     end
   end
 


### PR DESCRIPTION
Prior to this change, if the packaging repo was bootstrapped
(i.e. so that it lives inside another repo), and that
repo specified a value for tar_host, this one spec would
fail because it assumed that value was nil.

This change just stashes the value of tar_host, and sets it
to nil to match the spec test assumption, and then restores
the original value when it's done.
