### PR TITLE
(CPR-157) Allow packaging repo to build deb repos with more arches

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -158,7 +158,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; )
               f.puts "Origin: Puppet Labs
 Label: Puppet Labs
 Codename: #{dist}
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64 armel armhf powerpc sparc mips mipsel all
 Components: #{subrepo}
 Description: #{message} for #{dist}
 SignWith: #{Pkg::Config.gpg_key}"


### PR DESCRIPTION
Previously we would only look for i386/amd64 architecture for packaging.
This commit adds all sorts of other arches. If we have no packages of
that arch, nothing fails.