### PR TITLE
(RE-4880) Sign rpm repos during signed repo creation

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -147,7 +147,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; )
     def sign_repos(target = "repos", message = "Signed apt repository")
       subrepo = Pkg::Config.apt_repo_name || 'main'
       reprepro = Pkg::Util::Tool.check_tool('reprepro')
-      load_keychain if Pkg::Util::Tool.find_tool('keychain')
+      Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
 
       dists = Pkg::Util::File.directories("#{target}/apt")
 

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -1,5 +1,6 @@
 # Utilities for working with rpm repos
 require 'fileutils'
+require 'find'
 
 module Pkg::Rpm::Repo
   class << self
@@ -32,6 +33,13 @@ module Pkg::Rpm::Repo
       Dir.chdir(directory) do
         createrepo = Pkg::Util::Tool.check_tool('createrepo')
         Pkg::Util::Execution.ex("bash -c '#{repo_creation_command(createrepo)}'")
+      end
+    end
+
+    def sign_repos(directory)
+      files_to_sign = Find.find(directory).select { |file| file.match(/repomd.xml$/) }
+      files_to_sign.each do |file|
+        Pkg::Util::Gpg.sign_file(file)
       end
     end
 

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -16,6 +16,7 @@ module Pkg::Util
   require 'packaging/util/execution'
   require 'packaging/util/git'
   require 'packaging/util/jenkins'
+  require 'packaging/util/gpg'
 
   def self.boolean_value(var)
     return TRUE if var == TRUE || ( var.is_a?(String) && ( var.downcase == 'true' || var.downcase =~ /^y$|^yes$/))

--- a/lib/packaging/util/gpg.rb
+++ b/lib/packaging/util/gpg.rb
@@ -1,0 +1,49 @@
+module Pkg::Util::Gpg
+  class << self
+
+    def keychain
+      if @keychain.nil?
+        @keychain = Pkg::Util::Tool.find_tool('keychain')
+      else
+        @keychain
+      end
+    end
+
+    def load_keychain
+      unless @keychain_loaded
+        unless ENV['RPM_GPG_AGENT']
+          kill_keychain
+          start_keychain
+        end
+        @keychain_loaded = TRUE
+      end
+    end
+
+    def kill_keychain
+      if keychain
+        Pkg::Util::Execution.ex("#{keychain} -k mine")
+      end
+    end
+
+    def start_keychain
+      if keychain
+        keychain_output = Pkg::Util::Execution.ex("#{keychain} -q --agents gpg --eval #{Pkg::Config.gpg_key}").chomp
+        new_env = keychain_output.match(/GPG_AGENT_INFO=([^;]*)/)
+        ENV["GPG_AGENT_INFO"] = new_env[1]
+      else
+        fail "Keychain is not installed, it is required to autosign using gpg."
+      end
+    end
+
+    def sign_file(file)
+      gpg ||= Pkg::Util::Tool.find_tool('gpg')
+
+      if gpg
+        use_tty = "--no-tty --use-agent" if ENV['RPM_GPG_AGENT']
+        Pkg::Util::Execution.ex("#{gpg} #{use_tty} --armor --detach-sign -u #{Pkg::Config.gpg_key} #{file}")
+      else
+        fail "No gpg available. Cannot sign #{file}."
+      end
+    end
+  end
+end

--- a/spec/lib/packaging/util/gpg_spec.rb
+++ b/spec/lib/packaging/util/gpg_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe "Pkg::Util::Gpg" do
+  let(:gpg)      { "/local/bin/gpg" }
+  let(:keychain) { "/usr/local/bin/keychain" }
+  let(:gpg_key)  { "abcd1234" }
+  let(:target_file) { "/tmp/file" }
+
+  before(:each) do
+    reset_env(['RPM_GPG_AGENT'])
+    Pkg::Config.gpg_key = gpg_key
+  end
+
+  describe '#kill_keychain' do
+    it "doesn't reload the keychain if already loaded" do
+      Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", TRUE)
+      Pkg::Util::Gpg.should_receive(:kill_keychain).never
+      Pkg::Util::Gpg.should_receive(:start_keychain).never
+      Pkg::Util::Gpg.load_keychain
+      Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", nil)
+    end
+
+    it "doesn't reload the keychain if ENV['RPM_GPG_AGENT'] is set" do
+      ENV['RPM_GPG_AGENT'] = 'blerg'
+      Pkg::Util::Gpg.should_receive(:kill_keychain).never
+      Pkg::Util::Gpg.should_receive(:start_keychain).never
+      Pkg::Util::Gpg.load_keychain
+    end
+
+    it 'kills and starts the keychain if not loaded already' do
+      Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", nil)
+      Pkg::Util::Gpg.should_receive(:kill_keychain).once
+      Pkg::Util::Gpg.should_receive(:start_keychain).once
+      Pkg::Util::Gpg.load_keychain
+    end
+  end
+
+  describe '#sign_file' do
+    it 'adds special flags if RPM_GPG_AGENT is set' do
+      ENV['RPM_GPG_AGENT'] = 'blerg'
+      additional_flags = "--no-tty --use-agent"
+      Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
+      Pkg::Util::Execution.should_receive(:ex).with("#{gpg}\s#{additional_flags}\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      Pkg::Util::Gpg.sign_file(target_file)
+    end
+
+    it 'signs without extra flags when RPM_GPG_AGENT is not set' do
+      Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
+      Pkg::Util::Execution.should_receive(:ex).with("#{gpg}\s\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      Pkg::Util::Gpg.sign_file(target_file)
+    end
+  end
+end

--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -40,19 +40,6 @@ def cp_p(src, dest, options = {})
   cp(src, dest, options.merge(mandatory))
 end
 
-def mv_f(src, dest, options = {})
-  mandatory = { :force => true }
-  mv(src, dest, options.merge(mandatory))
-end
-
-def scp_file_from(host, path, file)
-  %x(scp #{host}:#{path}/#{file} #{@tempdir}/#{file})
-end
-
-def scp_file_to(host, path, file)
-  %x(scp #{@tempdir}/#{file} #{host}:#{path})
-end
-
 def load_keychain
   unless @keychain_loaded
     unless ENV['RPM_GPG_AGENT']
@@ -133,17 +120,6 @@ def ask_yes_or_no
   ask_yes_or_no
 end
 
-def handle_method_failure(method, args)
-  STDERR.puts "There was an error running the method #{method} with the arguments:"
-  args.each { |param, arg| STDERR.puts "\t#{param} => #{arg}\n" }
-  STDERR.puts "The rake session is paused. Would you like to retry #{method} with these args and continue where you left off? [y,n]"
-  if ask_yes_or_no
-    send(method, args)
-  else
-    exit 1
-  end
-end
-
 def confirm_ship(files)
   STDOUT.puts "The following files have been built and are ready to ship:"
   files.each { |file| STDOUT.puts "\t#{file}\n" unless File.directory?(file) }
@@ -180,14 +156,6 @@ def remote_buildparams(host, build)
   "/tmp/#{params_dir}/#{params_file_name}"
 end
 
-def update_rpm_repo(dir)
-  Pkg::Util::Tool.check_tool('createrepo')
-  cd dir do
-    sh "createrepo --checksum=sha --database --update ."
-  end
-end
-alias :create_rpm_repo :update_rpm_repo
-
 def deprecate(old_cmd, new_cmd = nil)
   msg = "!! #{old_cmd} is deprecated."
   if new_cmd
@@ -196,10 +164,6 @@ def deprecate(old_cmd, new_cmd = nil)
   STDOUT.puts
   STDOUT.puts(msg)
   STDOUT.puts
-end
-
-def random_string(length)
-  rand(36**length).to_s(36)
 end
 
 def escape_html(uri)

--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -40,37 +40,6 @@ def cp_p(src, dest, options = {})
   cp(src, dest, options.merge(mandatory))
 end
 
-def load_keychain
-  unless @keychain_loaded
-    unless ENV['RPM_GPG_AGENT']
-      kill_keychain
-      start_keychain
-    end
-    @keychain_loaded = TRUE
-  end
-end
-
-def kill_keychain
-  %x(keychain -k mine)
-end
-
-def start_keychain
-  keychain = %x(/usr/bin/keychain -q --agents gpg --eval #{Pkg::Config.gpg_key}).chomp
-  new_env = keychain.match(/(GPG_AGENT_INFO)=([^;]*)/)
-  ENV[new_env[1]] = new_env[2]
-end
-
-def gpg_sign_file(file)
-  gpg ||= Pkg::Util::Tool.find_tool('gpg')
-
-  if gpg
-    use_tty = "--no-tty --use-agent" if ENV['RPM_GPG_AGENT']
-    sh "#{gpg} #{use_tty} --armor --detach-sign -u #{Pkg::Config.gpg_key} #{file}"
-  else
-    fail "No gpg available. Cannot sign #{file}."
-  end
-end
-
 def set_cow_envs(cow)
   elements = /base-(.*)-(.*)\.cow/.match(cow)
   if elements.nil?
@@ -285,4 +254,24 @@ end
 def ex(command)
   deprecate("ex", "Pkg::Util::Execution.ex")
   Pkg::Util::Execution.ex(command)
+end
+
+def load_keychain
+  deprecate("load_keychain", "Pkg::Util::Gpg.load_keychain")
+  Pkg::Util::Gpg.load_keychain
+end
+
+def kill_keychain
+  deprecate("kill_keychain", "Pkg::Util::Gpg.kill_keychain")
+  Pkg::Util::Gpg.kill_keychain
+end
+
+def start_keychain
+  deprecate("start_keychain", "Pkg::Util::Gpg.start_keychain")
+  Pkg::Util::Gpg.start_keychain
+end
+
+def gpg_sign_file(file)
+  deprecate("gpg_sign_file", "Pkg::Util::Gpg.sign_file")
+  Pkg::Util::Gpg.sign_file(file)
 end

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -31,6 +31,7 @@ namespace :pl do
     task :sign_repos => "pl:fetch" do
       Pkg::Util::RakeUtils.invoke_task("pl:sign_rpms", "repos")
       Pkg::Rpm::Repo.create_repos('repos')
+      Pkg::Rpm::Repo.sign_repos('repos')
       Pkg::Deb::Repo.sign_repos('repos', 'Apt repository for signed builds')
     end
 

--- a/tasks/pe_sign.rake
+++ b/tasks/pe_sign.rake
@@ -40,7 +40,7 @@ if Pkg::Config.build_pe
     # this is a separate task we can pull out later.
     desc "Sign all debian changes files staged in pkg/pe"
     task :sign_deb_changes do
-      load_keychain if Pkg::Util::Tool.find_tool('keychain')
+      Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
       sign_deb_changes("pkg/pe/deb/*/*.changes") unless Dir["pkg/pe/deb/*/*.changes"].empty?
     end
   end

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -10,7 +10,7 @@ namespace :pl do
 
   task :release_deb_rc do
     deprecate("pl:release_deb_rc", "pl:release_deb")
-    load_keychain if Pkg::Util::Tool.find_tool('keychain')
+    Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
     Pkg::Util::RakeUtils.invoke_task("pl:deb_all_rc")
     Pkg::Util::RakeUtils.invoke_task("pl:sign_deb_changes")
     if confirm_ship(FileList["pkg/deb/**/*"])
@@ -20,7 +20,7 @@ namespace :pl do
 
   task :release_deb_final do
     deprecate("pl:release_deb_final", "pl:release_deb")
-    load_keychain if Pkg::Util::Tool.find_tool('keychain')
+    Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
     Pkg::Util::RakeUtils.invoke_task("pl:deb_all")
     Pkg::Util::RakeUtils.invoke_task("pl:sign_deb_changes")
     if confirm_ship(FileList["pkg/deb/**/*"])
@@ -29,7 +29,7 @@ namespace :pl do
   end
 
   task :release_deb do
-    load_keychain if Pkg::Util::Tool.find_tool('keychain')
+    Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
     Pkg::Util::RakeUtils.invoke_task("pl:deb_all")
     Pkg::Util::RakeUtils.invoke_task("pl:sign_deb_changes")
     if confirm_ship(FileList["pkg/deb/**/*"])

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -58,8 +58,8 @@ namespace :pl do
   task :sign_tar do
     unless Pkg::Config.vanagon_project
       File.exist?("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz") or fail "No tarball exists. Try rake package:tar?"
-      load_keychain if Pkg::Util::Tool.find_tool('keychain', :required => false)
-      gpg_sign_file "pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz"
+      Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
+      Pkg::Util::Gpg.sign_file "pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz"
     end
   end
 
@@ -115,7 +115,7 @@ namespace :pl do
     task :sign_gem do
       FileList["pkg/#{Pkg::Config.gem_name}-#{Pkg::Config.gemversion}*.gem"].each do |gem|
         puts "signing gem #{gem}"
-        gpg_sign_file(gem)
+        Pkg::Util::Gpg.sign_file(gem)
       end
     end
   end
@@ -140,11 +140,11 @@ namespace :pl do
   desc "Sign generated debian changes files. Defaults to PL Key, pass GPG_KEY to override"
   task :sign_deb_changes do
     begin
-      load_keychain if Pkg::Util::Tool.find_tool('keychain')
+      Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
       sign_deb_changes("pkg/deb/*/*.changes") unless Dir["pkg/deb/*/*.changes"].empty?
       sign_deb_changes("pkg/deb/*.changes") unless Dir["pkg/deb/*.changes"].empty?
     ensure
-      %x(keychain -k mine)
+      Pkg::Util::Gpg.kill_keychain
     end
   end
 


### PR DESCRIPTION
Previously our rpm repos were unsigned. However, this breaks sles repo
usage that expects the repomd files to be signed. This commit begins
signing all repomd.xml files in a new sign_repos method, which is called
in the nightly_repos.rake tasks. Non-sles platforms happily ignore
signed repomd.xml files, so this is safe to apply everywhere.

This PR also includes moving the gpg and keychain methods into Pkg::Util::Gpg.