### PR TITLE
(maint) Use Kernel.system for remote_ssh_cmd instead of ex

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -32,7 +32,8 @@ module Pkg::Util::Net
     def remote_ssh_cmd(target, command)
       Pkg::Util::Tool.check_tool('ssh')
       puts "Executing '#{command}' on #{target}"
-      ex(%Q[ssh -t #{target} '#{command.gsub("'", "'\\\\''")}'])
+      Kernel.system("ssh -t #{target} '#{command.gsub("'", "'\\\\''")}'")
+      $?.success? or raise "Remote ssh command failed."
     end
 
   end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -57,13 +57,18 @@ describe "Pkg::Util::Net" do
     end
 
     it "should execute a command :foo on a host :bar" do
-      Pkg::Util::Net.should_receive(:ex).with("ssh -t foo 'bar'")
+      Kernel.should_receive(:system).with("ssh -t foo 'bar'")
       Pkg::Util::Net.remote_ssh_cmd("foo", "bar")
     end
 
     it "should escape single quotes in the command" do
-      Pkg::Util::Net.should_receive(:ex).with("ssh -t foo 'b'\\''ar'")
+      Kernel.should_receive(:system).with("ssh -t foo 'b'\\''ar'")
       Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar")
+    end
+
+    it "should raise an error if ssh fails" do
+      Kernel.should_receive(:system).with("ssh -t foo 'bar'").and_raise(RuntimeError)
+      expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError)
     end
   end
 end


### PR DESCRIPTION
Because ex saves all output to a variable, commands that depend on user
input, such as pinentry/gpg-agent will not work as the screen will never
be rendered because the command hasn't completed yet. This commit
updates that call to use Kernel.system instead, which only returns true
or false and doesn't capture the output of the call. The current
implementation caused ships/signs to hang indefinitely during the
keychain passphrase section.
