### PR TITLE
Return raw git describe for tags 

### DIFF
--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -82,7 +82,9 @@ module Pkg::Util::Version
       # For a final with added commits, it will look like '0.7.0-63-g51ccc51'
       # and our return will be [0.7.0, 64, <dirty>]
       info = raw.chomp.sub(/^v/, '').split('-')
-      if info[1].to_s.match('^[\d]+')
+      if git_ref_type == "tag"
+        version_string = info.compact
+      elsif info[1].to_s.match('^[\d]+')
         version_string = info.values_at(0,1,3).compact
       else
         version_string = info.values_at(0,1,2,4).compact

--- a/spec/tasks/00_utils_spec.rb
+++ b/spec/tasks/00_utils_spec.rb
@@ -4,6 +4,20 @@ load_task('00_utils.rake')
 
 describe "00_utils" do
   TestVersions = {
+    '0.3.2-20140507.175526-5'       => {
+      :ref_type                     => "tag",
+      :method_map                   => {
+        :git_describe_version       => %w{0.3.2 20140507.175526 5},
+        :get_dash_version           => '0.3.2-20140507.175526-5',
+        :get_dot_version            => '0.3.2.20140507.175526.5',
+        :get_debversion             => '0.3.2.20140507.175526.5-1puppetlabs1',
+        :get_rpmversion             => '0.3.2.20140507.175526.5',
+        :get_rpmrelease             => '1',
+        :is_rc?                     => false,
+        :is_odd?                    => true,
+        :is_less_than_one?          => true,
+      },
+    },
     '0.7.0'                         => {
       :ref_type                     => "tag",
       :method_map                   => {
@@ -160,12 +174,14 @@ describe "00_utils" do
 
     describe "Versioning based on #{input}" do
       results = TestVersions[input][:method_map]
+      let(:ref_type) { TestVersions[input][:ref_type] }
       results.keys.sort_by(&:to_s).each do |method|
         it "using Pkg::Util::Version.#{method} #{input.inspect} becomes #{results[method].inspect}" do
           # We have to call the `stub!` alias because we are trying to stub on
           # `self`, and in the scope of an rspec block that is overridden to
           # return a new double, not to stub a method!
           Pkg::Config.release = "1"
+          Pkg::Util::Version.should_receive(:git_ref_type).and_return(ref_type)
 
           if method.to_s.include?("deb")
             Pkg::Util::Version.should_receive(:run_git_describe_internal).and_return(input)


### PR DESCRIPTION
Previously, the version returned by the packaging repo would _always_
have the last component when split on '-' removed (when there are a
certain number of elements), which works very well for standard commits
and for our rc tags, but doesn't work for maven timestamps. For example,
currently 0.3.2-20140507.175526-5 is stripped to 0.3.2-20140507.175526.
This commit addresses that by explicitly using the raw git describe for
tags, and only doing manipulation for commits.
