### PR TITLE
(maint) Add debug flag to Pkg::Util::Execution.ex

### DIFF
--- a/lib/packaging/util/execution.rb
+++ b/lib/packaging/util/execution.rb
@@ -21,11 +21,18 @@ module Pkg::Util::Execution
     # only true or false depending on its success or failure. With `ex(cmd)` we
     # purport to both return the results of the command execution (ala `%x{cmd}`)
     # while also raising an exception if a command does not succeed (ala `sh "cmd"`).
-    def ex(command)
+    def ex(command, debug = false)
+      puts "Executing '#{command}'..." if debug
       ret = `#{command}`
       unless Pkg::Util::Execution.success?
         raise RuntimeError
       end
+
+      if debug
+        puts "Command '#{command}' returned:"
+        puts ret
+      end
+
       ret
     end
 

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -49,7 +49,7 @@ module Pkg::Util::Net
       unless extra_flags.empty?
         flags << " " << extra_flags.join(" ")
       end
-      Pkg::Util::Execution.ex("#{rsync} #{flags} #{source} #{target}:#{dest}")
+      Pkg::Util::Execution.ex("#{rsync} #{flags} #{source} #{target}:#{dest}", true)
     end
 
     def rsync_from(source, target, dest, extra_flags = [])
@@ -58,7 +58,7 @@ module Pkg::Util::Net
       unless extra_flags.empty?
         flags << " " << extra_flags.join(" ")
       end
-      Pkg::Util::Execution.ex("#{rsync} #{flags} #{target}:#{source} #{dest}")
+      Pkg::Util::Execution.ex("#{rsync} #{flags} #{target}:#{source} #{dest}", true)
     end
 
     def s3sync_to(source, target_bucket, target_directory = "", flags = [])

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -116,19 +116,19 @@ describe "Pkg::Util::Net" do
 
     it "should rsync 'thing' to 'foo@bar:/home/foo' with flags '-rHlv -O --no-perms --no-owner --no-group --ignore-existing'" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group --ignore-existing thing foo@bar:/home/foo")
+      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group --ignore-existing thing foo@bar:/home/foo", true)
       Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo")
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include --ignore-existing" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group thing foo@bar:/home/foo")
+      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group thing foo@bar:/home/foo", true)
       Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", [])
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group --foo-bar --and-another-flag thing foo@bar:/home/foo")
+      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group --foo-bar --and-another-flag thing foo@bar:/home/foo", true)
       Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", ["--foo-bar", "--and-another-flag"])
     end
   end
@@ -170,13 +170,13 @@ describe "Pkg::Util::Net" do
 
     it "should rsync 'thing' from 'foo@bar' to '/home/foo' with flags '-rHlv -O --no-perms --no-owner --no-group'" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group foo@bar:thing /home/foo")
+      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group foo@bar:thing /home/foo", true)
       Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
     end
 
     it "rsyncs 'thing' from 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group --foo-bar --and-another-flag foo@bar:thing /home/foo")
+      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} -rHlv -O --no-perms --no-owner --no-group --foo-bar --and-another-flag foo@bar:thing /home/foo", true)
       Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo", ["--foo-bar", "--and-another-flag"])
     end
   end


### PR DESCRIPTION
It is currently fairly difficult to get details of why a command has
failed or what it returned by default in the packaging repo. This commit
aims to make that a little easier but adding a parameter to the ex
method to expose what command was executed and what it returned.
This PR also includes a commit which passes the verbose parameter to the ex method when rsync_to
and rsync_from methods are invoked. This should give a better picture of
what is happening when debugging failures.