### PR TITLE
(maint) Platform codenames can't be symbols

### DIFF
--- a/lib/packaging/config/platforms.rb
+++ b/lib/packaging/config/platforms.rb
@@ -29,7 +29,7 @@ module Pkg::Platforms
     },
 
     'cumulus' => {
-      '2.2' => { :codename => :'cumulus', :architectures => ['amd64'], :repo => true, :package_format => 'deb', },
+      '2.2' => { :codename => 'cumulus', :architectures => ['amd64'], :repo => true, :package_format => 'deb', },
     },
 
     'aix' => {


### PR DESCRIPTION
In the initial work I neglected to update the cumulus codename to be a
string and not a symbol in the platform hash. This breaks the whitelist
automation if cumulus is included.