### PR TITLE
(maint) Add release name to subtask summaries and projected date to d…

### DIFF
--- a/tasks/puppet-agent-release-tickets.rake
+++ b/tasks/puppet-agent-release-tickets.rake
@@ -382,6 +382,13 @@ DOC
 
   ]
 
+  # Add redundant (but very useful in emails and tab titles) info to subtask
+  # summaries / descriptions.
+  subtickets.each {|t|
+    t[:summary] << " (#{vars[:project]} #{vars[:puppet_agent_release]})"
+    t[:description] = "(Initial planned release date: #{vars[:date]})\n\n" + t[:description]
+  }
+
   # Use the human-friendly project name in the summary
   summary = "#{Pkg::Config.project} #{vars[:puppet_agent_release]} #{vars[:date]} Release"
   description[:top_level_ticket] = <<-DOC

--- a/tasks/tickets.rake
+++ b/tasks/tickets.rake
@@ -361,6 +361,13 @@ DOC
     },
   ]
 
+  # Add redundant (but very useful in emails and tab titles) info to subtask
+  # summaries / descriptions.
+  subtickets.each {|t|
+    t[:summary] << " (#{vars[:project]} #{vars[:release]})"
+    t[:description] = "(Initial planned release date: #{vars[:date]})\n\n" + t[:description]
+  }
+
   # Use the human-friendly project name in the summary
   summary = "#{Pkg::Config.project} #{vars[:release]} #{vars[:date]} Release"
   description[:top_level_ticket] = <<-DOC


### PR DESCRIPTION
…escriptions

Whenever a release ticket is created, the subtask assignees receive mystery meat
emails that tell us a release is happening, but not WHICH release, nor when it's
supposed to go down. Also, if there are multiple releases in flight at once (and
in my team there always are), the identical ticket summaries make it really hard
to distinguish between browser tabs.

This commit should hopefully improve that, by:

* Adding a string like " (puppet 4.3.0)" to the end of every release subtask
  summary, so we can distinguish between tickets in emails and tabs.
* Adding the originally projected release date (with caveat) to the beginning of
  every release subtask description, so at least the _initial_ email can tell us
  what the rest of the release crew is thinking.