### PR TITLE
(RE-2222) Push gems to internal server on release

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -103,7 +103,8 @@ module Pkg::Params
                   :version_file,
                   :version_strategy,
                   :yum_host,
-                  :yum_repo_path]
+                  :yum_repo_path,
+                  :internal_gem_host]
 
   # Environment variable overrides for Pkg::Config parameters
   #
@@ -149,7 +150,8 @@ module Pkg::Params
               {:var => :random_mockroot,   :val => true},
               {:var => :keychain_loaded,   :val => false},
               {:var => :build_date,        :val => Pkg::Util::Date.timestamp('-')},
-              {:var => :release,           :val => '1'}]
+              {:var => :release,           :val => '1'},
+              {:var => :internal_gem_host, :val => 'http://rubygems.delivery.puppetlabs.net/'}]
 
   # These are variables which, over time, we decided to rename or replace. For
   # backwards compatibility, we assign the value of the old/deprecated

--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -165,7 +165,17 @@ end
 
 def ship_gem(file)
   Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
-  %x{gem push #{file}}
+  ex("gem push #{file}")
+  begin
+    Pkg::Util::Tool.check_tool("stickler")
+    ex("stickler push #{file} --server=#{Pkg::Config.gemhost} 2>/dev/null")
+    puts "#{file} pushed to stickler server at #{Pkg::Config.internal_gem_host}"
+  rescue
+    puts "##########################################\n#"
+    puts "#  Stickler failed, ensure it's installed"
+    puts "#  and you have access to #{Pkg::Config.internal_gem_host} \n#"
+    puts "##########################################"
+  end
 end
 
 def ask_yes_or_no


### PR DESCRIPTION
This commit adjusts the ship_gem utility to include a try for pushing
the completed gem to the stickler host, currently rubygems.delivery.puppetlabs.net.
The host name can be overwritten using the environment variable GEM_HOST.
If it fails it puts an error for user to check if they can access the server and have stickler installed.
