### PR TITLE
(RE-2195) Exclude pkg directory when globbing gem

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -6,6 +6,7 @@ if Pkg::Config.build_gem
     gem_excludes_file_list = []
     gem_excludes_raw = Pkg::Config.gem_excludes.nil? ? [] : Pkg::Config.gem_excludes.split(' ')
     gem_excludes_raw << 'ext/packaging'
+    gem_excludes_raw << 'pkg'
     gem_excludes_raw.each do |exclude|
       if File.directory?(exclude)
         gem_excludes_file_list += FileList["#{exclude}/**/*"]


### PR DESCRIPTION
Previously, the gem task would build the generic gem, and
then build platform specific gems. However, the second gem
would include the previously built gem.

This commit excludes the pkg directory when globbing gem files.
