### PR TITLE
(RE-5619) Allow shipping to PE feature repos

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -344,6 +344,13 @@ module Pkg
           end
         end
       end
+
+      def yum_target_path(feature_branch = false)
+        if feature_branch || Pkg::Config.pe_feature_branch
+          return "#{Pkg::Config.yum_repo_path}/#{Pkg::Config.pe_version}/feature/repos/"
+        end
+        "#{Pkg::Config.yum_repo_path}/#{Pkg::Config.pe_version}/repos/"
+      end
     end
   end
 end

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -99,6 +99,7 @@ module Pkg::Params
                   :packaging_root,
                   :packaging_url,
                   :pbuild_conf,
+                  :pe_feature_branch,
                   :pe_name,
                   :pe_platforms,
                   :pe_version,
@@ -204,7 +205,8 @@ module Pkg::Params
               { :var => :team,                    :envvar => :TEAM },
               { :var => :update_version_file,     :envvar => :NEW_STYLE_PACKAGE },
               { :var => :yum_repo_path,           :envvar => :YUM_REPO },
-              { :var => :yum_host,                :envvar => :YUM_HOST }]
+              { :var => :yum_host,                :envvar => :YUM_HOST },
+              { :var => :pe_feature_branch,       :envvar => :PE_FEATURE_BRANCH }]
   # Default values that are supplied if the user does not supply them
   #
   # usage is the same as above
@@ -223,7 +225,8 @@ module Pkg::Params
               { :var => :ips_signing_cert,        :val => '$IPS_SIGNING_CERT' },
               { :var => :ips_inter_cert,          :val => '$IPS_INTER_CERT' },
               { :var => :ips_root_cert,           :val => '$IPS_ROOT_CERT' },
-              { :var => :ips_signing_key,         :val => '$IPS_SIGNING_KEY' }]
+              { :var => :ips_signing_key,         :val => '$IPS_SIGNING_KEY' },
+              { :var => :pe_feature_branch,       :val => false }]
 
   # These are variables which, over time, we decided to rename or replace. For
   # backwards compatibility, we assign the value of the old/deprecated


### PR DESCRIPTION
For PE, we want to allow the promotion and use of arbitrary
test/dev packages into feature branches of PE, that don't pollute
the mainline PE branches and repos.

This adds logic to enable shipping to the feature repos for a PE branch,
and during a normal ship/promotion, links the shipped package into the
feature repos (so that mainline packages are immediately available to the
feature branches).