### PR TITLE
(RE-5966) Add OSX 10.11 to platform hash

### DIFF
--- a/lib/packaging/config/platforms.rb
+++ b/lib/packaging/config/platforms.rb
@@ -37,6 +37,7 @@ module Pkg::Platforms
     'osx' => {
       '10.9' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
       '10.10' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
+      '10.11' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
     },
 
     'sles' => {


### PR DESCRIPTION
Add OSX 10.11 to platform hash in preparation for shipping to nightlies.