### PR TITLE
(maint) Add sles to the packages that we will ship

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -1,7 +1,7 @@
 namespace :pl do
   desc "Ship mocked rpms to #{Pkg::Config.yum_host}"
   task :ship_rpms do
-    ["el", "fedora", "nxos", "eos"].each do |dist|
+    ["el", "eos", "fedora", "nxos", "sles"].each do |dist|
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
         pkgs = Dir["pkg/#{dist}/**/*.rpm"].map { |f| "'#{f.gsub("pkg/#{dist}/", "#{Pkg::Config.yum_repo_path}/#{dist}/")}'" }
         unless pkgs.empty?


### PR DESCRIPTION
For shipping build tools, we need to ensure we can ship sles packages as
well as all the other rpm based packages. This commit also alphabetized
the list of rpm based platforms that we ship.