### PR TITLE
(maint) Change master ticket type to release

### DIFF
--- a/lib/packaging/util/jira.rb
+++ b/lib/packaging/util/jira.rb
@@ -27,7 +27,7 @@ module Pkg::Util
           'summary'     => summary,
           'description' => description,
           'project'     => { 'key' => project },
-          'issuetype'   => { 'name' => parent ? "Sub-task" : "Task" },
+          'issuetype'   => { 'name' => parent ? "Sub-task" : "Release" },
           'assignee'    => { 'name' => assignee },
       }
       if parent

--- a/spec/lib/packaging/util/jira_spec.rb
+++ b/spec/lib/packaging/util/jira_spec.rb
@@ -28,7 +28,7 @@ describe Pkg::Util::Jira do
     expect(fields['summary']).to eq("summary")
     expect(fields['description']).to eq("desc")
     expect(fields['project']['key']).to eq("PUP")
-    expect(fields['issuetype']['name']).to eq("Task")
+    expect(fields['issuetype']['name']).to eq("Release")
     expect(fields['assignee']['name']).to eq("ivy")
     expect(fields['parent']).to eq(nil)
   end


### PR DESCRIPTION
Background from Kenn Hussey's email "Jira update for September 2014":

"A new ‘Release’ issue type has been created introduced, also for
Engineering projects, to serve as “master tickets” for releases.
These tickets will be referenced on release pages in Confluence going forward."

So this ticket updates the ticket type for release tickets
generated from this rake task.
