### PR TITLE
(maint) Allow mock and cow list to be empty strings

### DIFF
--- a/templates/repo.xml.erb
+++ b/templates/repo.xml.erb
@@ -74,14 +74,15 @@ if [ $PACKAGE_BUILD_RESULT -eq 0 ] ; then
       rake package:bootstrap --trace
 
       ### Run repo creation
-<% if Pkg::Config.final_mocks %>
+<% if Pkg::Config.final_mocks and not Pkg::Config.final_mocks.empty? %>
       rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:rpm_repos --trace
+<% else %>
+      echo "No mock/rpm targets found, skipping rpm repo creation"
 <% end %>
-<% if Pkg::Config.cows %>
+<% if Pkg::Config.cows and not Pkg::Config.cows.empty? %>
       rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:deb_repos --trace
-<% end %>
-<% if Pkg::Config.final_mocks.nil? and Pkg::Config.cows.nil? %>
-      echo "No final_mocks or cows defined in configuration (usually build_defaults.yaml). Skipping repo creation"
+<% else %>
+      echo "No cow/deb targets found, skipping deb repo creation"
 <% end %>
     popd
   popd


### PR DESCRIPTION
Previously, the automation allowed empty strings to used in the `cows`
and `final_mocks` definition. In changes that I made recently, I took
away that functionality. This only impacts repo creating, which fails if
there are no packages of that kind to create a repo for.

This commit makes it so that we will not attempt to create repos in any
of the following situations:

`cows:`
`cows: ''`
`#cows: base-lucid-amd64.cow`

and will attempt to create repos only in the folowing situations:

`cows: base-lucid-amd64.cow`