### PR TITLE
(RE-1198) Change how/where deb packages are signed and deployed

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -298,11 +298,29 @@ module Pkg
         @apt_signing_server || deprecated_apt_signing_server
       end
 
+      # We're overriding the accessor for @apt_repo_staging_path so that
+      # a deprecation warning will be raised if @apt_repo_path is used as a
+      # path for staged repos.
+      #
+      # @return [String]
+      #   the pathname on the signing server where apt packages copied to
+      #   before being signed and shipped.
+      def apt_repo_staging_path
+        @apt_repo_staging_path || deprecated_apt_repo_staging_path
+      end
+
       # This function will hopefully go away once we've got build_data and
       # build_defaults ironed out everywhere.
       def deprecated_apt_signing_server
         warn "using :apt_host to sign packages is deprecated. Please update build_defaults.yaml to use :apt_signing_server"
         @apt_host
+      end
+
+      # This function will hopefully go away once we've got build_data and
+      # build_defaults ironed out everywhere.
+      def deprecated_apt_repo_staging_path
+        warn "using :apt_repo_path to ship packages is deprecated. Please update build_defaults.yaml to use :apt_repo_staging_path"
+        @apt_repo_path
       end
 
       def deb_build_targets

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -288,6 +288,23 @@ module Pkg
         mock.match(/pupent(-\d\.\d)?-([a-z]*)(\d*)-([^-]*)/)[2..4]
       end
 
+      # We're overriding the accessor for @apt_signing_server so that
+      # a deprecation warning will be raised if @apt_host is used as a signing server.
+      #
+      # @return [String]
+      #   the hostname of the server where apt repos and/or
+      #   packages should be signed before being shipped.
+      def apt_signing_server
+        @apt_signing_server || deprecated_apt_signing_server
+      end
+
+      # This function will hopefully go away once we've got build_data and
+      # build_defaults ironed out everywhere.
+      def deprecated_apt_signing_server
+        warn "using :apt_host to sign packages is deprecated. Please update build_defaults.yaml to use :apt_signing_server"
+        @apt_host
+      end
+
       def deb_build_targets
         if self.vanagon_project
           self.deb_targets.split(' ')

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -3,6 +3,7 @@
 module Pkg::Params
   BUILD_PARAMS = [:apt_host,
                   :apt_repo_path,
+                  :apt_repo_staging_path,
                   :apt_repo_name,
                   :apt_repo_url,
                   :apt_repo_command,
@@ -147,6 +148,7 @@ module Pkg::Params
   #
   ENV_VARS = [{ :var => :apt_host,                :envvar => :APT_HOST },
               { :var => :apt_repo_path,           :envvar => :APT_REPO },
+              { :var => :apt_repo_staging_path,   :envvar => :APT_REPO_STAGING_PATH },
               { :var => :apt_signing_server,      :envvar => :APT_SIGNING_SERVER },
               { :var => :build_dmg,               :envvar => :DMG,             :type => :bool },
               { :var => :build_doc,               :envvar => :DOC,             :type => :bool },

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -6,6 +6,7 @@ module Pkg::Params
                   :apt_repo_name,
                   :apt_repo_url,
                   :apt_repo_command,
+                  :apt_signing_server,
                   :author,
                   :benchmark,
                   :build_date,
@@ -146,6 +147,7 @@ module Pkg::Params
   #
   ENV_VARS = [{ :var => :apt_host,                :envvar => :APT_HOST },
               { :var => :apt_repo_path,           :envvar => :APT_REPO },
+              { :var => :apt_signing_server,      :envvar => :APT_SIGNING_SERVER },
               { :var => :build_dmg,               :envvar => :DMG,             :type => :bool },
               { :var => :build_doc,               :envvar => :DOC,             :type => :bool },
               { :var => :build_gem,               :envvar => :GEM,             :type => :bool },

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -221,8 +221,8 @@ SignWith: #{Pkg::Config.gpg_key}"
     # @return [String] an rsync command that can be executed on a remote host
     #   to copy local content from that host to a remote node.
     def deploy_repos(path, origin_server, destination_server, dryrun = false)
-      command = remote_repo_deployment_command(path, destination_server)
-      Pkg::Util::Net.remote_ssh_cmd(origin_server, command, dryrun)
+      command = remote_repo_deployment_command(path, destination_server, dryrun)
+      Pkg::Util::Net.remote_ssh_cmd(origin_server, command)
     end
 
   end

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -195,11 +195,9 @@ SignWith: #{Pkg::Config.gpg_key}"
       options.join("\s")
     end
 
-    def deploy_repos(path, from, to)
-      command = remote_repo_deployment_command(path, from, to)
-
-      puts command
-      # Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.apt_signing_server, command)
+    def deploy_repos(path, origin_server, destination_server)
+      command = remote_repo_deployment_command(path, destination_server)
+      Pkg::Util::Net.remote_ssh_cmd(origin_server, command)
     end
 
   end

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -171,5 +171,36 @@ SignWith: #{Pkg::Config.gpg_key}"
         warn "No repos found to sign. Maybe you didn't build any debs, or the repo creation failed?"
       end
     end
+
+    def remote_repo_deployment_command(filepath, destination, dryrun = false)
+      path = Pathname.new(filepath)
+
+      options = %w(
+        rsync
+        --hard-links
+        --links
+        --omit-dir-times
+        --progress
+        --recursive
+        --update
+        --verbose
+        --no-perms
+        --no-owner
+        --no-group
+      )
+
+      options << '--dry-run' if dryrun
+      options << path
+      options << "#{destination}:#{path.parent}"
+      options.join("\s")
+    end
+
+    def deploy_repos(path, from, to)
+      command = remote_repo_deployment_command(path, from, to)
+
+      puts command
+      # Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.apt_signing_server, command)
+    end
+
   end
 end

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -217,9 +217,6 @@ SignWith: #{Pkg::Config.gpg_key}"
     # @param filepath [String] path for Deb repos on local filesystem
     # @param destination [String] remote host to send rsynced content to
     # @param dryrun [Boolean] whether or not to use '--dry-run'
-    #
-    # @return [String] an rsync command that can be executed on a remote host
-    #   to copy local content from that host to a remote node.
     def deploy_repos(path, origin_server, destination_server, dryrun = false)
       command = remote_repo_deployment_command(path, destination_server, dryrun)
       Pkg::Util::Net.remote_ssh_cmd(origin_server, command)

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -195,9 +195,9 @@ SignWith: #{Pkg::Config.gpg_key}"
       options.join("\s")
     end
 
-    def deploy_repos(path, origin_server, destination_server)
+    def deploy_repos(path, origin_server, destination_server, dryrun = false)
       command = remote_repo_deployment_command(path, destination_server)
-      Pkg::Util::Net.remote_ssh_cmd(origin_server, command)
+      Pkg::Util::Net.remote_ssh_cmd(origin_server, command, dryrun)
     end
 
   end

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -172,6 +172,17 @@ SignWith: #{Pkg::Config.gpg_key}"
       end
     end
 
+    # @deprecated this command will die a painful death when we are
+    #   able to sit down with Operations and refactor our distribution infra.
+    #   For now, it's extremely debian specific, which is why it lives here.
+    #   - Ryan McKern 11/2015
+    #
+    # @param filepath [String] path for Deb repos on local filesystem
+    # @param destination [String] remote host to send rsynced content to
+    # @param dryrun [Boolean] whether or not to use '--dry-run'
+    #
+    # @return [String] an rsync command that can be executed on a remote host
+    #   to copy local content from that host to a remote node.
     def remote_repo_deployment_command(filepath, destination, dryrun = false)
       path = Pathname.new(filepath)
 
@@ -195,6 +206,20 @@ SignWith: #{Pkg::Config.gpg_key}"
       options.join("\s")
     end
 
+    # @deprecated this command will die a painful death when we are
+    #   able to sit down with Operations and refactor our distribution infra.
+    #   It's extremely Debian specific due to how Debian repos are signed,
+    #   which is why it lives here.
+    #   Yes, it is basically just a layer of indirection around the task
+    #   of copying content from one node to another. No, I am not proud
+    #   of it. - Ryan McKern 11/2015
+    #
+    # @param filepath [String] path for Deb repos on local filesystem
+    # @param destination [String] remote host to send rsynced content to
+    # @param dryrun [Boolean] whether or not to use '--dry-run'
+    #
+    # @return [String] an rsync command that can be executed on a remote host
+    #   to copy local content from that host to a remote node.
     def deploy_repos(path, origin_server, destination_server, dryrun = false)
       command = remote_repo_deployment_command(path, destination_server)
       Pkg::Util::Net.remote_ssh_cmd(origin_server, command, dryrun)

--- a/tasks/fetch.rake
+++ b/tasks/fetch.rake
@@ -24,6 +24,7 @@ team_data_url = data_repo + '/' + team_data_branch
 # It uses curl to download the files, and places them in a temporary
 # directory, e.g. /tmp/somedirectory/{project,team}/Pkg::Config.builder_data_file
 namespace :pl do
+  desc "retrieve build-data configurations to override/extend local build_defaults"
   task :fetch do
     # Remove .packaging directory from old-style extras loading
     rm_rf "#{ENV['HOME']}/.packaging" if File.directory?("#{ENV['HOME']}/.packaging")

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -70,7 +70,7 @@ namespace :pl do
   task :ship_debs do
     Pkg::Util::Execution.retry_on_fail(:times => 3) do
       if File.directory?("pkg/deb")
-        Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.Config.apt_signing_server, Pkg::Config.apt_repo_staging_path)
+        Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.apt_signing_server, Pkg::Config.apt_repo_staging_path)
       else
         warn "No deb packages found to ship; nothing to do"
       end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -95,6 +95,12 @@ namespace :pl do
     end
   end
 
+  desc "Move signed debs from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}"
+  task :deploy_debs do
+    Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      Pkg::Deb::Repo.deploy_repos(Pkg::Config.apt_repo_staging_path, Pkg::Config.apt_signing_server, Pkg::Config.apt_host)
+    end
+  end
 
   namespace :remote do
     desc "Update remote ips repository on #{Pkg::Config.ips_host}"

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -72,7 +72,7 @@ namespace :pl do
       if File.directory?("pkg/deb")
         Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.Config.apt_signing_server, Pkg::Config.apt_repo_staging_path)
       else
-        puts "No deb packages found to ship; nothing to do"
+        warn "No deb packages found to ship; nothing to do"
       end
     end
   end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -97,8 +97,15 @@ namespace :pl do
 
   desc "Move signed debs from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}"
   task :deploy_debs do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
-      Pkg::Deb::Repo.deploy_repos(Pkg::Config.apt_repo_staging_path, Pkg::Config.apt_signing_server, Pkg::Config.apt_host)
+    puts "Really run remote rsync to deploy Debian repos to #{Pkg::Config.apt_host}"
+    if ask_yes_or_no
+      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+        Pkg::Deb::Repo.deploy_repos(
+          Pkg::Config.apt_repo_staging_path,
+          Pkg::Config.apt_signing_server,
+          Pkg::Config.apt_host
+        )
+      end
     end
   end
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -103,7 +103,8 @@ namespace :pl do
         Pkg::Deb::Repo.deploy_repos(
           Pkg::Config.apt_repo_staging_path,
           Pkg::Config.apt_signing_server,
-          Pkg::Config.apt_host
+          Pkg::Config.apt_host,
+          ENV['DRYRUN']
         )
       end
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -40,7 +40,7 @@ namespace :pl do
     task :freight => :update_apt_repo
 
     desc "Update remote apt repository on '#{Pkg::Config.apt_signing_server}'"
-    task :update_apt_repo do
+    task :update_apt_repo => 'pl:fetch' do
       apt_whitelist = {
         :apt_repo_name => "__REPO_NAME__",
         :apt_repo_path => "__REPO_PATH__",

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -71,6 +71,8 @@ namespace :pl do
     Pkg::Util::Execution.retry_on_fail(:times => 3) do
       if File.directory?("pkg/deb")
         Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.Config.apt_signing_server, Pkg::Config.apt_repo_staging_path)
+      else
+        puts "No deb packages found to ship; nothing to do"
       end
     end
   end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -97,7 +97,7 @@ namespace :pl do
 
   desc "Move signed debs from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}"
   task :deploy_debs do
-    puts "Really run remote rsync to deploy Debian repos to #{Pkg::Config.apt_host}"
+    puts "Really run remote rsync to deploy Debian repos to #{Pkg::Config.apt_host}? [y,n]"
     if ask_yes_or_no
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
         Pkg::Deb::Repo.deploy_repos(

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -66,11 +66,11 @@ namespace :pl do
     end
   end
 
-  desc "Ship cow-built debs to #{Pkg::Config.apt_host}"
+  desc "Ship cow-built debs to #{Pkg::Config.apt_signing_server}"
   task :ship_debs do
     Pkg::Util::Execution.retry_on_fail(:times => 3) do
       if File.directory?("pkg/deb")
-        Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.apt_host, Pkg::Config.apt_repo_path)
+        Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.Config.apt_signing_server, Pkg::Config.apt_repo_staging_path)
       end
     end
   end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -39,7 +39,7 @@ namespace :pl do
 
     task :freight => :update_apt_repo
 
-    desc "Update remote apt repository on '#{Pkg::Config.apt_host}'"
+    desc "Update remote apt repository on '#{Pkg::Config.apt_signing_server}'"
     task :update_apt_repo do
       apt_whitelist = {
         :apt_repo_name => "__REPO_NAME__",
@@ -49,13 +49,18 @@ namespace :pl do
         :gpg_key       => "__GPG_KEY__",
       }
 
-      STDOUT.puts "Really run remote repo update on '#{Pkg::Config.apt_host}'? [y,n]"
+      STDOUT.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       if ask_yes_or_no
         if Pkg::Config.apt_repo_command
-          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.apt_host, Pkg::Util::Misc.search_and_replace(Pkg::Config.apt_repo_command, apt_whitelist))
+          Pkg::Util::Net.remote_ssh_cmd(
+            Pkg::Config.apt_signing_server,
+            Pkg::Util::Misc.search_and_replace(
+              Pkg::Config.apt_repo_command,
+              apt_whitelist
+            )
+          )
         else
-          override = "OVERRIDE=1" if ENV['OVERRIDE']
-          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.apt_host, "rake -f /opt/repository/Rakefile freight #{override}")
+          warn %(Pkg::Config#apt_repo_command returned something unexpected, so no attempt will be made to update remote repos)
         end
       end
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -101,7 +101,7 @@ namespace :pl do
     if ask_yes_or_no
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
         Pkg::Deb::Repo.deploy_repos(
-          Pkg::Config.apt_repo_staging_path,
+          Pkg::Config.apt_repo_path,
           Pkg::Config.apt_signing_server,
           Pkg::Config.apt_host,
           ENV['DRYRUN']


### PR DESCRIPTION
`:apt_signing_server` is a new value that can be added to a project's `build_defaults.yaml` file or the [build_data](https://github.com/puppetlabs/build-data) repo. It allows a user to target a new Apt repo signing server, hopefully divorced of the public shipping infrastructure (since we used to just reuse the `:apt_host` value).