### PR TITLE
(RE-4261) Add build_tar config parameter

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -16,6 +16,7 @@ module Pkg::Params
                   :build_ips,
                   :build_msi,
                   :build_pe,
+                  :build_tar,
                   :builder_data_file,
                   :builds_server,
                   :bundle_platforms,
@@ -134,6 +135,7 @@ module Pkg::Params
               { :var => :build_ips,           :envvar => :IPS,             :type => :bool },
               { :var => :build_msi,           :envvar => :MSI,             :type => :bool },
               { :var => :build_pe,            :envvar => :PE_BUILD,        :type => :bool },
+              { :var => :build_tar,           :envvar => :TAR,             :type => :bool },
               { :var => :vanagon_project,     :envvar => :VANAGON_PROJECT, :type => :bool },
               { :var => :certificate_pem,     :envvar => :CERT_PEM },
               { :var => :cows,                :envvar => :COW },
@@ -168,7 +170,8 @@ module Pkg::Params
               { :var => :keychain_loaded,   :val => false },
               { :var => :build_date,        :val => Pkg::Util::Date.timestamp('-') },
               { :var => :release,           :val => '1' },
-              { :var => :internal_gem_host, :val => 'http://rubygems.delivery.puppetlabs.net/' }]
+              { :var => :internal_gem_host, :val => 'http://rubygems.delivery.puppetlabs.net/' },
+              { :var => :build_tar,         :val => true }]
 
   # These are variables which, over time, we decided to rename or replace. For
   # backwards compatibility, we assign the value of the old/deprecated

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -19,6 +19,7 @@ describe "Pkg::Config" do
                   :build_ips,
                   :build_msi,
                   :build_pe,
+                  :build_tar,
                   :builder_data_file,
                   :bundle_platforms,
                   :certificate_pem,

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -115,10 +115,12 @@ namespace :pl do
     end
   end if Pkg::Config.build_dmg
 
-  desc "ship tarball and signature to #{Pkg::Config.tar_host}"
-  task :ship_tar => 'pl:fetch' do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
-      Pkg::Util::Net.rsync_to("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*", Pkg::Config.tar_host, Pkg::Config.tarball_path)
+  if Pkg::Config.build_tar
+    desc "ship tarball and signature to #{Pkg::Config.tar_host}"
+    task :ship_tar => 'pl:fetch' do
+      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+        Pkg::Util::Net.rsync_to("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*", Pkg::Config.tar_host, Pkg::Config.tarball_path)
+      end
     end
   end
 
@@ -130,7 +132,7 @@ namespace :pl do
       Rake::Task["pl:ship_rpms"].invoke
       Rake::Task["pl:ship_debs"].invoke
       Rake::Task["pl:ship_dmg"].execute if Pkg::Config.build_dmg
-      Rake::Task["pl:ship_tar"].execute
+      Rake::Task["pl:ship_tar"].execute if Pkg::Config.build_tar
       Rake::Task["pl:jenkins:ship"].invoke("shipped")
       add_shipped_metrics(:pe_version => ENV['PE_VER'], :is_rc => (!Pkg::Util::Version.is_final?)) if Pkg::Config.benchmark
       post_shipped_metrics if Pkg::Config.benchmark

--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -63,7 +63,7 @@ pl:jenkins:uber_build NOTIFY=foo@puppetlabs.com&#xd;
           <% end %>
         <% end %>
         <% Pkg::Config.final_mocks.split(' ').each do |mock| %>&quot;pl_mock MOCK=<%= mock %>&quot;: &quot;rpm&quot;,<% end %>
-        &quot;package_tar&quot;: &quot;rpm&quot;,
+        <% if Pkg::Config.build_tar then %>&quot;package_tar&quot;: &quot;rpm&quot;,<% end %>
         <% if Pkg::Config.build_gem then %>&quot;package_gem&quot;: &quot;gem&quot;,<% end %>
         <% if Pkg::Config.build_dmg then %>&quot;package_apple&quot;: &quot;dmg&quot;,<% end %>
 ];
@@ -109,7 +109,7 @@ return labelMap.get(binding.getVariables().get(&quot;command&quot;));</groovyScr
       <values>
         <% Pkg::Config.cows.split(' ').each do |cow| %><string>pl_deb COW=<%= cow %></string><% end %>
         <% Pkg::Config.final_mocks.split(' ').each do |mock| %><string>pl_mock MOCK=<%= mock %></string><% end %>
-        <string>package_tar</string>
+        <% if Pkg::Config.build_tar then %><string>package_tar</string><% end %>
         <% if Pkg::Config.build_gem then %><string>package_gem</string><% end %>
         <% if Pkg::Config.build_dmg then %><string>package_apple</string><% end %>
       </values>


### PR DESCRIPTION
For vanagon projects, tarballs will not be produced. This breaks the
uber_ship, which expects a tar to be there. This commit addresses this
by adding a build_tar parameter which defaults to true, which can be
used to toggle the tar ship/build. The TAR environment variable can also
be used to set this on the command line.