### PR TITLE
(RE-4008) Make repo tasks more fail friendly

### DIFF
--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -8,7 +8,11 @@ module Pkg::Rpm::Repo
     end
 
     def ship_repo_configs(target = "repo_configs")
-      Pkg::Util::File.empty_dir?("pkg/#{target}/rpm") and fail "No repo configs have been generated! Try pl:rpm_repo_configs."
+      if Pkg::Util::File.empty_dir?("pkg/#{target}/rpm")
+        warn "No repo configs have been generated! Try pl:rpm_repo_configs."
+        return
+      end
+
       invoke_task("pl:fetch")
       repo_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{target}/rpm"
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
@@ -79,7 +83,10 @@ module Pkg::Rpm::Repo
         end
       end
 
-      yum_repos.empty? and fail "No rpm repos were found to generate configs from!"
+      if yum_repos.empty?
+        warn "No rpm repos were found to generate configs from!"
+        return
+      end
 
       FileUtils.mkdir_p(File.join("pkg", target, "rpm"))
 

--- a/spec/lib/packaging/rpm/repo_spec.rb
+++ b/spec/lib/packaging/rpm/repo_spec.rb
@@ -40,10 +40,11 @@ describe "Pkg::Rpm::Repo" do
       expect {Pkg::Rpm::Repo.generate_repo_configs}.to raise_error(RuntimeError)
     end
 
-    it "fails if there are no rpm repos available for the build" do
+    it "warns if there are no rpm repos available for the build" do
       Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
       Pkg::Util::Execution.should_receive(:ex).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return("")
-      expect {Pkg::Rpm::Repo.generate_repo_configs}.to raise_error(RuntimeError, /No rpm repos/)
+      Pkg::Rpm::Repo.should_receive(:warn).with("No rpm repos were found to generate configs from!")
+      Pkg::Rpm::Repo.generate_repo_configs
     end
 
     it "writes the expected repo configs to disk" do
@@ -98,9 +99,10 @@ describe "Pkg::Rpm::Repo" do
   end
 
   describe "#ship_repo_configs" do
-    it "fails if there are no repo configs to ship" do
+    it "warn if there are no repo configs to ship" do
       Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/rpm").and_return(true)
-      expect { Pkg::Rpm::Repo.ship_repo_configs }.to raise_error(RuntimeError, /No repo configs have been generated!/)
+      Pkg::Rpm::Repo.should_receive(:warn).with("No repo configs have been generated! Try pl:rpm_repo_configs.")
+      Pkg::Rpm::Repo.ship_repo_configs
     end
 
     it "ships repo configs to the build server" do


### PR DESCRIPTION
Previously, if rpms and debs hadn't both been built, various repo
related methods would explode in failure when trying to wget, retreive
or ship repo/repo configs. This breaks a lot of automation when
developing a new project when only one platform may be being built. This
commit rectifies this by warning and returning early from these methods
instead of failing completely.