### PR TITLE
Revert "(RE-3702) Ensure uber_build taks uses retry_on_fail where approp...

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -132,7 +132,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
       invoke_task("pl:fetch")
       repo_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{target}/deb"
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      retry_on_fail(:times => 3) do
         Pkg::Util::Net.rsync_to("pkg/#{target}/deb/", Pkg::Config.distribution_server, repo_dir)
       end
     end

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -12,7 +12,7 @@ module Pkg::Rpm::Repo
       invoke_task("pl:fetch")
       repo_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{target}/rpm"
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      retry_on_fail(:times => 3) do
         Pkg::Util::Net.rsync_to("pkg/#{target}/rpm/", Pkg::Config.distribution_server, repo_dir)
       end
     end

--- a/lib/packaging/util/execution.rb
+++ b/lib/packaging/util/execution.rb
@@ -29,29 +29,5 @@ module Pkg::Util::Execution
       ret
     end
 
-    # Loop a block up to the number of attempts given, exiting when we receive success
-    # or max attempts is reached. Raise an exception unless we've succeeded.
-    def retry_on_fail(args, &blk)
-      success = FALSE
-
-      if args[:times].respond_to?(:times) and block_given?
-        args[:times].times do |i|
-          if args[:delay]
-            sleep args[:delay]
-          end
-
-          begin
-            blk.call
-            success = TRUE
-            break
-          rescue
-            puts "An error was encountered evaluating block. Retrying.."
-          end
-        end
-      else
-        fail "retry_on_fail requires and arg (:times => x) where x is an Integer/Fixnum, and a block to execute"
-      end
-      fail "Block failed maximum of #{args[:times]} tries. Exiting.." unless success
-    end
   end
 end

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -111,7 +111,7 @@ describe "Pkg::Deb::Repo" do
       Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/deb").and_return(false)
       Pkg::Deb::Repo.should_receive(:invoke_task).with("pl:fetch")
       Pkg::Util::Net.should_receive(:remote_ssh_cmd).with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
-      Pkg::Util::Execution.should_receive(:retry_on_fail).with(:times => 3)
+      Pkg::Deb::Repo.should_receive(:retry_on_fail).with(:times => 3)
       Pkg::Deb::Repo.ship_repo_configs
     end
   end

--- a/spec/lib/packaging/rpm/repo_spec.rb
+++ b/spec/lib/packaging/rpm/repo_spec.rb
@@ -112,7 +112,7 @@ describe "Pkg::Rpm::Repo" do
       Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/rpm").and_return(false)
       Pkg::Rpm::Repo.should_receive(:invoke_task).with("pl:fetch")
       Pkg::Util::Net.should_receive(:remote_ssh_cmd).with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
-      Pkg::Util::Execution.should_receive(:retry_on_fail).with(:times => 3)
+      Pkg::Rpm::Repo.should_receive(:retry_on_fail).with(:times => 3)
       Pkg::Rpm::Repo.ship_repo_configs
     end
   end

--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -119,7 +119,7 @@ def ship_gem(file)
     puts "#  and you have access to #{Pkg::Config.internal_gem_host} \n#"
     puts "##########################################"
   end
-  Pkg::Util::Execution.retry_on_fail(:times => 3) do
+  retry_on_fail(:times => 3) do
     Pkg::Util::Net.rsync_to("#{file}*", Pkg::Config.gem_host, Pkg::Config.gem_path)
   end
 end
@@ -187,6 +187,26 @@ def update_rpm_repo(dir)
   end
 end
 alias :create_rpm_repo :update_rpm_repo
+
+# Loop a block up to the number of attempts given, exiting when we receive success
+# or max attempts is reached. Raise an exception unless we've succeeded.
+def retry_on_fail(args, &blk)
+  success = FALSE
+  if args[:times].respond_to?(:times) and block_given?
+    args[:times].times do |i|
+      begin
+        blk.call
+        success = TRUE
+        break
+      rescue
+        puts "An error was encountered evaluating block. Retrying.."
+      end
+    end
+  else
+    fail "retry_on_fail requires and arg (:times => x) where x is an Integer/Fixnum, and a block to execute"
+  end
+  fail "Block failed maximum of #{args[:times]} tries. Exiting.." unless success
+end
 
 def deprecate(old_cmd, new_cmd = nil)
   msg = "!! #{old_cmd} is deprecated."
@@ -301,11 +321,6 @@ end
 def print_url_info(url_string)
   deprecate("print_url_info", "Pkg::Util::Net.print_url_info")
   Pkg::Util::Net.print_url_info(url_string)
-end
-
-def retry_on_fail(args, &block)
-  deprecate("retry_on_fail", "Pkg::Util::Execution.retry_on_fail")
-  Pkg::Util::Execution.retry_on_fail(args, &block)
 end
 
 # ex combines the behavior of `%x{cmd}` and rake's `sh "cmd"`. `%x{cmd}` has

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -15,7 +15,7 @@ end
 def update_cow(cow)
   ENV['PATH'] = "/usr/sbin:#{ENV['PATH']}"
   set_cow_envs(cow)
-  Pkg::Util::Execution.retry_on_fail(:times => 3) do
+  retry_on_fail(:times => 3) do
     sh "sudo -E /usr/sbin/cowbuilder --update --override-config --configfile #{Pkg::Config.pbuild_conf} --basepath /var/cache/pbuilder/#{cow} --distribution #{ENV['DIST']} --architecture #{ENV['ARCH']}"
   end
 end

--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -54,7 +54,7 @@ namespace :pl do
         if Pkg::Util::Jenkins.jenkins_job_exists?(job_name)
           raise "Job #{job_name} already exists on #{Pkg::Config.jenkins_build_host}"
         else
-          Pkg::Util::Execution.retry_on_fail(:times => 3) do
+          retry_on_fail(:times => 3) do
             url = Pkg::Util::Jenkins.create_jenkins_job(job_name, xml_file)
             if t == "packaging.xml.erb"
               ENV["PACKAGE_BUILD_URL"] = url
@@ -77,10 +77,7 @@ namespace :pl do
         #
         name = "#{Pkg::Config.project}-packaging-#{Pkg::Config.build_date}-#{Pkg::Config.ref}"
         packaging_job_url = "http://#{Pkg::Config.jenkins_build_host}/job/#{name}"
-
-        Pkg::Util::Execution.retry_on_fail(:times => 10, :delay => 1) do
-          packaging_build_hash = Pkg::Util::Jenkins.poll_jenkins_job(packaging_job_url)
-        end
+        packaging_build_hash = Pkg::Util::Jenkins.poll_jenkins_job(packaging_job_url)
 
         ##
         # Output status of packaging build for cli consumption
@@ -97,10 +94,7 @@ namespace :pl do
           #
           name = "#{Pkg::Config.project}-msi-#{Pkg::Config.build_date}-#{Pkg::Config.short_ref}"
           msi_job_url = "http://#{Pkg::Config.jenkins_build_host}/job/#{name}"
-
-          Pkg::Util::Execution.retry_on_fail(:times => 10, :delay => 1) do
-            msi_build_hash = Pkg::Util::Jenkins.poll_jenkins_job(msi_job_url)
-          end
+          msi_build_hash = Pkg::Util::Jenkins.poll_jenkins_job(msi_job_url)
 
           ##
           # Output status of msi build for cli consumption
@@ -117,10 +111,7 @@ namespace :pl do
         #
         name = "#{Pkg::Config.project}-repo-#{Pkg::Config.build_date}-#{Pkg::Config.ref}"
         repo_job_url = "http://#{Pkg::Config.jenkins_build_host}/job/#{name}"
-
-        Pkg::Util::Execution.retry_on_fail(:times => 10, :delay => 1) do
-          repo_build_hash = Pkg::Util::Jenkins.poll_jenkins_job(repo_job_url)
-        end
+        repo_build_hash = Pkg::Util::Jenkins.poll_jenkins_job(repo_job_url)
 
         ##
         # Output status of repo build for cli consumption

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -35,7 +35,7 @@ namespace :pl do
 
     task :ship_nightly_repos => "pl:fetch" do
       target_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/nightly_repos"
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      retry_on_fail(:times => 3) do
         # Ship the now signed repos to the distribution server
         Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, "mkdir -p #{target_dir}")
         Pkg::Util::Net.rsync_to("nightly_repos/", Pkg::Config.distribution_server, target_dir)

--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -4,7 +4,7 @@ if Pkg::Config.build_pe
     task :ship_rpms => "pl:fetch" do
       Pkg::Util::File.empty_dir?("pkg/pe/rpm") and fail "The 'pkg/pe/rpm' directory has no packages. Did you run rake pe:deb?"
       target_path = ENV['YUM_REPO'] ? ENV['YUM_REPO'] : "#{Pkg::Config.yum_repo_path}/#{Pkg::Config.pe_version}/repos/"
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      retry_on_fail(:times => 3) do
         Pkg::Util::Net.rsync_to('pkg/pe/rpm/', Pkg::Config.yum_host, target_path)
       end
       if Pkg::Config.team == 'release'
@@ -50,7 +50,7 @@ if Pkg::Config.build_pe
         #                 |_wheezy/*.deb
         #
         puts "Shipping PE debs to apt repo 'incoming' dir on #{Pkg::Config.apt_host}"
-        Pkg::Util::Execution.retry_on_fail(:times => 3) do
+        retry_on_fail(:times => 3) do
           Dir["pkg/pe/deb/#{dist}/*.deb"].each do |deb|
             Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.apt_host, "mkdir -p '#{target_path}/#{dist}'")
             Pkg::Util::Net.rsync_to(deb, Pkg::Config.apt_host, "#{target_path}/#{dist}/#{File.basename(deb)}")

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -2,7 +2,7 @@ namespace :pl do
   desc "Ship mocked rpms to #{Pkg::Config.yum_host}"
   task :ship_rpms do
     ["el", "fedora"].each do |dist|
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      retry_on_fail(:times => 3) do
         pkgs = Dir["pkg/#{dist}/**/*.rpm"].map { |f| "'#{f.gsub("pkg/#{dist}/", "#{Pkg::Config.yum_repo_path}/#{dist}/")}'" }
         unless pkgs.empty?
           Pkg::Util::Net.rsync_to("pkg/#{dist}", Pkg::Config.yum_host, Pkg::Config.yum_repo_path)
@@ -38,7 +38,7 @@ namespace :pl do
 
   desc "Ship cow-built debs to #{Pkg::Config.apt_host}"
   task :ship_debs do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
+    retry_on_fail(:times => 3) do
       if File.directory?("pkg/deb")
         Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.apt_host, Pkg::Config.apt_repo_path)
       end
@@ -85,14 +85,14 @@ namespace :pl do
 
   desc "ship apple dmg to #{Pkg::Config.yum_host}"
   task :ship_dmg => 'pl:fetch' do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
+    retry_on_fail(:times => 3) do
       Pkg::Util::Net.rsync_to('pkg/apple/*.dmg', Pkg::Config.yum_host, Pkg::Config.dmg_path)
     end
   end if Pkg::Config.build_dmg
 
   desc "ship tarball and signature to #{Pkg::Config.tar_host}"
   task :ship_tar => 'pl:fetch' do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
+    retry_on_fail(:times => 3) do
       Pkg::Util::Net.rsync_to("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*", Pkg::Config.tar_host, Pkg::Config.tarball_path)
     end
   end
@@ -164,7 +164,7 @@ namespace :pl do
         mv(packaging_bundle, local_dir)
       end
 
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      retry_on_fail(:times => 3) do
         Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, "mkdir -p #{artifact_dir}")
         Pkg::Util::Net.rsync_to("#{local_dir}/", Pkg::Config.distribution_server, "#{artifact_dir}/", ["--ignore-existing", "--exclude repo_configs"])
       end

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -19,7 +19,7 @@ def sign_rpm(rpm, sign_flags = nil)
   end
 
   # Try this up to 5 times, to allow for incorrect passwords
-  Pkg::Util::Execution.retry_on_fail(:times => 5) do
+  retry_on_fail(:times => 5) do
     # This definition of %__gpg_sign_cmd is the default on modern rpm. We
     # accept extra flags to override certain signing behavior for older
     # versions of rpm, e.g. specifying V3 signatures instead of V4.


### PR DESCRIPTION
We're seeing uber_build fail in the following manner:

```
undefined local variable or method `packaging_build_hash' for main:Object
```

This reverts puppetlabs/packaging#366.