### PR TITLE
(CPR-83) Extend rsync_from to include extra flags

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -45,9 +45,12 @@ module Pkg::Util::Net
       Pkg::Util::Execution.ex("#{rsync} #{flags} #{source} #{target}:#{dest}")
     end
 
-    def rsync_from(source, target, dest)
+    def rsync_from(source, target, dest, extra_flags = [])
       rsync = Pkg::Util::Tool.check_tool('rsync')
       flags = "-rHlv -O --no-perms --no-owner --no-group"
+      unless extra_flags.empty?
+        flags << " " << extra_flags.join(" ")
+      end
       Pkg::Util::Execution.ex("#{rsync} #{flags} #{target}:#{source} #{dest}")
     end
 

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -118,6 +118,12 @@ describe "Pkg::Util::Net" do
       Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group foo@bar:thing /home/foo")
       Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
     end
+
+    it "rsyncs 'thing' from 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
+      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
+      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group --foo-bar --and-another-flag foo@bar:thing /home/foo")
+      Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo", ["--foo-bar", "--and-another-flag"])
+    end
   end
 
   describe "#curl_form_data" do


### PR DESCRIPTION
In a previous commit, the rsync_to method was updated to include
arbitrary extra flags to facilitate overriding the default extra_flags
of --ignore-existing. This commit applies the same change to the
rsync_from method, except there is no default set of extra flags.
