### PR TITLE
(maint) Move update_ips_repo to the remote namespace

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -79,31 +79,34 @@ namespace :pl do
     end
   end
 
-  desc "Update remote ips repository on #{Pkg::Config.ips_host}"
-  task :update_ips_repo  => 'pl:fetch' do
-    if Dir['pkg/ips/pkgs/**/*'].empty? && Dir['pkg/solaris/11/**/*'].empty?
-      STDOUT.puts "There aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11. Maybe something went wrong?"
-    else
-      if !Dir['pkg/ips/pkgs/**/*'].empty?
-        source_dir = 'pkg/ips/pkgs/'
+  namespace :remote do
+    desc "Update remote ips repository on #{Pkg::Config.ips_host}"
+    task :update_ips_repo  => 'pl:fetch' do
+      if Dir['pkg/ips/pkgs/**/*'].empty? && Dir['pkg/solaris/11/**/*'].empty?
+        STDOUT.puts "There aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11. Maybe something went wrong?"
       else
-        source_dir = 'pkg/solaris/11/'
-      end
 
-      tmpdir, _ = Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, 'mktemp -d -p /var/tmp', true)
-      tmpdir.chomp!
+        if !Dir['pkg/ips/pkgs/**/*'].empty?
+          source_dir = 'pkg/ips/pkgs/'
+        else
+          source_dir = 'pkg/solaris/11/'
+        end
 
-      Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
+        tmpdir, _ = Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, 'mktemp -d -p /var/tmp', true)
+        tmpdir.chomp!
 
-      remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
+        Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
+
+        remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
       sudo pkgrecv -s $pkg -d #{Pkg::Config.ips_path} '*';
       done)
 
-      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, remote_cmd)
-      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
-      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
-    end
-  end if Pkg::Config.build_ips || Pkg::Config.vanagon_project
+        Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, remote_cmd)
+        Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
+        Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
+      end
+    end if Pkg::Config.build_ips || Pkg::Config.vanagon_project
+  end
 
   desc "Upload ips p5p packages to downloads"
   task :ship_ips => 'remote:update_ips_repo' if Pkg::Config.build_ips || Pkg::Config.vanagon_project


### PR DESCRIPTION
This improves consistency with the other update_*_repo tasks that
already live under remote.