### PR TITLE
(maint) Also ship aix rpms in the uber_ship

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -1,7 +1,7 @@
 namespace :pl do
   desc "Ship mocked rpms to #{Pkg::Config.yum_host}"
   task :ship_rpms do
-    ["cisco-wrlinux", "el", "eos", "fedora", "huaweios", "nxos", "sles"].each do |dist|
+    ["aix", "cisco-wrlinux", "el", "eos", "fedora", "huaweios", "nxos", "sles"].each do |dist|
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
         pkgs = Dir["pkg/#{dist}/**/*.rpm"].map { |f| "'#{f.gsub("pkg/#{dist}/", "#{Pkg::Config.yum_repo_path}/#{dist}/")}'" }
         unless pkgs.empty?


### PR DESCRIPTION
Previously aix rpms couldn't be uber_shipped because they weren't
included in the ship_rpms search. This commit adds the aix directory to
the ship task, to ensure they will be shipped.