### PR TITLE
(RE-4045) Add support for alternate repositories

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -3,6 +3,7 @@
 module Pkg::Params
   BUILD_PARAMS = [:apt_host,
                   :apt_repo_path,
+                  :apt_repo_name,
                   :apt_repo_url,
                   :author,
                   :benchmark,
@@ -113,6 +114,7 @@ module Pkg::Params
                   :version_strategy,
                   :yum_host,
                   :yum_repo_path,
+                  :yum_repo_name,
                   :internal_gem_host]
 
   # Environment variable overrides for Pkg::Config parameters

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -7,6 +7,7 @@ describe "Pkg::Config" do
   Build_Params = [:apt_host,
                   :apt_repo_path,
                   :apt_repo_url,
+                  :apt_repo_name,
                   :author,
                   :benchmark,
                   :build_date,
@@ -107,7 +108,9 @@ describe "Pkg::Config" do
                   :version_file,
                   :version_strategy,
                   :yum_host,
-                  :yum_repo_path]
+                  :yum_repo_path,
+                  :yum_repo_name,
+  ]
 
   describe "#new" do
     Build_Params.each do |param|

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -63,12 +63,14 @@ task :prep_deb_tars, :work_dir do |t, args|
 end
 
 task :build_deb, :deb_command, :cow do |t, args|
+  subrepo = Pkg::Config.apt_repo_name
   bench = Benchmark.realtime do
     deb_build = args.deb_command
     cow       = args.cow
     work_dir  = Pkg::Util::File.mktemp
     subdir    = 'pe/' if Pkg::Config.build_pe
-    dest_dir  = "#{Pkg::Config.project_root}/pkg/#{subdir}deb/#{/base-(.*)-(.*)\.cow/.match(cow)[1] unless cow.nil?}"
+    codename = /base-(.*)-(.*)\.cow/.match(cow)[1] unless cow.nil?
+    dest_dir  = File.join(Pkg::Config.project_root, "pkg", "#{subdir}deb", codename, subrepo.to_s)
     Pkg::Util::Tool.check_tool(deb_build)
     mkdir_p dest_dir
     deb_args  = { :work_dir => work_dir, :cow => cow }

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -188,7 +188,11 @@ def build_rpm_with_mock(mocks)
   mocks.split(' ').each do |mock_config|
     family  = mock_el_family(mock_config)
     version = mock_el_ver(mock_config)
-    subdir  = Pkg::Util::Version.is_final? ? 'products' : 'devel'
+    subdir  = if Pkg::Config.yum_repo_name
+                Pkg::Config.yum_repo_name
+              else
+                Pkg::Util::Version.is_final? ? 'products' : 'devel'
+              end
     bench = Benchmark.realtime do
       # Set up the rpmbuild dir in a temp space, with our tarball and spec
       workdir = prep_rpm_build_dir


### PR DESCRIPTION
Previously the packaging repo was limited to shipping to main/production
or devel, based on the versioning scheme of the project being shipped.
This commit extends that to allow the rpeo to be overriden for apt or
yum repos using a param in the yaml file. apt_repo_name and
yum_repo_name are both available to override the defaults.