### PR TITLE
(RE-4008) Remove whitespace from deb repo heredoc

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -153,12 +153,12 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; '
           Dir.chdir("#{target}/apt/#{dist}") do
             File.open("conf/distributions", "w") do |f|
               f.puts "Origin: Puppet Labs
-  Label: Puppet Labs
-  Codename: #{dist}
-  Architectures: i386 amd64
-  Components: main
-  Description: #{message} for #{dist}
-  SignWith: #{Pkg::Config.gpg_key}"
+Label: Puppet Labs
+Codename: #{dist}
+Architectures: i386 amd64
+Components: main
+Description: #{message} for #{dist}
+SignWith: #{Pkg::Config.gpg_key}"
             end
 
             Pkg::Util::Execution.ex("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")


### PR DESCRIPTION
In a previous commit, some additional whitespace was added to the deb
repo heredoc, which totally prevents reprepro from parsing it. This
commit removes that whitespace.