### PR TITLE
(RE-4669) Fail promotion on reprepro errors

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -171,12 +171,14 @@ if Pkg::Config.build_pe
             --incomingdir #{incoming_dir} \
             --verbose", true)
 
-        if (stdout + stderr).include?("Skipping inclusion")
+        output = stdout + stderr
+
+        if output.include?("Skipping inclusion")
           fail "Unable to add packages to debian repo because it already contains identical files. Perhaps you are trying to ship a deb that already exists. Verify the debs are a newer version than what already exists in #{reprepro_basedir} on #{Pkg::Config.apt_host}"
         end
 
         puts
-        puts "Repsimple output: #{stdout + stderr}"
+        puts "Repsimple output: #{output}"
         puts
 
         puts "Cleaning up apt repo 'incoming' dir on #{Pkg::Config.apt_host}"

--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -175,6 +175,9 @@ if Pkg::Config.build_pe
 
         if output.include?("Skipping inclusion")
           fail "Unable to add packages to debian repo because it already contains identical files. Perhaps you are trying to ship a deb that already exists. Verify the debs are a newer version than what already exists in #{reprepro_basedir} on #{Pkg::Config.apt_host}"
+        elsif output.include?("ERROR:") || output.include?("There have been errors!")
+          # We shouldn't ever get here if repsimple returns non-zero on failure, but just in case...
+          fail "Unable to add packages to debian repo. Hopefully the output has some helpful information. Output: #{output}"
         end
 
         puts


### PR DESCRIPTION
Previously the promotion would continue rolling even on errors creating
repos using reprepro. This commit addresses that by checking the output
of the repsimple call for errors and failing if any are found. This will
be coupled with a change to repsimple itself to exit non-zero on
reprepro errors.