### PR TITLE
(re-4028) Fix bad regex in pe_ship that breaks Cumulus

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -87,7 +87,7 @@ if Pkg::Config.build_pe
 
 
       Pkg::Config.deb_build_targets.each do |target|
-        dist, arch = target.split('-')
+        dist, arch = target.match(/(.*)-(.*)/)[1, 2]
         unless Pkg::Util::File.empty_dir? "pkg/pe/deb/#{dist}"
           archive_path = "#{base_path}/#{dist}-#{arch}"
 


### PR DESCRIPTION
Currently, the regex used to ship PE components breaks on the
CumulusLinux-2.2 codename due to an optimistic split('-')

This updates with a regex (the same one used before the above change
was implemented) that matches correctly.