### PR TITLE
(RE-3358) Move versionbump from Pkg::Tar to Pkg:Util:File.

### DIFF
--- a/lib/packaging/tar.rb
+++ b/lib/packaging/tar.rb
@@ -145,7 +145,6 @@ module Pkg
       mkpath workdir
       self.install_files_to workdir
       self.template(workdir)
-      Pkg::Util::Version.versionbump(workdir) if Pkg::Config.update_version_file
       self.tar(@target, workdir)
       self.clean_up workdir
     end

--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -101,6 +101,7 @@ module Pkg::Util::File
           end
         end
       end
+      Pkg::Util::Version.versionbump(workdir) if Pkg::Config.update_version_file
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, versionbump was occurring in Pkg::Tar, but not
Pkg::Util::File. This resulted in missing versionbumps for some artifacts,
such as gems. This commit moves the versionbump to Pkg:Util:File, where
it will versionbump the appropriate artifacts.
