### PR TITLE
(MAINT) Let Travis use modern infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 script: "bundle exec $CHECK"
+sudo: false
 notifications:
   email: false
 rvm:


### PR DESCRIPTION
Without `sudo: false` in .travis.yml, the tests will run on legacy
travis infrastructure; this means that tests take FOREVER to run.
Since we shouldn't need root access to test this repo, we can speed
up our runs by disabling root access. Eg. `sudo: false`.