### PR TITLE
(RE-4155) Ensure directories are created with 775 perms

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -192,7 +192,7 @@ namespace :pl do
       end
 
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
-        Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, "mkdir -p #{artifact_dir}")
+        Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, "mkdir --mode=775 -p #{artifact_dir}")
         Pkg::Util::Net.rsync_to("#{local_dir}/", Pkg::Config.distribution_server, "#{artifact_dir}/", ["--ignore-existing", "--exclude repo_configs"])
       end
 


### PR DESCRIPTION
Prior to this commit, directories were being created on
builds.puppetlabs.lan with 755 permissions. This is fine except when
we need to add additional directories to them. For instance, when we do
a release, we create a 'shipped' directory under the main sha/tag
direcotry. This would cause ships to break because it would be unable to
create the 'shipped' directory. This commit updates the ship process to
always create directories with 775 permissions.