### PR TITLE
(RE-1535) Restore previous template behavior

### DIFF
--- a/lib/packaging/tar.rb
+++ b/lib/packaging/tar.rb
@@ -125,7 +125,15 @@ module Pkg
         #   essence, templating "in place." This is why we remove the original
         #   files - they're not the originals in the authoritative project
         #   directory, but the originals in the temporary working copy.
-        Pkg::Util::File.erb_file(File.join(workdir,rel_path_to_template), File.join(workdir, rel_path_to_target), true, :binding => Pkg::Config.get_binding)
+        if File.exist?(File.join(workdir,rel_path_to_template))
+          mkpath(File.dirname( File.join(workdir, rel_path_to_target) ), :verbose => false)
+          Pkg::Util::File.erb_file(File.join(workdir,rel_path_to_template), File.join(workdir, rel_path_to_target), true, :binding => Pkg::Config.get_binding)
+        elsif File.exist?(File.join(root,rel_path_to_template))
+          mkpath(File.dirname( File.join(workdir, rel_path_to_target) ), :verbose => false)
+          Pkg::Util::File.erb_file(File.join(root,rel_path_to_template), File.join(workdir, rel_path_to_target), false, :binding => Pkg::Config.get_binding)
+        else
+          fail "Expected to find #{template_file} in #{root} for templating. But it was not there. Maybe you deleted it?"
+        end
       end
     end
 


### PR DESCRIPTION
Previously, debian templates would be automatically evaluated and
included in tarballs. This functionality was lost at some point. This
commit works around the issue by sourcing the template from the root if
it doesn't exist in the workdir. If it is not available in either
location it exits with a helpful message.
