### PR TITLE
escape the '.' in the cow match regex

### DIFF
--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -85,7 +85,7 @@ def gpg_sign_file(file)
 end
 
 def set_cow_envs(cow)
-  elements = /base-(.*)-(.*).cow/.match(cow)
+  elements = /base-(.*)-(.*)\.cow/.match(cow)
   if elements.nil?
     fail "Didn't get a matching cow, e.g. 'base-squeeze-i386'"
   end

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -68,7 +68,7 @@ task :build_deb, :deb_command, :cow do |t, args|
     cow       = args.cow
     work_dir  = Pkg::Util::File.mktemp
     subdir    = 'pe/' if Pkg::Config.build_pe
-    dest_dir  = "#{Pkg::Config.project_root}/pkg/#{subdir}deb/#{/base-(.*)-(.*).cow/.match(cow)[1] unless cow.nil?}"
+    dest_dir  = "#{Pkg::Config.project_root}/pkg/#{subdir}deb/#{/base-(.*)-(.*)\.cow/.match(cow)[1] unless cow.nil?}"
     Pkg::Util::Tool.check_tool(deb_build)
     mkdir_p dest_dir
     deb_args  = { :work_dir => work_dir, :cow => cow }


### PR DESCRIPTION
This PR provides a fixup to the cow match regex.  We should escape the "." just in case we ever have an arch with "cow" in the name.
