### PR TITLE
(RE-5613) Don't fail if no swix packages to sign

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -66,10 +66,11 @@ namespace :pl do
   desc "Sign the Arista EOS swix packages, defaults to PL key, pass GPG_KEY to override or edit build_defaults"
   task :sign_swix do
     packages = Dir["pkg/eos/**/*.swix"]
-    fail "No swix packages exist." if packages.empty?
-    Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
-    packages.each do |swix_package|
-      Pkg::Util::Gpg.sign_file swix_package
+    unless packages.empty?
+      Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
+      packages.each do |swix_package|
+        Pkg::Util::Gpg.sign_file swix_package
+      end
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the `pl:sign_swix` and
`pl:sign_all` tasks fail if there are no swix
packages to sign. Current enterprise-dist
package promotion workflow removes packages
that won't be promoted into enterprise-dist
before invoking packaging's `pl:sign_all`
task. This means swix packages are removed
before the signing attempt, which causes
package promotion to fail, since there are
no swix packages to sign.

This commit adjusts the `pl:sign_swix` task
so it does not fail if there are no swix packages
to sign. (This is similar to the current
behavior of `sign_svr4` and `sign_osx`.)