### PR TITLE
(CPR-58) Move jenkins utilities into library

### DIFF
--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -14,6 +14,7 @@ module Pkg::Util
   require 'packaging/util/jira'
   require 'packaging/util/execution'
   require 'packaging/util/git'
+  require 'packaging/util/jenkins'
 
   def self.boolean_value(var)
     return TRUE if var == TRUE || ( var.is_a?(String) && ( var.downcase == 'true' || var.downcase =~ /^y$|^yes$/))

--- a/lib/packaging/util/jenkins.rb
+++ b/lib/packaging/util/jenkins.rb
@@ -1,0 +1,27 @@
+# Utility methods for handling Jenkins
+
+module Pkg::Util::Jenkins
+
+  class << self
+
+    # Use the curl to create a jenkins job from a valid XML
+    # configuration file.
+    # Returns the URL to the job
+    def create_jenkins_job(name, xml_file)
+      create_url = "http://#{Pkg::Config.jenkins_build_host}/createItem?name=#{name}"
+      form_args = ["-H", '"Content-Type: application/xml"', "--data-binary", "@#{xml_file}"]
+      Pkg::Util::Net.curl_form_data(create_url, form_args)
+      "http://#{Pkg::Config.jenkins_build_host}/job/#{name}"
+    end
+
+    # Use the curl to check of a named job is defined on the jenkins server.  We
+    # curl the config file rather than just checking if the job exists by curling
+    # the job url and passing --head because jenkins will mistakenly return 200 OK
+    # if you issue multiple very fast requests just requesting the header.
+    def jenkins_job_exists?(name)
+      job_url = "http://#{Pkg::Config.jenkins_build_host}/job/#{name}/config.xml"
+      form_args = ["--silent", "--fail"]
+      Pkg::Util::Net.curl_form_data(job_url, form_args, :quiet => true)
+    end
+  end
+end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -48,5 +48,52 @@ module Pkg::Util::Net
       flags = "-rHlv -O --no-perms --no-owner --no-group"
       Pkg::Util::Execution.ex("#{rsync} #{flags} #{target}:#{source} #{dest}")
     end
+
+    # This is fairly absurd. We're implementing curl by shelling out. What do I
+    # wish we were doing? Using a sweet ruby wrapper around curl, such as Curb or
+    # Curb-fu. However, because we're using clean build systems and trying to
+    # make this portable with minimal system requirements, we can't very well
+    # depend on libraries that aren't in the ruby standard libaries. We could
+    # also do this using Net::HTTP but that set of libraries is a rabbit hole to
+    # go down when what we're trying to accomplish is posting multi-part form
+    # data that includes file uploads to jenkins. It gets hairy fairly quickly,
+    # but, as they say, pull requests accepted.
+    #
+    # This method takes three arguments
+    # 1) String - the URL to post to
+    # 2) Array  - Ordered array of name=VALUE curl form parameters
+    # 3) Hash - Options to be set
+    def curl_form_data(uri, form_data = [], options = {})
+      curl = Pkg::Util::Tool.check_tool("curl")
+      #
+      # Begin constructing the post string.
+      # First, assemble the form_data arguments
+      #
+      post_string = "-i "
+      form_data.each do |param|
+        post_string << "#{param} "
+      end
+
+      # Add the uri
+      post_string << "#{uri}"
+
+      # If this is quiet, we're going to silence all output
+      if options[:quiet]
+        post_string << " >#{Pkg::Util::OS::DEVNULL} 2>&1"
+      end
+      begin
+        Pkg::Util::Execution.ex("#{curl} #{post_string}")
+      rescue RuntimeError
+        return false
+      end
+    end
+
+    # Use the provided URL string to print important information with
+    # ASCII emphasis
+    def print_url_info(url_string)
+      puts "\n////////////////////////////////////////////////////////////////////////////////\n\n
+  Build submitted. To view your build progress, go to\n#{url_string}\n\n
+////////////////////////////////////////////////////////////////////////////////\n\n"
+    end
   end
 end

--- a/spec/lib/packaging/util/jenkins_spec.rb
+++ b/spec/lib/packaging/util/jenkins_spec.rb
@@ -1,0 +1,40 @@
+# -*- ruby -*-
+require 'spec_helper'
+
+describe "Pkg::Util::Jenkins" do
+  let(:build_host) {"Jenkins-foo"}
+  let(:name) {"job-foo"}
+  around do |example|
+    old_build_host = Pkg::Config.jenkins_build_host
+    Pkg::Config.jenkins_build_host = build_host
+    example.run
+    Pkg::Config.jenkins_build_host = old_build_host
+  end
+
+  describe "#create_jenkins_job" do
+    let(:xml_file) {"bar.xml"}
+
+    it "should call curl_form_data with the correct arguments" do
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/createItem?name=#{name}", ["-H", '"Content-Type: application/xml"', "--data-binary", "@#{xml_file}"])
+      Pkg::Util::Jenkins.create_jenkins_job(name, xml_file)
+    end
+  end
+
+  describe "#jenkins_job_exists?" do
+
+    it "should call curl_form_data with correct arguments" do
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true)
+      Pkg::Util::Jenkins.jenkins_job_exists?(name)
+    end
+
+    it "should return false on job not existing" do
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(false)
+      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
+    end
+
+    it "should return true when job exists" do
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(true)
+      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_true
+    end
+  end
+end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -113,4 +113,45 @@ describe "Pkg::Util::Net" do
       Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
     end
   end
+
+  describe "#curl_form_data" do
+    let(:curl) {"/bin/curl"}
+    let(:form_data) {["name=FOO"]}
+    let(:options) { {:quiet => true} }
+
+    it "should return false on failure" do
+      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
+      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{target_uri}").and_return(false)
+      Pkg::Util::Net.curl_form_data(target_uri).should be_false
+    end
+
+
+    it "should curl with just the uri" do
+      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
+      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{target_uri}")
+      Pkg::Util::Net.curl_form_data(target_uri)
+    end
+
+    it "should curl with the form data and uri" do
+      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
+      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{form_data[0]} #{target_uri}")
+      Pkg::Util::Net.curl_form_data(target_uri, form_data)
+    end
+
+    it "should curl with form data, uri, and be quiet" do
+      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
+      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{form_data[0]} #{target_uri} >/dev/null 2>&1")
+      Pkg::Util::Net.curl_form_data(target_uri, form_data, options)
+    end
+
+  end
+
+  describe "#print_url_info" do
+    it "should output correct formatting" do
+      Pkg::Util::Net.should_receive(:puts).with("\n////////////////////////////////////////////////////////////////////////////////\n\n
+  Build submitted. To view your build progress, go to\n#{target_uri}\n\n
+////////////////////////////////////////////////////////////////////////////////\n\n")
+      Pkg::Util::Net.print_url_info(target_uri)
+    end
+  end
 end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -193,7 +193,7 @@ namespace :pl do
       # Call out to the curl_form_data utility method in 00_utils.rake
       #
       begin
-        if curl_form_data(trigger_url, args)
+        if Pkg::Util::Net.curl_form_data(trigger_url, args)
           puts "Build submitted. To view your build results, go to #{job_url}"
           puts "Your packages will be available at #{Pkg::Config.distribution_server}:#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
         else
@@ -349,7 +349,7 @@ namespace :pl do
       "-FSubmit=Build"
       ]
 
-      if curl_form_data(uri, args)
+      if Pkg::Util::Net.curl_form_data(uri, args)
         puts "Job triggered at #{uri}."
       else
         fail "An error occurred attempting to trigger the job at #{uri}. Please see the preceding http response for more info."

--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -38,16 +38,16 @@ namespace :pl do
         Pkg::Util::File.erb_file(erb_template, xml_file, nil, :binding => Pkg::Config.get_binding)
         job_name  = "#{Pkg::Config.project}-#{t.gsub('.xml.erb', '')}-#{Pkg::Config.build_date}-#{Pkg::Config.ref}"
         puts "Checking for existence of #{job_name}..."
-        if jenkins_job_exists?(job_name)
+        if Pkg::Util::Jenkins.jenkins_job_exists?(job_name)
           raise "Job #{job_name} already exists on #{Pkg::Config.jenkins_build_host}"
         else
           retry_on_fail(:times => 3) do
-            url = create_jenkins_job(job_name, xml_file)
+            url = Pkg::Util::Jenkins.create_jenkins_job(job_name, xml_file)
             if t == "packaging.xml.erb"
               ENV["PACKAGE_BUILD_URL"] = url
             end
             puts "Verifying job created successfully..."
-            unless jenkins_job_exists?(job_name)
+            unless Pkg::Util::Jenkins.jenkins_job_exists?(job_name)
               raise "Unable to verify Jenkins job, trying again..."
             end
             puts "Jenkins job created at #{url}"
@@ -98,8 +98,8 @@ namespace :pl do
       # Contstruct the job url
       trigger_url = "#{Pkg::Config.jenkins_build_host}/job/#{name}/build"
 
-      if curl_form_data(trigger_url, curl_args)
-        print_url_info("http://#{Pkg::Config.jenkins_build_host}/job/#{name}")
+      if Pkg::Util::Net.curl_form_data(trigger_url, curl_args)
+        Pkg::Util::Net.print_url_info("http://#{Pkg::Config.jenkins_build_host}/job/#{name}")
         puts "Your packages will be available at #{Pkg::Config.distribution_server}:#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       else
         fail "An error occurred submitting the job to jenkins. Take a look at the preceding http response for more info."


### PR DESCRIPTION
This commit goes through and takes all the jenkins based utilities in
00_utils.rake and mvoes them to jenkins.rb or net.rb as appropriate. It
deprecates old functions.
