### PR TITLE
(CPR-50) Change order of build-data

### DIFF
--- a/tasks/fetch.rake
+++ b/tasks/fetch.rake
@@ -34,7 +34,7 @@ namespace :pl do
         flag = "-k"
       end
     end
-    [project_data_url, team_data_url].each do |url|
+    [team_data_url, project_data_url].each do |url|
       begin
         tempdir = Pkg::Util::File.mktemp
         %x{curl --fail --silent #{flag} #{url}/#{Pkg::Config.builder_data_file} > #{tempdir}/#{Pkg::Config.builder_data_file}}


### PR DESCRIPTION
This commit goes in and changes the fetch.rake task to allow for project
data to overwrite team data. Before it would fetch the project data then
team data from the build-data repo, overwriting anything that is the
same in project. Since we currently do not have any intersections
between project and team datas this should not break anything.
