### PR TITLE
(maint) Remove all as an arch

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -158,7 +158,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; )
               f.puts "Origin: Puppet Labs
 Label: Puppet Labs
 Codename: #{dist}
-Architectures: i386 amd64 arm64 armel armhf powerpc sparc mips mipsel all
+Architectures: i386 amd64 arm64 armel armhf powerpc sparc mips mipsel
 Components: #{subrepo}
 Description: #{message} for #{dist}
 SignWith: #{Pkg::Config.gpg_key}"


### PR DESCRIPTION
Apparently all is some sort of meta-arch and doesn't need to specified,
and if you do specify it, things blow up. Who knew?