### PR TITLE
(maint) use matching for cows dist and arch instead of splitting based on dashes

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -84,15 +84,13 @@ def gpg_sign_file(file)
   end
 end
 
-
 def set_cow_envs(cow)
-  elements = cow.split('-')
-  if elements.size != 3
-    fail "Expecting a cow name split on hyphens, e.g. 'base-squeeze-i386'"
+  elements = /base-(.*)-(.*).cow/.match(cow)
+  if elements.nil?
+    fail "Didn't get a matching cow, e.g. 'base-squeeze-i386'"
   end
   dist = elements[1]
   arch = elements[2]
-  arch = arch.split('.')[0] if arch.include?('.')
   if Pkg::Config.build_pe
     ENV['PE_VER'] = Pkg::Config.pe_version
   end

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -68,7 +68,7 @@ task :build_deb, :deb_command, :cow do |t, args|
     cow       = args.cow
     work_dir  = Pkg::Util::File.mktemp
     subdir    = 'pe/' if Pkg::Config.build_pe
-    dest_dir  = "#{Pkg::Config.project_root}/pkg/#{subdir}deb/#{cow.split('-')[1] unless cow.nil?}"
+    dest_dir  = "#{Pkg::Config.project_root}/pkg/#{subdir}deb/#{/base-(.*)-(.*).cow/.match(cow)[1] unless cow.nil?}"
     Pkg::Util::Tool.check_tool(deb_build)
     mkdir_p dest_dir
     deb_args  = { :work_dir => work_dir, :cow => cow }


### PR DESCRIPTION
This commit changes the way we set the DIST and ARCH environment based on the cow name.  Instead of splitting based on "-", we use matching for the DIST and ARCH.  This allows us to have cows with a dash in the DIST name ( such as CumulusLinux-2.2 ).
