### PR TITLE
(RE-4008) Update conditional to also check for non-existence

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -129,7 +129,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
     end
 
     def ship_repo_configs(target = "repo_configs")
-      if Pkg::Util::File.empty_dir?("pkg/#{target}/deb")
+      if (!File.exist?("pkg/#{target}/deb")) || Pkg::Util::File.empty_dir?("pkg/#{target}/deb")
         warn "No repo configs have been generated! Try pl:deb_repo_configs."
         return
       end

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -99,12 +99,14 @@ describe "Pkg::Deb::Repo" do
 
   describe "#ship_repo_configs" do
     it "warns if there are no repo configs to ship" do
+      File.should_receive(:exist?).with("pkg/repo_configs/deb").and_return(true)
       Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/deb").and_return(true)
       Pkg::Deb::Repo.should_receive(:warn).with("No repo configs have been generated! Try pl:deb_repo_configs.")
       Pkg::Deb::Repo.ship_repo_configs
     end
 
     it "ships repo configs to the build server" do
+      File.should_receive(:exist?).with("pkg/repo_configs/deb").and_return(true)
       Pkg::Config.jenkins_repo_path = "/a/b/c/d"
       Pkg::Config.distribution_server = "a.host.that.wont.exist"
       repo_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/repo_configs/deb"


### PR DESCRIPTION
Previously if the directory did not exist, it could not be considered
empty. That is fine for the implementation of empty_dir?, but isn't good
for the ship_repo_configs method. This commit updates the bailout
section to also return early if the directory does not exist at all.