### PR TITLE
(maint) Allow for multidimensional hashes in yaml configs

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -29,9 +29,17 @@ module Pkg
       #   value for each Config param to the corresponding hash key,value.
       #
       def config_from_hash(data = {})
+        build_type="pl"
+        if @build_pe
+          build_type="pe"
+        end
         data.each do |param, value|
           if Pkg::Params::BUILD_PARAMS.include?(param.to_sym)
             self.instance_variable_set("@#{param}", value)
+          elsif value.is_a?(Hash)
+            if param == build_type
+              config_from_hash(value)
+            end
           else
             warn "Warning - No build data parameter found for '#{param}'. Perhaps you have an erroneous entry in your yaml file?"
           end


### PR DESCRIPTION
This allows us to use multidimensional hashes in the yaml configs.

This will allow us to have conditional configuration based on the
build type (pe or FOSS), like mock and cow information. Currently
we have a flat data structure, config variables are set unconditionally,
if they exist, based on the load order of the configuration files - last
to load wins.

This pr sets a flag based on the build type and allows us to specify
different configuration sets based on that distinction, "pe" vs "pl".
