### PR TITLE
(RE-3836) Move rpm and deb _build_targets methods to Pkg::Config

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -273,6 +273,42 @@ module Pkg
           end
         end
       end
+
+
+      # This method is duplicated from enterprise-dist so we can access it here.
+      def cow_to_codename_arch(cow)
+        /^base-(.*)-(.*)\.cow$/.match(cow).captures
+      end
+
+      # This method is duplicated from enterprise-dist so we can access it here.
+      def mock_to_dist_version_arch(mock)
+        # We care about matching against two patterns here:
+        # pupent-3.4-el5-i386 <= old style with PE_VER baked into the mock name
+        # pupent-el5-i386     <= new style derived from a template
+        mock.match(/pupent(-\d\.\d)?-([a-z]*)(\d*)-([^-]*)/)[2..4]
+      end
+
+      def deb_build_targets
+        if self.vanagon_project
+          self.deb_targets.split(' ')
+        else
+          self.cows.split(' ').map do |cow|
+            codename, arch = self.cow_to_codename_arch(cow)
+            "#{codename}-#{arch}"
+          end
+        end
+      end
+
+      def rpm_build_targets
+        if self.vanagon_project
+          self.rpm_targets.split(' ')
+        else
+          self.final_mocks.split(' ').map do |mock|
+            platform, version, arch = self.mock_to_dist_version_arch(mock)
+            "#{platform}-#{version}-#{arch}"
+          end
+        end
+      end
     end
   end
 end

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -101,21 +101,6 @@ task :build_deb, :deb_command, :cow do |t, args|
   puts "Finished building in: #{bench}"
 end
 
-def cow_to_codename_arch(cow)
-  /^base-(.*)-(.*)\.cow$/.match(cow).captures
-end
-
-def deb_build_targets
-  if Pkg::Config.vanagon_project
-    Pkg::Config.deb_targets.split(' ')
-  else
-    Pkg::Config.cows.split(' ').map do |cow|
-      codename, arch = cow_to_codename_arch(cow)
-      "#{codename}-#{arch}"
-    end
-  end
-end
-
 namespace :package do
   desc "Create a deb from this repo, using debuild (all builddeps must be installed)"
   task :deb => :tar do

--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -86,7 +86,7 @@ if Pkg::Config.build_pe
       puts "Shipping all built artifacts to to archive directories on #{Pkg::Config.apt_host}"
 
 
-      deb_build_targets.each do |target|
+      Pkg::Config.deb_build_targets.each do |target|
         dist, arch = target.split('-')
         unless Pkg::Util::File.empty_dir? "pkg/pe/deb/#{dist}"
           archive_path = "#{base_path}/#{dist}-#{arch}"


### PR DESCRIPTION
This commit moves 'deb_build_targets' and 'rpm_build_targets' methods
to the Pkg::Config class to so they can be accessed from
enterprise-dist tasks.