### PR TITLE
Revert " (RE-4595) Add AIX rpms to the list that packaging repo signs"

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -86,8 +86,7 @@ namespace :pl do
     old_rpms = Dir["#{rpm_dir}/el/4/**/*.rpm"] +
       Dir["#{rpm_dir}/el/5/**/*.rpm"] +
       Dir["#{rpm_dir}/sles/10/**/*.rpm"] +
-      Dir["#{rpm_dir}/sles/11/**/*.rpm"] +
-      Dir["#{rpm_dir}/aix/**/**/*.rpm"]
+      Dir["#{rpm_dir}/sles/11/**/*.rpm"]
     modern_rpms = Dir["#{rpm_dir}/el/6/**/*.rpm"] +
       Dir["#{rpm_dir}/el/7/**/*.rpm"] +
       Dir["#{rpm_dir}/fedora/**/*.rpm"] +


### PR DESCRIPTION
This reverts commit 896ea5f035fb9a4dc76774d87d6692bdfdb1e874.

Currently, signing on AIX is broken, and it prevents us from signing any
other packages

Conflicts:
	tasks/sign.rake