### PR TITLE
(maint) Ensure we fetch necessary vars for gem ship

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -68,7 +68,7 @@ namespace :pl do
   # We want to ship a gem only for projects that build gems
   if Pkg::Config.build_gem
     desc "Ship built gem to rubygems"
-    task :ship_gem do
+    task :ship_gem => 'pl:fetch' do
       # Even if a project builds a gem, if it uses the odd_even or zero-based
       # strategies, we only want to ship final gems because otherwise a
       # development gem would be preferred over the last final gem


### PR DESCRIPTION
Prior to this commit, we kept running into issues where centain
variables we not being populated. This was because we never invoke the
`pl:fetch` task, which looks for and sets all remote variables defined
in the build-data repo. New updates to the gem ship task requires this
information, whereas before we didn't. The gem ship will fail unless we
add this task requirement.