### PR TITLE
(maint) use matching for cows instead of splitting based on dashes

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -86,7 +86,7 @@ if Pkg::Config.build_pe
       puts "Shipping all built artifacts to to archive directories on #{Pkg::Config.apt_host}"
 
       Pkg::Config.cows.split(' ').map { |i| i.sub('.cow', '') }.each do |cow|
-        _base, dist, arch = cow.split('-')
+        dist, arch = /base-(.*)-(.*)\.cow/.match(cow).captures
         unless Pkg::Util::File.empty_dir? "pkg/pe/deb/#{dist}"
           archive_path = "#{base_path}/#{dist}-#{arch}"
 


### PR DESCRIPTION
This commit changes the way we extract the dist and arch based on the cow name when shipping artifacts to the archives directories. Instead of splitting based on "-", we use matching for the dist and arch. This allows us to have cows with a dash in the dist name ( such as CumulusLinux-2.2 ).
