### PR TITLE
Add cow_list method to Pkg::Config

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -96,6 +96,17 @@ module Pkg
         self.config_to_hash.each { |k,v| puts "#{k}: #{v}" }
       end
 
+      ##
+      # Print the names of all of the cows for the project, taking off the
+      # base prefix, the architecture, and the .cow suffix. This is helpful in
+      # the debian changelog.
+      #
+      def cow_list
+        self.cows.split(' ').map do
+          |cow| cow.split('-')[1]
+        end.uniq.join(' ')
+      end
+
       def default_project_root
         # It is really quite unsafe to assume github.com/puppetlabs/packaging has been
         # cloned into $project_root/ext/packaging even if it has _always_ been the

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -199,6 +199,13 @@ describe "Pkg::Config" do
     end
   end
 
+  describe "#cow_list" do
+    it "should return a list of the cows for a project" do
+      Pkg::Config.cows = "base-lucid-i386.cow base-lucid-amd64.cow base-precise-i386.cow base-precise-amd64.cow base-quantal-i386.cow base-quantal-amd64.cow base-saucy-i386.cow base-saucy-amd64.cow base-sid-i386.cow base-sid-amd64.cow base-squeeze-i386.cow base-squeeze-amd64.cow base-stable-i386.cow base-stable-amd64.cow base-testing-i386.cow base-testing-amd64.cow base-trusty-i386.cow base-trusty-amd64.cow base-unstable-i386.cow base-unstable-amd64.cow base-wheezy-i386.cow base-wheezy-amd64.cow"
+      Pkg::Config.cow_list.should eq "lucid precise quantal saucy sid squeeze stable testing trusty unstable wheezy"
+    end
+  end
+
   describe "#config" do
     context "given :format => :hash" do
       it "should call Pkg::Config.config_to_hash" do


### PR DESCRIPTION
Currently our debian changelogs are littered with inaccurate lists of
debian platforms. Updating all of those lists independently of the
build_defaults file seems like a duplication of work. This commit
addresses that by making available a simple method to get a space
separated list of debian platforms for a project.
