### PR TITLE
Include short sha in puppet-agent MSI filename

### DIFF
--- a/templates/msi.xml.erb
+++ b/templates/msi.xml.erb
@@ -129,7 +129,7 @@ File.open(&quot;#{ENV[&apos;WORKSPACE&apos;]}/ondemand.yaml&quot;, &apos;w&apos;
       <command>call c:\puppetwinbuilder\setup_env.bat
 
 set PKG_NAME=<%= Pkg::Config.msi_name || 'puppet' %>
-set AGENT_VERSION_STRING=<%= Pkg::Config.version %>
+set AGENT_VERSION_STRING=<%= Pkg::Config.version %>-<%= Pkg::Config.short_ref %>
 set ARCH=%ARCH%
 set SUFFIX=-%ARCH%
 if &quot;%ARCH%&quot; == &quot;x86&quot; (


### PR DESCRIPTION
Previously, MSIs were generated using `git describe` with the short sha
removed, e.g. `3.7.4-1303`. This version identifier is not passed
through the AIO pipeline, and is not necessarily unique enough to
identify the puppet-agent package to be installed.

This commit changes the xml template for creating jenkins jobs so that
the resulting puppet-agent MSI contains the short sha, e.g.
`3.7.4-1303-ge96f55b`. This  will simplify the process for installing
MSIs during AIO acceptance testing.