### PR TITLE
(maint) Fixes for Windows builder environment

### DIFF
--- a/templates/msi.xml.erb
+++ b/templates/msi.xml.erb
@@ -83,7 +83,7 @@ This job will trigger the downstream job supplied with DOWNSTREAM_JOB if passed 
   </axes>
   <builders>
     <hudson.tasks.Shell>
-      <command>#!C:/puppetwinbuilder/sys/ruby/bin/ruby.exe
+      <command>#!ruby.exe
 
 require &apos;yaml&apos;
 
@@ -126,7 +126,9 @@ CONFIG = {
 File.open(&quot;#{ENV[&apos;WORKSPACE&apos;]}/ondemand.yaml&quot;, &apos;w&apos;) { |f| f.write(YAML.dump(CONFIG)) }</command>
     </hudson.tasks.Shell>
     <hudson.tasks.BatchFile>
-      <command>call c:\puppetwinbuilder\setup_env.bat
+      <command>
+REM Print the environment
+set
 
 set PKG_NAME=<%= Pkg::Config.msi_name || 'puppet' %>
 set AGENT_VERSION_STRING=<%= Pkg::Config.version %>


### PR DESCRIPTION
Prior to this commit, our Windows packaging jobs required two key
commands:
  - `#!C:/puppetwinbuilder/sys/ruby/bin/ruby.exe`
  - `call c:\puppetwinbuilder\setup_env.bat`

The first of these commands hard-coded the Ruby runtime, and the second
used a hard-coded path to a file on each of the Windows builders that
set up certain parts of the environment (e.g. `%PATH%`) so the builds
could actually take place.

With the work I've been doing to manage our Windows build infrastructure
with Puppet, we can ensure that our tooling is always available on
`%PATH%` and is managed using the Chocolatey package manager, ensuring that
we don't need to bundle and distribute binaries or explicitly modify or
hard-code pieces of the environment.

This commit modifies the shebang that Jenkins uses to find a Ruby
interpreter to simply call `ruby.exe`, since it will now be on our PATH.
It also removes the call to the `setup_env.bat` script, because we will
manage the system's `%PATH%` using Puppet.