### PR TITLE
Use name as defined in ext/project_data.yaml rather than that provided b...

### DIFF
--- a/tasks/tickets.rake
+++ b/tasks/tickets.rake
@@ -357,8 +357,7 @@ DOC
   ]
 
   # Use the human-friendly project name in the summary
-  project_name = jira.project_name(vars[:project])
-  summary = "#{project_name} #{vars[:release]} #{vars[:date]} Release"
+  summary = "#{Pkg::Config.project} #{vars[:release]} #{vars[:date]} Release"
   description[:top_level_ticket] = <<-DOC
 #{summary}
 


### PR DESCRIPTION
...y JIRA

This variable is defined for all projects. This will not change much,
except for where we have multiple projects under one JIRA project.
MCollective plugins is the prime example here. We have multiple plugins,
all with different names, but work is tracked under a single JIRA
project (MCOP). Because of this, the mcollective plugins, regardless of
which plugin is going to be released, all are assigned the same release
ticket title. This way, we can ensure the ticket title will be more
project specific, regardless of JIRA project.

It will not be as nice, for instance, when doing a Razor release, we
currently have `Razor 0.16.0 2014-11-24 Release`, but this will change
to `razor-server 0.16.0 2014-11-24 Release`.
