### PR TITLE
(RE-4595) Allow RPMS for SLES and eos to be signed

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -71,8 +71,12 @@ namespace :pl do
     rm_r Dir["#{rpm_dir}/*/*/*/x86_64/*.noarch.rpm"]
     # We'll sign the remaining noarch
     all_rpms = Dir["#{rpm_dir}/**/*.rpm"]
-    old_rpms    = Dir["#{rpm_dir}/el/4/**/*.rpm"] + Dir["#{rpm_dir}/el/5/**/*.rpm"]
-    modern_rpms = Dir["#{rpm_dir}/el/6/**/*.rpm"] + Dir["#{rpm_dir}/el/7/**/*.rpm"] + Dir["#{rpm_dir}/fedora/**/*.rpm"] + Dir["#{rpm_dir}/nxos/**/*.rpm"]
+    old_rpms = Dir["#{rpm_dir}/el/4/**/*.rpm"] + Dir["#{rpm_dir}/el/5/**/*.rpm"] +
+      Dir["#{rpm_dir}/sles/10/**/*.rpm"] + Dir["#{rpm_dir}/sles/11/**/*.rpm"]
+    modern_rpms = Dir["#{rpm_dir}/el/6/**/*.rpm"] +
+      Dir["#{rpm_dir}/el/7/**/*.rpm"] +
+      Dir["#{rpm_dir}/fedora/**/*.rpm"] + Dir["#{rpm_dir}/nxos/**/*.rpm"] +
+      Dir["#{rpm_dir}/sles/12/**/*.rpm"] + Dir["#{rpm_dir}/eos/**/**/*.rpm"]
 
     unsigned_rpms = all_rpms - old_rpms - modern_rpms
     unless unsigned_rpms.empty?


### PR DESCRIPTION
Currently in packaging you can't ship SLES or eos builds because you
can't sign them, because they were never run through the packaging repo
tasks before. With the advent of vanagon, this is now a requirement, so
here we go.

Sometime in the future, we should consolidate pe_sign.rake and sign.rake
into something that is smarter, but for now this should get us
unblocked.