### PR TITLE
(RE-5550) Update link_signed_repos task

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -204,6 +204,30 @@ namespace :pl do
       puts "Shipped '#{Pkg::Config.ref}' (#{Pkg::Config.version}) of '#{Pkg::Config.project}' into the puppet-agent repos."
     end
 
+    # We want to keep the puppet-agent repos at a higher level and them link
+    # them into the correct version of PE. This is a private method and is
+    # called from the internal_puppet-agent-ship jenkins job
+    task :link_signed_repos, [:target_host, :pa_source, :pe_target, :versioning] => ["pl:fetch"] do |t, args|
+      target_host = args.target_host or fail ":target_host is a required argument for #{t}"
+      pa_source = args.pa_source or fail ":pa_source is a required argument for #{t}"
+      pe_target = args.pe_target or fail ":pe_target is a required argument for #{t}"
+      versioning = args.versioning or fail ":versioning is a required argument for #{t}"
+
+      if versioning == 'ref'
+        local_pa = File.join(pa_source, Pkg::Config.ref)
+        local_pe = File.join(pe_target, Pkg::Config.ref)
+        local_pe_latest = "#{pe_target}-latest"
+      elsif versioning == 'version'
+        local_pa = File.join(pa_source, Pkg::Util::Version.get_dot_version)
+        local_pe = File.join(pe_target, Pkg::Util::Version.get_dot_version)
+        local_pe_latest = "#{pe_target}-latest"
+      end
+
+      Pkg::Util::Net.remote_ssh_cmd(target_host, "mkdir -p '#{pe_target}'")
+      Pkg::Util::Net.remote_ssh_cmd(target_host, "ln -sf '#{local_pa}' '#{local_pe_latest}'")
+      Pkg::Util::Net.remote_ssh_cmd(target_host, "ln -sf '#{local_pa}' '#{local_pe}'")
+    end
+
     task :nightly_repos => ["pl:fetch"] do
       Pkg::Util::RakeUtils.invoke_task("pl:jenkins:generate_signed_repos", 'nightly')
     end


### PR DESCRIPTION
The task now takes a target host, the directory the puppet-agent source
is expected to be found in (minus the version/ref), the pe target to
link puppet agent into, and the same versioning param included in other
jobs (takes versioning/ref). The following rake task should link
puppet-agent into pe: `rake
pl:jenkins:link_signed_repos[agent-downloads.delivery.puppetlabs.net,/opt/puppet-agent,/opt/puppet-agent/${remote_prefix}/puppet-agent,version]`