### PR TITLE
(RE-1178) Add ability to use an array to list cows and mocks in build_defaults.yaml

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -45,6 +45,7 @@ module Pkg
       def config_from_yaml(file)
         build_data = Pkg::Util::Serialization.load_yaml(file)
         config_from_hash(build_data)
+        sanitize_mocks_and_cows
       end
 
       ##
@@ -107,35 +108,33 @@ module Pkg
         end.uniq.join(' ')
       end
 
-     def enumerate_cows
-       if self.cows
-         if self.cows.is_a?(String)
-            warn "warning: 'cows' should be an array, not a string"
-            @enumerated_cows = self.cows.split(' ')
-         elsif self.cows.is_a?(Array)
-            @enumerated_cows = self.cows
-         else
-           fail "'cows' must be a string or an array!"
-         end
-       else
-         @enumerated_cows = []
-       end
-     end
+  def sanitize_mocks_and_cows
+    if self.cows
+      if self.cows.is_a?(String)
+         warn "warning: 'cows' should be an array, not a string"
+         @cows = self.cows.split(' ')
+      elsif self.cows.is_a?(Array)
+         @cows = self.cows
+      else
+         fail "'cows' must be a string or an array!"
+      end
+    else
+      @cows = []
+    end
 
-     def enumerate_mocks
-       if self.final_mocks
-         if self.final_mocks.is_a?(String)
-            warn "warning: 'final_mocks' should be an array, not a string"
-            @enumerated_mocks = self.final_mocks.split(' ')
-         elsif self.final_mocks.is_a?(Array)
-            @enumerated_mocks = self.final_mocks
-         else
-           fail "'final_mocks' must be a string or an array!"
-         end
-       else
-         @enumerated_mocks = []
-       end
-     end
+    if self.final_mocks
+      if self.final_mocks.is_a?(String)
+        warn "warning: 'final_mocks' should be an array, not a string"
+        @final_mocks = self.final_mocks.split(' ')
+      elsif self.final_mocks.is_a?(Array)
+        @final_mocks = self.final_mocks
+      else
+        fail "'final_mocks' must be a string or an array!"
+      end
+    else
+      @final_mocks = []
+    end
+  end
 
       def default_project_root
         # It is really quite unsafe to assume github.com/puppetlabs/packaging has been

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -118,7 +118,7 @@ namespace :pl do
   desc "Create debs from this git repository using all cows specified in build_defaults yaml"
   task :deb_all do
     check_var('PE_VER', Pkg::Config.pe_version) if Pkg::Config.build_pe
-    Pkg::Config.enumerate_cows.each do |cow|
+    Pkg::Config.cows.each do |cow|
       Rake::Task["package:tar"].invoke
       Rake::Task[:build_deb].reenable
       Rake::Task[:build_deb].invoke('pdebuild', cow)

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -126,9 +126,9 @@ namespace :pl do
         when /deb/ then Pkg::Config.default_cow.split('-')[1]
         when /rpm/
           if Pkg::Config.pe_version
-            Pkg::Config.enumerate_mocks[0].split('-')[2]
+            Pkg::Config.final_mocks[0].split('-')[2]
           else
-            Pkg::Config.enumerate_mocks[0].split('-')[1..2].join("")
+            Pkg::Config.final_mocks[0].split('-')[1..2].join("")
           end
         when /dmg/ then "apple"
         when /gem/ then "gem"
@@ -231,7 +231,7 @@ namespace :pl do
     # DOSing it with our packaging.
     desc "Queue pl:deb_all on jenkins builder"
     task :deb_all => "pl:fetch" do
-      Pkg::Config.enumerate_cows.each do |cow|
+      Pkg::Config.cows.each do |cow|
         Pkg::Config.default_cow = cow
         invoke_task("pl:jenkins:post_build", "pl:deb")
         sleep 5
@@ -241,7 +241,7 @@ namespace :pl do
     # This does the mocks in parallel
     desc "Queue pl:mock_all on jenkins builder"
     task :mock_all => "pl:fetch" do
-      Pkg::Config.enumerate_mocks.each do |mock|
+      Pkg::Config.final_mocks.each do |mock|
         Pkg::Config.default_mock = mock
         invoke_task("pl:jenkins:post_build", "pl:mock")
         sleep 5
@@ -278,7 +278,7 @@ if Pkg::Config.build_pe
       desc "Queue pe:deb_all on jenkins builder"
       task :deb_all => "pl:fetch" do
         check_var("PE_VER", Pkg::Config.pe_version)
-        Pkg::Config.enumerate_cows.each do |cow|
+        Pkg::Config.cows.each do |cow|
           Pkg::Config.default_cow = cow
           invoke_task("pl:jenkins:post_build", "pe:deb")
           sleep 5
@@ -288,7 +288,7 @@ if Pkg::Config.build_pe
       # This does the mocks in parallel
       desc "Queue pe:mock_all on jenkins builder"
       task :mock_all => "pl:fetch" do
-        Pkg::Config.enumerate_mocks.each do |mock|
+        Pkg::Config.final_mocks.each do |mock|
           Pkg::Config.default_mock = mock
           invoke_task("pl:jenkins:post_build", "pe:mock")
           sleep 5

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -279,12 +279,12 @@ namespace :pl do
   desc "Use default mock to make a final rpm, keyed to PL infrastructure, pass MOCK to specify config"
   task :mock => "package:tar" do
     # If default mock isn't specified, just take the first one in the Pkg::Config.final_mocks list
-    Pkg::Config.default_mock ||= Pkg::Config.enumerate_mocks[0]
+    Pkg::Config.default_mock ||= Pkg::Config.final_mocks[0]
     build_rpm_with_mock(Pkg::Config.default_mock)
   end
 
   desc "Use specified mocks to make rpms, keyed to PL infrastructure, pass MOCK to specifiy config"
   task :mock_all => "package:tar" do
-    build_rpm_with_mock(Pkg::Config.enumerate_mocks)
+    build_rpm_with_mock(Pkg::Config.final_mocks)
   end
 end

--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -85,7 +85,7 @@ if Pkg::Config.build_pe
 
       puts "Shipping all built artifacts to to archive directories on #{Pkg::Config.apt_host}"
 
-      Pkg::Config.cows.enumerate_cows.map { |i| i.sub('.cow','') }.each do |cow|
+      Pkg::Config.cows.map { |i| i.sub('.cow','') }.each do |cow|
         _base, dist, arch = cow.split('-')
         unless Pkg::Util::File.empty_dir? "pkg/pe/deb/#{dist}"
           archive_path = "#{base_path}/#{dist}-#{arch}"
@@ -129,7 +129,7 @@ if Pkg::Config.build_pe
       desc "Update remote rpm repodata for PE on #{Pkg::Config.yum_host}"
       task :update_yum_repo => "pl:fetch" do
         repo_base_path = File.join(Pkg::Config.yum_repo_path, Pkg::Config.pe_version, "repos")
-        mock_paths = Pkg::Config.enumerate_mocks.map {|mock| "#{mock_el_family(mock)}-#{mock_el_ver(mock)}"}
+        mock_paths = Pkg::Config.final_mocks.map {|mock| "#{mock_el_family(mock)}-#{mock_el_ver(mock)}"}
 
         # This entire command is going to be passed across SSH, but it's unwieldy on a
         # single line. By breaking it into a series of concatenated strings, we can maintain

--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -55,14 +55,14 @@ pl:jenkins:uber_build NOTIFY=foo@puppetlabs.com&#xd;
   <properties>
     <jp.ikedam.jenkins.plugins.groovy__label__assignment.GroovyLabelAssignmentProperty plugin="groovy-label-assignment@1.0.0">
       <groovyScript>def labelMap = [
-        <% Pkg::Config.enumerate_cows.each do |cow| %>
+        <% Pkg::Config.cows.each do |cow| %>
           <% if cow =~ /cumulus/ %>
         &quot;pl_deb COW=<%= cow %>&quot;: &quot;cumulus&quot;,
           <% else %>
         &quot;pl_deb COW=<%= cow %>&quot;: &quot;deb&quot;,
           <% end %>
         <% end %>
-        <% Pkg::Config.enumerate_mocks.each do |mock| %>&quot;pl_mock MOCK=<%= mock %>&quot;: &quot;rpm&quot;,<% end %>
+        <% Pkg::Config.final_mocks.each do |mock| %>&quot;pl_mock MOCK=<%= mock %>&quot;: &quot;rpm&quot;,<% end %>
         &quot;package_tar&quot;: &quot;rpm&quot;,
         <% if Pkg::Config.build_gem then %>&quot;package_gem&quot;: &quot;gem&quot;,<% end %>
         <% if Pkg::Config.build_dmg then %>&quot;package_apple&quot;: &quot;dmg&quot;,<% end %>
@@ -107,8 +107,8 @@ return labelMap.get(binding.getVariables().get(&quot;command&quot;));</groovyScr
     <hudson.matrix.TextAxis>
       <name>command</name>
       <values>
-        <% Pkg::Config.enumerate_cows.each do |cow| %><string>pl_deb COW=<%= cow %></string><% end %>
-        <% Pkg::Config.enumerate_mocks.each do |mock| %><string>pl_mock MOCK=<%= mock %></string><% end %>
+        <% Pkg::Config.cows.each do |cow| %><string>pl_deb COW=<%= cow %></string><% end %>
+        <% Pkg::Config.final_mocks.each do |mock| %><string>pl_mock MOCK=<%= mock %></string><% end %>
         <string>package_tar</string>
         <% if Pkg::Config.build_gem then %><string>package_gem</string><% end %>
         <% if Pkg::Config.build_dmg then %><string>package_apple</string><% end %>


### PR DESCRIPTION
These commits update 'packaging' to accept either a string or an array for 'cows'
and 'final_mocks' in build_defaults.yaml. Prior to these commits, only a string was valid.
