### PR TITLE
(RE-2116) Build gem in a tmpdir and burn in version

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -88,6 +88,9 @@ if Pkg::Config.build_gem
     bench = Benchmark.realtime do
       copy_gem_files_into(workdir)
 
+      # Burn in the version for the project if needed
+      Pkg::Util::Version.versionbump(workdir) if Pkg::Config.update_version_file
+
       cd workdir do
         gem_task = Gem::PackageTask.new(spec)
         gem_task.define


### PR DESCRIPTION
Previously, the gem was built out of the project_root, which worked well
as long as you didn't want to manipulate any of the files in the gem,
like to burn in a version string. This PR updates the create_gem
method to first make a tmp directory, then copy all of the gem files
into it, and build the gem.

Previously, burning in the version during gem creation was not possible.
This PR also adds an invocation of the versionbump method if
it is required.
