### PR TITLE
(RE-3293) Treat SNAPSHOT builds like RCs for versioning

### DIFF
--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -146,6 +146,9 @@ module Pkg::Util::Version
         # Grab the rc number
         rc_num = dash.match(/rc(\d+)/)[1]
         ver = dash.sub(/-?rc[0-9]+/, "-0.#{Pkg::Config.release}rc#{rc_num}").gsub(/(rc[0-9]+)-(\d+)?-?/, '\1.\2')
+      elsif dash.include?("SNAPSHOT")
+        # Insert -0.#{release} between the version and the SNAPSHOT string
+        ver = dash.sub(/^(.*)\.(SNAPSHOT\..*)$/, "\\1-0.#{Pkg::Config.release}\\2")
       else
         ver = dash.gsub('-', '.') + "-#{Pkg::Config.release}"
       end
@@ -215,9 +218,16 @@ module Pkg::Util::Version
     # '0.7.0-rc1'
     # '0.7.0-rc1-63'
     # '0.7.0-rc1-63-dirty'
+    # '0.7.0.SNAPSHOT.2015.03.25T0146'
     def is_rc?
-      return TRUE if get_dash_version =~ /^\d+\.\d+\.\d+-*rc\d+/
-      return FALSE
+      case get_dash_version
+      when /^\d+\.\d+\.\d+-*rc\d+/
+        TRUE
+      when /^\d+\.\d+\.\d+\.SNAPSHOT\.\d{4}\.\d{2}\.\d{2}T\d{4}/
+        TRUE
+      else
+        FALSE
+      end
     end
 
     # the odd_even strategy (mcollective)

--- a/spec/tasks/00_utils_spec.rb
+++ b/spec/tasks/00_utils_spec.rb
@@ -63,6 +63,21 @@ describe "00_utils" do
         :is_less_than_one?          => true,
       },
     },
+    '0.7.0.SNAPSHOT.2015.03.25T0146' => {
+      :ref_type                     => "tag",
+      :method_map                   => {
+        :git_describe_version       => %w{0.7.0.SNAPSHOT.2015.03.25T0146},
+        :get_dash_version           => '0.7.0.SNAPSHOT.2015.03.25T0146',
+        :get_ips_version            => '0.7.0.SNAPSHOT.2015.03.25T0146,3.14159-0',
+        :get_dot_version            => '0.7.0.SNAPSHOT.2015.03.25T0146',
+        :get_debversion             => '0.7.0-0.1SNAPSHOT.2015.03.25T0146puppetlabs1',
+        :get_rpmversion             => '0.7.0',
+        :get_rpmrelease             => '0.1SNAPSHOT.2015.03.25T0146',
+        :is_rc?                     => true,
+        :is_odd?                    => true,
+        :is_less_than_one?          => true,
+      },
+    },
     '0.4.0-rc1-63-ge391f55'         => {
       :ref_type                     => "commit",
       :method_map                   => {


### PR DESCRIPTION
Previously, ezbake builds would have a SNAPSHOT build that was treated
like any other. This had the consequence of making the 'final' release
for a given version series as less than the SNAPSHOT builds, which means
it would be unpromotable (also not immediately upgradable from the
snapshot version). This commit updates the versioning in packaging to
treat SNAPSHOT builds as if they were RC builds. This means that
SNAPSHOT versions will have a '0.1' prepended to them (0.7.0.SNAPSHOT...
becomes 0.7.0-0.1SNAPSHOT...), which makes the final version higher than
the snapshot version for packaging purposes.