### PR TITLE
(RE-4221) Allow building and shipping of only tar/gem artifacts

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -129,8 +129,8 @@ namespace :pl do
     if confirm_ship(FileList["pkg/**/*"])
       ENV['ANSWER_OVERRIDE'] = 'yes'
       Rake::Task["pl:ship_gem"].invoke if Pkg::Config.build_gem
-      Rake::Task["pl:ship_rpms"].invoke
-      Rake::Task["pl:ship_debs"].invoke
+      Rake::Task["pl:ship_rpms"].invoke if Pkg::Config.final_mocks
+      Rake::Task["pl:ship_debs"].invoke if Pkg::Config.cows
       Rake::Task["pl:ship_dmg"].execute if Pkg::Config.build_dmg
       Rake::Task["pl:ship_tar"].execute if Pkg::Config.build_tar
       Rake::Task["pl:jenkins:ship"].invoke("shipped")

--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -55,14 +55,18 @@ pl:jenkins:uber_build NOTIFY=foo@puppetlabs.com&#xd;
   <properties>
     <jp.ikedam.jenkins.plugins.groovy__label__assignment.GroovyLabelAssignmentProperty plugin="groovy-label-assignment@1.0.0">
       <groovyScript>def labelMap = [
-        <% Pkg::Config.cows.split(' ').each do |cow| %>
-          <% if cow =~ /cumulus/ %>
-        &quot;pl_deb COW=<%= cow %>&quot;: &quot;cumulus&quot;,
-          <% else %>
-        &quot;pl_deb COW=<%= cow %>&quot;: &quot;deb&quot;,
+        <% if Pkg::Config.cows %>
+          <% Pkg::Config.cows.split(' ').each do |cow| %>
+            <% if cow =~ /cumulus/ %>
+          &quot;pl_deb COW=<%= cow %>&quot;: &quot;cumulus&quot;,
+            <% else %>
+          &quot;pl_deb COW=<%= cow %>&quot;: &quot;deb&quot;,
+            <% end %>
           <% end %>
         <% end %>
-        <% Pkg::Config.final_mocks.split(' ').each do |mock| %>&quot;pl_mock MOCK=<%= mock %>&quot;: &quot;rpm&quot;,<% end %>
+        <% if Pkg::Config.final_mocks %>
+          <% Pkg::Config.final_mocks.split(' ').each do |mock| %>&quot;pl_mock MOCK=<%= mock %>&quot;: &quot;rpm&quot;,<% end %>
+        <% end %>
         <% if Pkg::Config.build_tar then %>&quot;package_tar&quot;: &quot;rpm&quot;,<% end %>
         <% if Pkg::Config.build_gem then %>&quot;package_gem&quot;: &quot;gem&quot;,<% end %>
         <% if Pkg::Config.build_dmg then %>&quot;package_apple&quot;: &quot;dmg&quot;,<% end %>
@@ -107,8 +111,12 @@ return labelMap.get(binding.getVariables().get(&quot;command&quot;));</groovyScr
     <hudson.matrix.TextAxis>
       <name>command</name>
       <values>
-        <% Pkg::Config.cows.split(' ').each do |cow| %><string>pl_deb COW=<%= cow %></string><% end %>
-        <% Pkg::Config.final_mocks.split(' ').each do |mock| %><string>pl_mock MOCK=<%= mock %></string><% end %>
+        <% if Pkg::Config.cows %>
+          <% Pkg::Config.cows.split(' ').each do |cow| %><string>pl_deb COW=<%= cow %></string><% end %>
+        <% end %>
+        <% if Pkg::Config.final_mocks %>
+          <% Pkg::Config.final_mocks.split(' ').each do |mock| %><string>pl_mock MOCK=<%= mock %></string><% end %>
+        <% end %>
         <% if Pkg::Config.build_tar then %><string>package_tar</string><% end %>
         <% if Pkg::Config.build_gem then %><string>package_gem</string><% end %>
         <% if Pkg::Config.build_dmg then %><string>package_apple</string><% end %>

--- a/templates/repo.xml.erb
+++ b/templates/repo.xml.erb
@@ -74,15 +74,14 @@ if [ $PACKAGE_BUILD_RESULT -eq 0 ] ; then
       rake package:bootstrap --trace
 
       ### Run repo creation
-<% if not Pkg::Config.final_mocks.empty? %>
+<% if Pkg::Config.final_mocks %>
       rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:rpm_repos --trace
 <% end %>
-<% if not Pkg::Config.cows.empty? %>
+<% if Pkg::Config.cows %>
       rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:deb_repos --trace
 <% end %>
-<% if Pkg::Config.final_mocks.empty? and Pkg::Config.cows.empty? %>
-      echo "No final_mocks or cows defined in configuration (usually build_defaults.yaml)! Failing!"
-      exit 1
+<% if Pkg::Config.final_mocks.nil? and Pkg::Config.cows.nil? %>
+      echo "No final_mocks or cows defined in configuration (usually build_defaults.yaml). Skipping repo creation"
 <% end %>
     popd
   popd


### PR DESCRIPTION
With the shift to delivering our software via the puppet-agent package,
we want to discontinue shipping conventional packages. However, we do
want to continue shipping the tar and gem artifacts.

This commit lets us maintain a list of LTS build targets for community
members who are using this automation to build rpm or deb packages while
not building rpm/deb packages when we run `rake pl:jenkins:uber_build`.
It also lets us easily not ship any deb/rpm packages. The important this
is that `pl:deb` and `pl:mock` still work for building deb/rpm packages
if that is wanted. If the setting needs to be overridden, like for a
jenkins uber_build, we can do that by setting `RPM=TRUE` and/or
`DEB=TRUE` as environment variables when that rake task is invoked.