### PR TITLE
(RE-4595) Do not fail for unsigned aix packages

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -96,7 +96,11 @@ namespace :pl do
       Dir["#{rpm_dir}/sles/12/**/*.rpm"] +
       Dir["#{rpm_dir}/eos/**/**/*.rpm"]
 
-    unsigned_rpms = all_rpms - old_rpms - modern_rpms
+    # We don't sign AIX rpms, but we don't want to fail because they
+    # will be in the list
+    aix_rpms = Dir["#{rpm_dir}/aix/**/*.rpm"]
+
+    unsigned_rpms = all_rpms - old_rpms - modern_rpms - aix_rpms
     unless unsigned_rpms.empty?
       fail "#{unsigned_rpms} are not signed. Please update the automation in the signing task"
     end
@@ -206,4 +210,3 @@ namespace :pl do
     end
   end
 end
-


### PR DESCRIPTION
A previous commit removed aix packages from signing,
but now the task fails because they are still left in
the total package list after the signed packages
have been removed.

This removes the aix packages from the list so they
will be ignored for the signing check.