### PR TITLE
(maint) Move dist and arch setting out of conditional

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -123,11 +123,10 @@ def set_cow_envs(cow)
   elements = cow.split('-')
   if elements.size != 3
     fail "Expecting a cow name split on hyphens, e.g. 'base-squeeze-i386'"
-  else
-    dist = elements[1]
-    arch = elements[2]
-    arch = arch.split('.')[0] if arch.include?('.')
   end
+  dist = elements[1]
+  arch = elements[2]
+  arch = arch.split('.')[0] if arch.include?('.')
   if Pkg::Config.build_pe
     ENV['PE_VER'] = Pkg::Config.pe_version
   end


### PR DESCRIPTION
Previously dist and arch were set inside of the else case of an if
block, which should mean that it vanishes once the block ends. Due to
either an oddity of ruby's scoping or some other bug, this has not yet
bitten us. This PR moves it out of the else block and simply ends
the conditional after the fail call, as that will exit the program
anyway.
This PR also removes a check that is unnecessary. There is previous code
which verifies that the split string has exactly 3 elements. There is no
case where any of those 3 elements could be nil when coming from a split
string. The empty string is possible, but nil is not.
