### PR TITLE
(RE-4907) Update nightly_repos to avoid ref == version problems

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -125,8 +125,9 @@ namespace :pl do
 
         # If we're using the version strategy instead of ref, here we shuffle
         # around directories and munge repo_configs to replace the ref with the
-        # version
-        if versioning == 'version'
+        # version. In the case that get_dot_version and ref are the same, we
+        # have nothing to do, so the conditional is skipped.
+        if versioning == 'version' && Pkg::Util::Version.get_dot_version != Pkg::Config.ref
           Dir.glob("#{local_target}/repo_configs/**/*").select { |t_config| File.file?(t_config) }.each do |config|
             new_contents = File.read(config)
             new_contents.gsub!(%r{#{Pkg::Config.ref}}, Pkg::Util::Version.get_dot_version)


### PR DESCRIPTION
When version == ref, the repo_configs will be named the same and moving
them onto themself won't work, and will fail the job. This commit avoids
the entire rewrite conditional in the case that the ref is equal to the
version, as it is not needed then.