### PR TITLE
Remove non-existent .cow suffix from the deb regex

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -85,8 +85,8 @@ if Pkg::Config.build_pe
 
       puts "Shipping all built artifacts to to archive directories on #{Pkg::Config.apt_host}"
 
-      Pkg::Config.cows.split(' ').map { |i| i.sub('.cow', '') }.each do |cow|
-        dist, arch = /base-(.*)-(.*)\.cow/.match(cow).captures
+      Pkg::Config.cows.split(' ').each do |cow|
+        dist, arch = /^base-(.*)-(.*)\.cow$/.match(cow).captures
         unless Pkg::Util::File.empty_dir? "pkg/pe/deb/#{dist}"
           archive_path = "#{base_path}/#{dist}-#{arch}"
 


### PR DESCRIPTION
The cow has already had the .cow chopped off by the time the match is
invoked, so the previous regex never matched. This commit updates the
regex to not include the .cow to address the problem.
