### PR TITLE
(maint) On ship don't set symlinks immutable

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -170,7 +170,7 @@ namespace :pl do
       end
 
       # If we just shipped a tagged version, we want to make it immutable
-      files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) }.map do |file|
+      files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) && !File.symlink?(f) }.map do |file|
         "#{artifact_dir}/#{file.sub(/^#{local_dir}\//, '')}"
       end
       remote_set_immutable(Pkg::Config.distribution_server, files)


### PR DESCRIPTION
 - Windows packages are being built in the AIO pipeline for installation
   during acceptance runs.  However, the pipeline was passing SHA and
   ARCH, but not the `git describe` used to tag the file version.

   Other platforms use repo configs and are unaffected by this, but
   to be able to find the packages by convention, it was decided that
   symlinks should be used so that an MSI could always be found at

   `puppet-agent/<SHA>/artifacts/windows/puppet-agent-<ARCH>.msi`

   This symlink is generated at build time and points to a file that
   contains the complete version string generated from `git describe`.

   However, this generated a new problem with the :ship rake task,
   since it is now trying to `chattr +i` on symlinks.  The error that
   occurs is:

   `chattr: Operation not supported while reading flags on <PATH>`

   To fix this, filter the file set passed to remote_set_immutable to
   exclude symlinks.

   More details on the addition of symlinks can be found in:
   https://github.com/puppetlabs/puppet/commit/0976d62