### PR TITLE
(maint) Update sign_repos for deb to handle failure

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -143,20 +143,24 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
 
       dists = Pkg::Util::File.directories("#{target}/apt")
 
-      dists.each do |dist|
-        Dir.chdir("#{target}/apt/#{dist}") do
-          File.open("conf/distributions", "w") do |f|
-            f.puts "Origin: Puppet Labs
-Label: Puppet Labs
-Codename: #{dist}
-Architectures: i386 amd64
-Components: main
-Description: #{message} for #{dist}
-SignWith: #{Pkg::Config.gpg_key}"
-          end
+      if dists
+        dists.each do |dist|
+          Dir.chdir("#{target}/apt/#{dist}") do
+            File.open("conf/distributions", "w") do |f|
+              f.puts "Origin: Puppet Labs
+  Label: Puppet Labs
+  Codename: #{dist}
+  Architectures: i386 amd64
+  Components: main
+  Description: #{message} for #{dist}
+  SignWith: #{Pkg::Config.gpg_key}"
+            end
 
-          Pkg::Util::Execution.ex("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
+            Pkg::Util::Execution.ex("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
+          end
         end
+      else
+        STDERR.puts "No repos found to sign. Maybe you didn't build any debs, or the repo creation failed?"
       end
     end
   end


### PR DESCRIPTION
Previously, if there were no deb repos to sign, the nightly repo ship
would explode, because we try to call each on a possibly nil object.
This commit updates the method to helpfully let us know that there were
no deb repos to sign if dists is nil.