### PR TITLE
(RE-3677) Add gemspec to packaging

### DIFF
--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -1,0 +1,21 @@
+Gem::Specification.new do |gem|
+  gem.name    = 'packaging'
+  gem.version = %x(git describe --tags).sub('-', '.').chomp
+  gem.date    = Date.today.to_s
+
+  gem.summary = "Puppet Labs' packaging automation"
+  gem.description = "Packaging automation written in Rake and Ruby. Easily build native packages for most platforms with a few data files and git."
+
+  gem.authors  = ['Puppet Labs']
+  gem.email    = 'info@puppetlabs.com'
+  gem.homepage = 'http://github.com/puppetlabs/packaging'
+
+  gem.add_development_dependency('rspec', ['~> 2.14.1'])
+  gem.add_development_dependency('rake', ['~> 0.9.6'])
+  gem.add_development_dependency('rubocop', ['~> 0.24.1'])
+  gem.require_path = 'lib'
+
+  # Ensure the gem is built out of versioned files
+  gem.files = Dir['{lib,spec,static_artifacts,tasks,templates}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")
+  gem.test_files = Dir['spec/**/*_spec.rb']
+end


### PR DESCRIPTION
In order to sanely reference packaging from other projects using bundler,
a gemspec is essential. It allows users to pin to a specific version or
range of versions, like ~> 0.1 instead of just the 0.1.0 tag. This will
also allow us to easily ship our packaging tools to rubygems if we want
to.
