### PR TITLE
Generate MSI filename using `git describe`

### DIFF
--- a/templates/msi.xml.erb
+++ b/templates/msi.xml.erb
@@ -129,7 +129,7 @@ File.open(&quot;#{ENV[&apos;WORKSPACE&apos;]}/ondemand.yaml&quot;, &apos;w&apos;
       <command>call c:\puppetwinbuilder\setup_env.bat
 
 set PKG_NAME=<%= Pkg::Config.msi_name || 'puppet' %>
-set AGENT_VERSION_STRING=<%= Pkg::Config.version %>
+set AGENT_VERSION_STRING=<%= Pkg::Util::Version.git_describe_version %>
 set ARCH=%ARCH%
 set SUFFIX=-%ARCH%
 if &quot;%ARCH%&quot; == &quot;x86&quot; (


### PR DESCRIPTION
Previously,  MSIs were generated using `git describe` with the short sha removed, e.g. `3.7.4-1303`, which is not data that is currently passed through the AIO pipeline.

This commit changes the MSI to use the `git describe`, e.g. `3.7.4-1303-ge96f55b`. This  will simplify the process for installing MSIs during AIO acceptance testing.