### PR TITLE
(maint) Remove Ruby 1.8 specifics from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ group :development, :test do
   gem 'rspec', "~> 2.14.1"
   gem 'pry'
   gem 'win32console', :platforms => [:mingw_18, :mingw_19]
-  gem 'rubocop', "~> 0.24.1", :require => false unless RUBY_VERSION =~ /^1.8/
-  gem 'json_pure', :require => true if RUBY_VERSION =~ /^1.8/
+  gem 'rubocop', "~> 0.24.1", :require => false
 end


### PR DESCRIPTION
We no longer support Ruby 1.8 in the packaging repo. We can now remove
Ruby 1.8 specifics from the Gemfile