### PR TITLE
(maint) Add nil check for foss_platforms in nightly_repos.rake

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -148,7 +148,7 @@ namespace :pl do
       target_basedir = args.target_basedir or fail ":target_basedir is a required argument to #{t}"
       include_paths = []
 
-      if args.foss_only && !Pkg::Config.foss_platforms.empty?
+      if args.foss_only && Pkg::Config.foss_platforms && !Pkg::Config.foss_platforms.empty?
         Pkg::Config.foss_platforms.each do |platform|
           include_paths << Pkg::Util::Platform.repo_path(platform)
           if Pkg::Util::Platform.repo_config_path(platform)


### PR DESCRIPTION
Previously the checks were insufficient in the nightly repos ship job
for projects that have not defined foss_platforms to whitelist nightly
repo ships. If foss_platforms were nil, the empty? check would explode
in a empty? not defined for nilclass error. This is bad. This commit
avoids that problem by ensuring that foss_platforms is set and non-nil
before running .empty? on it.