### PR TITLE
(RE-4374) Create x86_64 dir during rpm signing

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -91,6 +91,7 @@ namespace :pl do
     # Now we hardlink them back in
     Dir["#{rpm_dir}/*/*/*/i386/*.noarch.rpm"].each do |rpm|
       cd File.dirname(rpm) do
+        FileUtils.mkdir_p(File.join("..", "x86_64"))
         FileUtils.ln(File.basename(rpm), File.join("..", "x86_64"), :force => true, :verbose => true)
       end
     end


### PR DESCRIPTION
When building a vanagon noarch package, the x86_64 directory won't
always be created. When hardlinking, this will mean that there won't be
hardlinks of the noarch packages in the x86_64 directory. This commit
avoids that problem by ensuring that the x86_64 directory is created
before the hardlink is attempted.