### PR TITLE
(maint) Use correct dist macro definition in mock_defines

### DIFF
--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -174,7 +174,7 @@ def mock_defines(mock_config)
   version = mock_el_ver(mock_config)
   defines = ""
   if version =~ /^(4|5)$/ or family == "sles"
-    defines = %Q(--define "%dist .#{family}#{version}" \
+    defines = %Q(--define "dist .#{family}#{version}" \
       --define "_source_filedigest_algorithm 1" \
       --define "_binary_filedigest_algorithm 1" \
       --define "_binary_payload w9.gzdio" \


### PR DESCRIPTION
This updates the dist macro. As explained in RE-4897:

> Previously we incorrectly specified the dist macro. All --defines passed
> along the command line are accessed using % in the spec file, but
> defined without it on the command line. This commit removes the % so
> that the dist macro can be correctly defined for platforms that don't
> already have it available (el4, el5, sles10).