### PR TITLE
(RE-5573) Update tar creation to set group and owner to root 

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -65,7 +65,7 @@ namespace :pl do
           if Pkg::Util::File.empty_dir?(path_to_repo)
             warn "Skipping #{name_of_archive} because it (#{path_to_repo}) has no files"
           else
-            Pkg::Util::Execution.ex("#{tar} --owner=0 --group=0 -czf #{File.join("repos", "#{name_of_archive}.tar.gz")} #{path_to_repo}")
+            Pkg::Util::Execution.ex("#{tar} --owner=0 --group=0 --create --gzip --file #{File.join("repos", "#{name_of_archive}.tar.gz")} #{path_to_repo}")
           end
         end
       end

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -65,7 +65,7 @@ namespace :pl do
           if Pkg::Util::File.empty_dir?(path_to_repo)
             warn "Skipping #{name_of_archive} because it (#{path_to_repo}) has no files"
           else
-            Pkg::Util::Execution.ex("#{tar} -czf #{File.join("repos", "#{name_of_archive}.tar.gz")} #{path_to_repo}")
+            Pkg::Util::Execution.ex("#{tar} --owner=0 --group=0 -czf #{File.join("repos", "#{name_of_archive}.tar.gz")} #{path_to_repo}")
           end
         end
       end


### PR DESCRIPTION
Previously the tar command used to pack up repos did not specify owner
or group, which meant that it was set to the user running the task,
which is generally jenkins. This user/group won't always exist on the
system that is fetching the tarballs, so this commit updates the tar
invocation to also pass --owner=0 --group=0 to ensure that it is set to
root or root's equivalent when packing.