### PR TITLE
(maint) Update hash syntax in uber_build polling for ruby 1.9/1.8

### DIFF
--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -15,7 +15,7 @@ namespace :pl do
   namespace :jenkins do
     desc "Dynamic Jenkins UBER build: Build all the things with ONE job"
     task :uber_build, [:poll_interval] => "pl:fetch" do |t, args|
-      args.with_defaults(poll_interval: 0)
+      args.with_defaults(:poll_interval => 0)
       poll_interval = args.poll_interval.to_i
 
       # If we have a dirty source, bail, because changes won't get reflected in


### PR DESCRIPTION
As we still support older rubies in our tools, we cannot yet move to the
more modern hash syntax. This commit updates the uber_build polling
argument setting to use the hash rocket instead of the newer syntax.
