### PR TITLE
(RE-4684) Add automation to ship repos to s3

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -61,6 +61,16 @@ module Pkg::Util::Net
       Pkg::Util::Execution.ex("#{rsync} #{flags} #{target}:#{source} #{dest}")
     end
 
+    def s3sync_to(source, target_bucket, target_directory = "", flags = [])
+      s3cmd = Pkg::Util::Tool.check_tool('s3cmd')
+
+      if Pkg::Util::File.file_exists?(File.join(ENV['HOME'], '.s3cfg'))
+        Pkg::Util::Execution.ex("#{s3cmd} sync #{flags.join(' ')} '#{source}' s3://#{target_bucket}/#{target_directory}/")
+      else
+        fail "#{File.join(ENV['HOME'], '.s3cfg')} does not exist. It is required to ship files using s3cmd."
+      end
+    end
+
     # This is fairly absurd. We're implementing curl by shelling out. What do I
     # wish we were doing? Using a sweet ruby wrapper around curl, such as Curb or
     # Curb-fu. However, because we're using clean build systems and trying to

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -44,9 +44,8 @@ namespace :pl do
       end
     end
 
-    task :deploy_signed_repos, [:target_host, :target_basedir, :target_prefix, :versioning] => ["clean", "pl:fetch"] do |t, args|
+    task :prepare_signed_repos, [:target_host, :target_prefix, :versioning] => ["clean", "pl:fetch"] do |t, args|
       target_host = args.target_host or fail ":target_host is a required argument to #{t}"
-      target_basedir = args.target_basedir or fail ":target_basedir is a required argument to #{t}"
       target_prefix = args.target_prefix or fail ":target_prefix is a required argument for #{t}"
       versioning = args.versioning or fail ":versioning is a required argument for #{t}"
       mkdir("pkg")
@@ -114,7 +113,11 @@ namespace :pl do
         # Make a latest symlink for the project
         FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))
       end
+    end
 
+    task :deploy_signed_repos, [:target_host, :target_basedir] => "pl:fetch" do |t, args|
+      target_host = args.target_host or fail ":target_host is a required argument to #{t}"
+      target_basedir = args.target_basedir or fail ":target_basedir is a required argument to #{t}"
       # Ship it to the target for consumption
       # First we ship the latest and clean up any repo-configs that are no longer valid with --delete-after
       Pkg::Util::Net.rsync_to("pkg/#{Pkg::Config.project}-latest", target_host, target_basedir, ["--delete-after"])
@@ -151,7 +154,8 @@ namespace :pl do
     task :deploy_nightly_repos, [:target_host, :target_basedir] => ["pl:fetch"] do |t, args|
       target_host = args.target_host or fail ":target_host is a required argument to #{t}"
       target_basedir = args.target_basedir or fail ":target_basedir is a required argument to #{t}"
-      Pkg::Util::RakeUtils.invoke_task("pl:jenkins:deploy_signed_repos", target_host, target_basedir, 'nightly', 'ref')
+      Pkg::Util::RakeUtils.invoke_task("pl:jenkins:prepare_signed_repos", target_host, 'nightly', 'ref')
+      Pkg::Util::RakeUtils.invoke_task("pl:jenkins:deploy_signed_repos", target_host, target_basedir)
     end
   end
 end


### PR DESCRIPTION
This PR includes some refactoring to the deployed repos tasks and also 
adds two new tasks to nightly_repos.rake. The first is a
task that ships an already signed repo to a given s3 bucket and the
second is a wrapper task that first signs repos for a given project and
SHA and then ships it to s3.
A new method is also added to Pkg::Util::Net to enable syncing out of repos to s3.