### PR TITLE
(maint) Use gsub instead of sub in gemspec

### DIFF
--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name    = 'packaging'
-  gem.version = %x(git describe --tags).sub('-', '.').chomp
+  gem.version = %x(git describe --tags).gsub('-', '.').chomp
   gem.date    = Date.today.to_s
 
   gem.summary = "Puppet Labs' packaging automation"


### PR DESCRIPTION
sub only replaces the first instance of a match, but for git describe,
we need to replace all instances of - to get a valid gem version. This
commit makes that change.