### PR TITLE
(CPR-59) Move git utilities into library

### DIFF
--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -13,6 +13,7 @@ module Pkg::Util
   require 'packaging/util/rake_utils'
   require 'packaging/util/jira'
   require 'packaging/util/execution'
+  require 'packaging/util/git'
 
   def self.boolean_value(var)
     return TRUE if var == TRUE || ( var.is_a?(String) && ( var.downcase == 'true' || var.downcase =~ /^y$|^yes$/))

--- a/lib/packaging/util/git.rb
+++ b/lib/packaging/util/git.rb
@@ -1,0 +1,38 @@
+# Utility methods for handling git
+require "fileutils"
+
+module Pkg::Util::Git
+  class << self
+    def git_commit_file(file, message = "changes")
+      fail unless Pkg::Util::Version.is_git_repo?
+      puts "Commiting changes:"
+      puts
+      diff = Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
+      puts diff
+      Pkg::Util::Execution.ex(%Q(#{Pkg::Util::Tool::GIT} commit #{file} -m "Commit #{message} in #{file}" &> #{Pkg::Util::OS::DEVNULL}))
+    end
+
+    def git_tag(version)
+      fail unless Pkg::Util::Version.is_git_repo?
+      Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} tag -s -u #{Pkg::Config.gpg_key} -m '#{version}' #{version}")
+    end
+
+    def git_bundle(treeish, appendix = rand_string, temp = Pkg::Util::File.mktemp)
+      fail unless Pkg::Util::Version.is_git_repo?
+      Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix} #{treeish} --tags")
+      Dir.chdir(temp) do
+        Pkg::Util::Execution.ex("#{Pkg::Util::Tool.find_tool('tar')} -czf #{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}.tar.gz #{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}")
+        FileUtils.rm_rf("#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}")
+      end
+      "#{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}.tar.gz"
+    end
+
+    def git_pull(remote, branch)
+      fail unless Pkg::Util::Version.is_git_repo?
+      Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} pull #{remote} #{branch}")
+    end
+
+  end
+end
+
+

--- a/spec/lib/packaging/util/git_spec.rb
+++ b/spec/lib/packaging/util/git_spec.rb
@@ -1,0 +1,96 @@
+# -*- ruby -*-
+require 'spec_helper'
+
+describe "Pkg::Util::Git" do
+  context "#git_commit_file" do
+    let(:file) {"thing.txt"}
+    let(:message) {"foo"}
+
+    it "should commit a file with no message, giving changes as the message instead" do
+      Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} commit #{file} -m \"Commit changes in #{file}\" &> /dev/null")
+      Pkg::Util::Git.git_commit_file(file)
+    end
+
+    it "should commit a file with foo as message" do
+      Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} commit #{file} -m \"Commit #{message} in #{file}\" &> /dev/null")
+      Pkg::Util::Git.git_commit_file(file, message)
+    end
+  end
+
+  context "#git_tag" do
+    let(:version) { "1.2.3" }
+    let(:gpg_key) {"1231242354asdfawd"}
+    around do |example|
+      prev_gpg_key = Pkg::Config.gpg_key
+      Pkg::Config.gpg_key = gpg_key
+      example.run
+      Pkg::Config.gpg_key = prev_gpg_key
+    end
+
+    it "should not fail" do
+      Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} tag -s -u #{gpg_key} -m '#{version}' #{version}")
+      Pkg::Util::Git.should_not raise_error
+      Pkg::Util::Git.git_tag(version)
+    end
+  end
+
+  context "#git_bundle" do
+    let(:treeish) { "foo" }
+    let(:appendix) { "append" }
+    let(:output_dir) { "/path/to/place" }
+    let(:version) {"1.2.3"}
+    let(:project) {"fooproj"}
+    let(:string) {"bar"}
+    let(:temp) {"/other/path/to/place" }
+    around do |example|
+      prev_project = Pkg::Config.project
+      prev_version = Pkg::Config.version
+      Pkg::Config.project = project
+      Pkg::Config.version = version
+      example.run
+      Pkg::Config.project = prev_project
+      Pkg::Config.version = prev_version
+    end
+
+    it "should create a git bundle with random appendix and random output directory" do
+      Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
+      Pkg::Util::File.should_receive(:mktemp).and_return(temp)
+      Pkg::Util::Git.should_receive(:rand_string).and_return(string)
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{project}-#{version}-#{string} #{treeish} --tags")
+      Dir.should_receive(:chdir).with(temp)
+      Pkg::Util::Git.git_bundle(treeish)
+    end
+
+    it "should create a git bundle with random output directory" do
+      Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
+      Pkg::Util::File.should_receive(:mktemp).and_return(temp)
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{project}-#{version}-#{appendix} #{treeish} --tags")
+      Dir.should_receive(:chdir).with(temp)
+      Pkg::Util::Git.git_bundle(treeish, appendix)
+    end
+
+    it "should create a git bundle" do
+      Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} bundle create #{output_dir}/#{project}-#{version}-#{appendix} #{treeish} --tags")
+      Dir.should_receive(:chdir).with(output_dir)
+      Pkg::Util::Git.git_bundle(treeish, appendix, output_dir)
+    end
+  end
+
+  context "#git_pull" do
+    let(:remote) {"rand.url"}
+    let(:branch) {"foo"}
+
+    it "should pull the branch" do
+      Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
+      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} pull #{remote} #{branch}")
+      Pkg::Util::Git.git_pull(remote, branch)
+    end
+  end
+end
+

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -145,7 +145,7 @@ namespace :pl do
       #
       # Create the data files to send to jenkins
       properties = Pkg::Config.config_to_yaml
-      bundle = git_bundle('HEAD')
+      bundle = Pkg::Util::Git.git_bundle('HEAD')
 
       # Construct the parameters, which is an array of hashes we turn into JSON
       parameters = [{ "name" => "BUILD_PROPERTIES", "file"  => "file0" },

--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -66,7 +66,7 @@ namespace :pl do
       name = args.name
 
       properties = Pkg::Config.config_to_yaml
-      bundle = git_bundle('HEAD')
+      bundle = Pkg::Util::Git.git_bundle('HEAD')
 
       # Create a string of metrics to send to Jenkins for data analysis
       if Pkg::Config.pe_version

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -139,7 +139,7 @@ namespace :pl do
       # use the packaging repo for shipping and signing (things that really
       # don't require build automation, specifically) we still need the project
       # clone itself.
-      git_bundle('HEAD', 'signing_bundle', 'pkg')
+      Pkg::Util::Git.git_bundle('HEAD', 'signing_bundle', 'pkg')
 
       # While we're bundling things, let's also make a git bundle of the
       # packaging repo that we're using when we invoke pl:jenkins:ship. We can
@@ -158,7 +158,7 @@ namespace :pl do
       if defined?(PACKAGING_ROOT)
         packaging_bundle = ''
         cd PACKAGING_ROOT do
-          packaging_bundle = git_bundle('HEAD', 'packaging-bundle')
+          packaging_bundle = Pkg::Util::Git.git_bundle('HEAD', 'packaging-bundle')
         end
         mv(packaging_bundle, 'pkg')
       end

--- a/tasks/tag.rake
+++ b/tasks/tag.rake
@@ -2,7 +2,7 @@ namespace 'pl' do
   desc "Tag this repository, requires a TAG, e.g. TAG=1.1.1"
   task "tag" do
     check_var('TAG', ENV['TAG'])
-    git_tag(ENV['TAG'])
+    Pkg::Util::Git.git_tag(ENV['TAG'])
   end
 end
 

--- a/tasks/update.rake
+++ b/tasks/update.rake
@@ -8,7 +8,7 @@ namespace :package do
         STDERR.puts "Couldn't parse the packaging repo URL from 'ext/build_defaults.yaml'."
         STDERR.puts "Normally this is a string in the format git@github.com:<User>/<packaging_repo> --branch=<branch>"
       else
-        git_pull(remote, branch)
+        Pkg::Util::Git.git_pull(remote, branch)
       end
     end
   end

--- a/tasks/version.rake
+++ b/tasks/version.rake
@@ -16,7 +16,7 @@ namespace :package do
   task :versionset do
     check_var('VERSION', ENV['VERSION'])
     Pkg::Util::Version.versionbump
-    git_commit_file(Pkg::Config.version_file, "update to #{ENV['VERSION']}")
+    Pkg::Util::Git.git_commit_file(Pkg::Config.version_file, "update to #{ENV['VERSION']}")
   end
 
   task :versionbump, :workdir do |t, args|


### PR DESCRIPTION
This commit goes through and takes all of the git based utilities in
00_utils.rake and moves them to their own ruby file in packaging. It
also goes through and finds every use of the old version and replaces it
with the new one. Finally it deprecates the old one so as to show a
warning message in the event the old one is still used. However it won't
break, just warn.
