### PR TITLE
(RE-4956) Add osx signing to nightly repos tasks

### DIFF
--- a/lib/packaging/osx.rb
+++ b/lib/packaging/osx.rb
@@ -1,6 +1,6 @@
 module Pkg::OSX
   class << self
-    def sign_osx
+    def sign
       use_identity = "-i #{Pkg::Config.osx_signing_ssh_key}" unless Pkg::Config.osx_signing_ssh_key.nil?
 
       ssh_host_string = "#{use_identity} #{ENV['USER']}@#{Pkg::Config.osx_signing_server}"

--- a/lib/packaging/osx.rb
+++ b/lib/packaging/osx.rb
@@ -1,6 +1,6 @@
 module Pkg::OSX
   class << self
-    def sign
+    def sign(target_dir = 'pkg')
       use_identity = "-i #{Pkg::Config.osx_signing_ssh_key}" unless Pkg::Config.osx_signing_ssh_key.nil?
 
       ssh_host_string = "#{use_identity} #{ENV['USER']}@#{Pkg::Config.osx_signing_server}"
@@ -9,9 +9,9 @@ module Pkg::OSX
       work_dir  = "/tmp/#{rand_string}"
       mount     = File.join(work_dir, "mount")
       signed    = File.join(work_dir, "signed")
-      output    = File.join("pkg", "apple", "#{Pkg::Config.yum_repo_name}")
+      output    = File.join(target_dir, "apple", "#{Pkg::Config.yum_repo_name}")
       Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, "mkdir -p #{mount} #{signed}")
-      dmgs = Dir.glob("pkg/apple/**/*.dmg")
+      dmgs = Dir.glob("#{target_dir}/apple/**/*.dmg")
       Pkg::Util::Net.rsync_to(dmgs.join(" "), rsync_host_string, work_dir)
       Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, %Q[for dmg in #{dmgs.map { |d| File.basename(d, ".dmg") }.join(" ")}; do
         /usr/bin/hdiutil attach #{work_dir}/$dmg.dmg -mountpoint #{mount} -nobrowse -quiet ;

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -33,6 +33,7 @@ namespace :pl do
       Pkg::Rpm::Repo.create_repos('repos')
       Pkg::Rpm::Repo.sign_repos('repos')
       Pkg::Deb::Repo.sign_repos('repos', 'Apt repository for signed builds')
+      Pkg::OSX.sign('repos') unless Dir['repos/apple/**/*.dmg'].empty?
     end
 
     task :ship_signed_repos, [:target_prefix] => "pl:fetch" do |t, args|

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -150,7 +150,7 @@ namespace :pl do
 
   desc "Sign OSX packages"
   task :sign_osx => "pl:fetch" do
-    Pkg::OSX.sign_osx unless Dir['pkg/apple/**/*.dmg'].empty?
+    Pkg::OSX.sign unless Dir['pkg/apple/**/*.dmg'].empty?
   end
 
   ##


### PR DESCRIPTION
This PR adds osx signing automation to the nightly repos task. To do that it adds a parameter to the sign method of Pkg::OSX.