### PR TITLE
(maint) Let's actually ship ips packages during the uber_ship

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -250,7 +250,7 @@ namespace :pl do
 
     desc "Retrieve packages built by jenkins, sign, and ship all!"
     task :uber_ship => "pl:fetch" do
-      uber_tasks = ["jenkins:retrieve", "jenkins:sign_all", "uber_ship", "remote:update_apt_repo", "remote:update_yum_repo"]
+      uber_tasks = ["jenkins:retrieve", "jenkins:sign_all", "uber_ship", "remote:update_apt_repo", "remote:update_yum_repo", "remote:update_ips_repo"]
       uber_tasks.map { |t| "pl:#{t}" }.each { |t| Rake::Task[t].invoke }
       Rake::Task["pl:jenkins:ship"].invoke("shipped")
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -83,27 +83,26 @@ namespace :pl do
   task :update_ips_repo  => 'pl:fetch' do
     if Dir['pkg/ips/pkgs/**/*'].empty? && Dir['pkg/solaris/11/**/*'].empty?
       STDOUT.puts "There aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11. Maybe something went wrong?"
-      fail
-    end
-
-    if !Dir['pkg/ips/pkgs/**/*'].empty?
-      source_dir = 'pkg/ips/pkgs/'
     else
-      source_dir = 'pkg/solaris/11/'
+      if !Dir['pkg/ips/pkgs/**/*'].empty?
+        source_dir = 'pkg/ips/pkgs/'
+      else
+        source_dir = 'pkg/solaris/11/'
+      end
+
+      tmpdir, _ = Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, 'mktemp -d -p /var/tmp', true)
+      tmpdir.chomp!
+
+      Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
+
+      remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
+      sudo pkgrecv -s $pkg -d #{Pkg::Config.ips_path} '*';
+      done)
+
+      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, remote_cmd)
+      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
+      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
     end
-
-    tmpdir, _ = Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, 'mktemp -d -p /var/tmp', true)
-    tmpdir.chomp!
-
-    Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
-
-    remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
-    sudo pkgrecv -s $pkg -d #{Pkg::Config.ips_path} '*';
-    done)
-
-    Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, remote_cmd)
-    Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
-    Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
   end if Pkg::Config.build_ips || Pkg::Config.vanagon_project
 
   desc "Upload ips p5p packages to downloads"


### PR DESCRIPTION
Previously the uber_ship neglected to include update_ips_repo, which is
good because any builds that didn't have solaris 11 packages would have
failed in a large ball of flames. This commit adds update_ips_repo to
the uber_ship task and also updates the task itself to not fail but just
to helpfully warn so that builds without solaris 11 packages won't fail.