### PR TITLE
(maint) The task should always exist

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -115,7 +115,7 @@ namespace :pl do
         Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
         Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
       end
-    end if Pkg::Config.build_ips || Pkg::Config.vanagon_project
+    end
   end
 
   # We want to ship a gem only for projects that build gems


### PR DESCRIPTION
There were some old conditionals that made the update_ips_repo task only
exist for vanagon packages or when explicitly building for IPS. We fail
gracefully within the task if there are no solaris packages, so this is
unnecessary.