### PR TITLE
Some quick updates for the new Deb signing pipeline

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -250,7 +250,15 @@ namespace :pl do
 
     desc "Retrieve packages built by jenkins, sign, and ship all!"
     task :uber_ship => "pl:fetch" do
-      uber_tasks = ["jenkins:retrieve", "jenkins:sign_all", "uber_ship", "remote:update_apt_repo", "remote:update_yum_repo", "remote:update_ips_repo"]
+      uber_tasks = %w(
+        jenkins:retrieve
+        jenkins:sign_all
+        uber_ship
+        remote:update_apt_repo
+        remote:deploy_apt_repo
+        remote:update_yum_repo
+        remote:update_ips_repo
+      )
       uber_tasks.map { |t| "pl:#{t}" }.each { |t| Rake::Task[t].invoke }
       Rake::Task["pl:jenkins:ship"].invoke("shipped")
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -95,21 +95,6 @@ namespace :pl do
     end
   end
 
-  desc "Move signed debs from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}"
-  task :deploy_debs do
-    puts "Really run remote rsync to deploy Debian repos to #{Pkg::Config.apt_host}? [y,n]"
-    if ask_yes_or_no
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
-        Pkg::Deb::Repo.deploy_repos(
-          Pkg::Config.apt_repo_path,
-          Pkg::Config.apt_signing_server,
-          Pkg::Config.apt_host,
-          ENV['DRYRUN']
-        )
-      end
-    end
-  end
-
   namespace :remote do
     desc "Update remote ips repository on #{Pkg::Config.ips_host}"
     task :update_ips_repo  => 'pl:fetch' do
@@ -135,6 +120,21 @@ namespace :pl do
         Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, remote_cmd)
         Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
         Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
+      end
+    end
+
+    desc "Move signed deb repos from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}"
+    task :deploy_apt_repo do
+      puts "Really run remote rsync to deploy Debian repos from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}? [y,n]"
+      if ask_yes_or_no
+        Pkg::Util::Execution.retry_on_fail(:times => 3) do
+          Pkg::Deb::Repo.deploy_repos(
+            Pkg::Config.apt_repo_path,
+            Pkg::Config.apt_signing_server,
+            Pkg::Config.apt_host,
+            ENV['DRYRUN']
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
- Rename `pl:deploy_debs` to `remote:deploy_apt_repo`
- Add  `remote:deploy_apt_repo` to `pl:jenkins:uber_ship`
- Formatting cleanup for the Array of tasks that `pl:jenkins:uber_ship` runs
