### PR TITLE
(maint) Allow rpm.rake to fall through to other spec sources

### DIFF
--- a/tasks/rpm.rake
+++ b/tasks/rpm.rake
@@ -8,7 +8,11 @@ def prep_rpm_build_dir
   # ext/redhat/<project>.spec.erb. If that doesn't exist, we fail. To do this,
   # we have to open the tarball.
   cp_p("pkg/#{tarball}", temp)
-  if ex(%Q[tar -tzf #{File.join(temp, tarball)}]).split.grep(/ext\/redhat\/#{Pkg::Config.project}.spec$/)
+
+  # Test for specfile in tarball
+  %x{tar -tzf #{File.join(temp, tarball)}}.split.grep(/ext\/redhat\/#{Pkg::Config.project}.spec$/)
+
+  if $?.success?
     sh "tar -C #{temp} -xzf #{File.join(temp, tarball)} #{Pkg::Config.project}-#{Pkg::Config.version}/ext/redhat/#{Pkg::Config.project}.spec"
     cp("#{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}/ext/redhat/#{Pkg::Config.project}.spec", "#{temp}/SPECS/")
   elsif File.exists?("ext/redhat/#{Pkg::Config.project}.spec.erb")


### PR DESCRIPTION
Previously the tar inspection happened using the ex method, which raises
an exception and fails if the command itself fails. This doesn't allow
the logic to fail through to templating the specfile anew from the
project as intended. This commit updates the logic to use %x and test $?
explicitly for success?. This will allow the logic to fall through
before failing as it was intended to.
