### PR TITLE
(maint) Remove space before arg parens warnings

### DIFF
--- a/tasks/tickets.rake
+++ b/tasks/tickets.rake
@@ -33,10 +33,10 @@ def get_vars
 end
 
 def validate_vars(jira, vars)
-  jira.project? (vars[:project])
-  jira.user? (vars[:builder])
-  jira.user? (vars[:writer])
-  jira.user? (vars[:developer])
+  jira.project? vars[:project]
+  jira.user? vars[:builder]
+  jira.user? vars[:writer]
+  jira.user? vars[:developer]
 end
 
 def create_tickets(jira, vars)


### PR DESCRIPTION
This removes the warnings we get thrown due to space before arg parens:

tasks/tickets.rake:36: warning: don't put space before argument parentheses
tasks/tickets.rake:37: warning: don't put space before argument parentheses
tasks/tickets.rake:38: warning: don't put space before argument parentheses
tasks/tickets.rake:39: warning: don't put space before argument parentheses

Signed-off-by: Ken Barber ken@bob.sh
