### PR TITLE
(maint) Remove Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ script: "bundle exec $CHECK"
 notifications:
   email: false
 rvm:
-  - 1.8.7-p374
   - 1.9.3
   - 2.0.0
   - 2.1.1
@@ -14,8 +13,6 @@ env:
 
 matrix:
   exclude:
-    - rvm: 1.8.7-p374
-      env: "CHECK='rubocop -D'"
     - rvm: 1.9.3
       env: "CHECK='rubocop -D'"
     - rvm: 2.0.0


### PR DESCRIPTION
We no longer support Ruby 1.8 in the packaging repo. Previously, this
was kept around because we were using some builders that only had Ruby
1.8 available for use. However, we have since gotten rid of those
builders, and now have the luxury of having at least Ruby 1.9 in all
situations where we will use the automation in the packaging repo.