### PR TITLE
(RE-4139) Update ship taks to use repo_command if set 

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -5,6 +5,7 @@ module Pkg::Params
                   :apt_repo_path,
                   :apt_repo_name,
                   :apt_repo_url,
+                  :apt_repo_command,
                   :author,
                   :benchmark,
                   :build_date,
@@ -116,6 +117,7 @@ module Pkg::Params
                   :yum_host,
                   :yum_repo_path,
                   :yum_repo_name,
+                  :yum_repo_command,
   ]
 
   # Environment variable overrides for Pkg::Config parameters

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -57,6 +57,7 @@ module Pkg::Params
                   :gpg_key,
                   :gpg_name,
                   :homepage,
+                  :internal_gem_host,
                   :ips_build_host,
                   :ips_host,
                   :ips_inter_cert,
@@ -115,7 +116,7 @@ module Pkg::Params
                   :yum_host,
                   :yum_repo_path,
                   :yum_repo_name,
-                  :internal_gem_host]
+  ]
 
   # Environment variable overrides for Pkg::Config parameters
   #

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -7,6 +7,7 @@ module Pkg::Util
   require 'packaging/util/date'
   require 'packaging/util/tool'
   require 'packaging/util/file'
+  require 'packaging/util/misc'
   require 'packaging/util/net'
   require 'packaging/util/version'
   require 'packaging/util/serialization'

--- a/lib/packaging/util/misc.rb
+++ b/lib/packaging/util/misc.rb
@@ -1,0 +1,22 @@
+# A collection of utility methods that don't belong in any of our other top level Pkg::Util modules
+# and probably won't anytime soon.
+
+module Pkg::Util::Misc
+  class << self
+    # This method takes a string and a list of tokens and variables and it replaces
+    # the listed tokens with the matched variable if it exists.
+    def search_and_replace(search_string, replacements)
+      replacements.each do |variable, token|
+        begin
+          if (replacement = Pkg::Config.send(variable))
+            search_string.gsub!(token, replacement)
+          end
+        rescue NoMethodError
+          warn "Pkg::Config doesn't have '#{variable}' defined"
+        end
+      end
+
+      search_string
+    end
+  end
+end

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -8,6 +8,7 @@ describe "Pkg::Config" do
                   :apt_repo_path,
                   :apt_repo_url,
                   :apt_repo_name,
+                  :apt_repo_command,
                   :author,
                   :benchmark,
                   :build_date,
@@ -110,6 +111,7 @@ describe "Pkg::Config" do
                   :yum_host,
                   :yum_repo_path,
                   :yum_repo_name,
+                  :yum_repo_command,
   ]
 
   describe "#new" do

--- a/spec/lib/packaging/util/misc_spec.rb
+++ b/spec/lib/packaging/util/misc_spec.rb
@@ -1,0 +1,31 @@
+# -*- ruby -*-
+require 'spec_helper'
+
+describe 'Pkg::Util::Misc' do
+  context "#search_and_replace" do
+    let(:orig_string) { "#!/bin/bash\necho '__REPO_NAME__'" }
+    let(:updated_string) { "#!/bin/bash\necho 'abcdefg'" }
+    let(:good_replacements) do
+      { :yum_repo_name => '__REPO_NAME__', }
+    end
+    let(:warn_replacements) do
+      { :blargy_bilge => '__REPO_NAME__', }
+    end
+
+    it 'replaces the token with the Pkg::Config variable' do
+      Pkg::Config.config_from_hash({:project => "foo", :yum_repo_name => 'abcdefg'})
+      Pkg::Util::Misc.search_and_replace(orig_string, good_replacements).should eq(updated_string)
+    end
+
+    it 'does no replacement if the Pkg::Config variable is not set' do
+      Pkg::Config.config_from_hash({:project => 'foo',})
+      Pkg::Util::Misc.search_and_replace(orig_string, good_replacements).should eq(orig_string)
+    end
+
+    it 'warns and continues if the Pkg::Config variable is unknown to packaging' do
+      Pkg::Config.config_from_hash({:project => 'foo',})
+      Pkg::Util::Misc.should_receive(:warn).with("Pkg::Config doesn't have 'blargy_bilge' defined")
+      Pkg::Util::Misc.search_and_replace(orig_string, warn_replacements).should eq(orig_string)
+    end
+  end
+end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -250,7 +250,7 @@ namespace :pl do
 
     desc "Retrieve packages built by jenkins, sign, and ship all!"
     task :uber_ship => "pl:fetch" do
-      uber_tasks = ["jenkins:retrieve", "jenkins:sign_all", "uber_ship", "remote:freight", "remote:update_yum_repo"]
+      uber_tasks = ["jenkins:retrieve", "jenkins:sign_all", "uber_ship", "remote:update_apt_repo", "remote:update_yum_repo"]
       uber_tasks.map { |t| "pl:#{t}" }.each { |t| Rake::Task[t].invoke }
       Rake::Task["pl:jenkins:ship"].invoke("shipped")
     end


### PR DESCRIPTION
If the user has used the new Pkg::Config.apt_repo_command or
Pkg::Config.yum_repo_command, we want to prefer those commands over the
legacy defaults. This PR adds logic to check if the new param is
set, and if so to invoke it, and otherwise to fall back to the old
behavior. The freight rake task is renamed to update_apt_repo, and the
uber_ship is updated to use it instead of freight.