### PR TITLE
(RE-4292) Add uber_ship binary to packaging

### DIFF
--- a/bin/uber_ship
+++ b/bin/uber_ship
@@ -1,0 +1,143 @@
+#!/usr/bin/env ruby
+require 'tmpdir'
+require 'yaml'
+
+project = ARGV[0]
+ref = ARGV[1]
+target_repo = ARGV[2]
+
+def usage
+  puts <<USAGE
+uber_ship: a light wrapper to make shipping Puppet Labs projects easier. This is not intended or tested for use outside Puppet Labs.
+
+usage: uber_ship <project> <ref> <target repo>
+
+Both project and ref are required arguments. ref can be either a tag or a git sha of the project.
+
+target_repo is an optional argument. using target_repo will rearrange the
+packages into a new layout under the target repo and then ship them
+
+USAGE
+end
+
+def get_directories(dir)
+  Dir.entries(dir).select { |entry| entry !~ /\./ and File.directory?("#{dir}/#{entry}") }
+end
+
+def get_files(dir)
+  Dir.glob("#{dir}/**/*").select { |entry| File.file?(entry) }
+end
+
+# This method will rearrange rpm or dep packages under a new repo
+def rearrange_packages(source_directory, target_directory, target_repo, subdirs)
+  targets = get_directories(source_directory)
+  unless targets.empty?
+    FileUtils.mkdir_p(target_directory)
+    targets.each do |target|
+      subdirs.each do |subdir|
+        target_dir = "#{target_directory}/#{target}/#{target_repo}/#{subdir}"
+        FileUtils.mkdir_p(target_dir)
+        packages = get_files("#{source_directory}/#{target}/**/#{subdir}")
+        FileUtils.cp(packages, target_dir)
+      end
+    end
+  end
+end
+
+
+# Given a project and a ref, this method downloads the params yaml file and
+# signing bundle, and also unpacks and clones the signing bundle. This prepares
+# the directory for either uber_shipping or reshipping.
+def bootstrap(project, ref)
+  package_url = "http://builds.puppetlabs.lan/#{project}/#{ref}/artifacts"
+
+  # First fetch the params file
+  params_file = "#{package_url}/#{ref}.yaml"
+  puts "Fetching params file from '#{params_file}'..."
+  system("wget #{params_file}")
+  unless $?.success?
+    fail "Could not download params file '#{params_file}'. Perhaps project or ref were incorrect?"
+  end
+
+  data = YAML.load_file(File.basename(params_file))
+
+  # Next fetch the signing bundle
+  signing_bundle = "#{data[:project]}-#{data[:version]}-signing_bundle.tar.gz"
+  puts "Fetching signing bundle from '#{package_url}/#{signing_bundle}'..."
+  system("wget #{package_url}/#{signing_bundle}")
+
+  unless $?.success?
+    fail "Could not download signing bundle '#{signing_bundle}'. Perhaps project or ref were incorrect?"
+  end
+
+  # Unpack and clone the bundle
+  puts "Unpacking signing bundle..."
+  system("tar xf #{signing_bundle}")
+
+  puts "Cloning signing bundle..."
+  system("git clone --recursive #{signing_bundle.gsub('.tar.gz', '')} #{data[:project]}-#{data[:version]}")
+  return [data[:project], data[:version]]
+end
+
+def uber_ship(rake)
+  puts "Running the uber_ship..."
+  system("#{rake} pl:jenkins:uber_ship")
+end
+
+# This method rearranges all of the deb and rpm packages under pkg into a new
+# dir called new_pkg and then moves new_pkg on top of pkg. Once the packages
+# are rearranged under pkg they can be reshipped using most of the normal
+# uber_ship dependencies.
+def rearrange_and_reship(rake, target_repo, signing_bundle)
+  puts "Retrieving packages..."
+  system("#{rake} -s pl:jenkins:retrieve &> /dev/null")
+
+  puts "Moving the packages into the new layout..."
+  puts "Moving debs..."
+  rearrange_packages("pkg/deb", "new_pkg/deb", target_repo, [""])
+  puts "Moving rpms..."
+  rearrange_packages("pkg/el", "new_pkg/el", target_repo, ["i386", "x86_64", "SRPMS"])
+  rearrange_packages("pkg/fedora", "new_pkg/fedora", target_repo, ["i386", "x86_64", "SRPMS"])
+
+  puts "Moving new_pkg into place on top of pkg..."
+  FileUtils.mv("pkg", "old_pkg")
+  FileUtils.mv("new_pkg", "pkg")
+
+  puts "uber_shipping relocated packages..."
+  ENV["SIGNING_BUNDLE"] = "../#{signing_bundle}"
+  ENV["TAR"] = "FALSE"
+  system("#{rake} -s pl:jenkins:sign_all pl:uber_ship pl:remote:update_apt_repo pl:remote:update_yum_repo")
+end
+
+tmpdir = Dir.mktmpdir
+puts "Working directory is '#{tmpdir}'"
+
+if project and ref
+  Dir.chdir(tmpdir) do
+    project_name, version = bootstrap(project, ref)
+    project_dir = "#{project_name}-#{version}"
+
+    # Now do the shipping or rearranging
+    Dir.chdir(project_dir)  do
+      if File.exists?("Gemfile")
+        rake = "bundle exec rake"
+        system("bundle install --path=./vendor")
+      else
+        rake = "rake"
+      end
+
+      system("#{rake} package:bootstrap")
+      if target_repo
+        rearrange_and_reship(rake, target_repo, "#{project_name}-#{version}-signing_bundle.tar.gz")
+      else
+        uber_ship(rake)
+      end
+    end
+  end
+
+  FileUtils.rm_rf tmpdir
+else
+  warn "project and ref are required arguments"
+  usage
+  exit 1
+end


### PR DESCRIPTION
This commit adds an uber_ship binary to packaging. This file serves two
purposes. First, it allows us to ship ezbake projects in a more
automated fashion than was previously possible. Running `./bin/uber_ship
puppetserver 2.0.0` would ship puppetserver 2.0.0 to our public repos,
without any of the manual steps that are currently required.
The second purpose is to reship a given package. For puppetdb, we will
be shipping the 2.3.x to two repos, products/main and PC1. This was not
possible with our previous tooling. With this commit, if a third
optional argument is included, the packages will be rearranged under the
target repo given, and shipped there. For puppetdb, that means that
2.3.3, which was targeted at main/products, can be rearranged under the
PC1 repo structure and shipped to our public repositories in an
automated fashion, without manual steps required.