### PR TITLE
(RE-4595) Add AIX rpms to the list that packaging repo signs

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -72,7 +72,8 @@ namespace :pl do
     # We'll sign the remaining noarch
     all_rpms = Dir["#{rpm_dir}/**/*.rpm"]
     old_rpms = Dir["#{rpm_dir}/el/4/**/*.rpm"] + Dir["#{rpm_dir}/el/5/**/*.rpm"] +
-      Dir["#{rpm_dir}/sles/10/**/*.rpm"] + Dir["#{rpm_dir}/sles/11/**/*.rpm"]
+      Dir["#{rpm_dir}/sles/10/**/*.rpm"] + Dir["#{rpm_dir}/sles/11/**/*.rpm"] +
+      Dir["#{rpm_dir}/aix/**/**/*.rpm"]
     modern_rpms = Dir["#{rpm_dir}/el/6/**/*.rpm"] +
       Dir["#{rpm_dir}/el/7/**/*.rpm"] +
       Dir["#{rpm_dir}/fedora/**/*.rpm"] + Dir["#{rpm_dir}/nxos/**/*.rpm"] +


### PR DESCRIPTION
When we added nxos and SLES support for rpm signing, AIX was missed.
This fixes that by adding AIX to the older_rpms signing patterns.