### PR TITLE
(maint) Remove HuaweiOS from RPM tasks

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -1,7 +1,7 @@
 namespace :pl do
   desc "Ship mocked rpms to #{Pkg::Config.yum_host}"
   task :ship_rpms do
-    ["aix", "cisco-wrlinux", "el", "eos", "fedora", "huaweios", "nxos", "sles"].each do |dist|
+    ["aix", "cisco-wrlinux", "el", "eos", "fedora", "nxos", "sles"].each do |dist|
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
         pkgs = Dir["pkg/#{dist}/**/*.rpm"].map { |f| "'#{f.gsub("pkg/#{dist}/", "#{Pkg::Config.yum_repo_path}/#{dist}/")}'" }
         unless pkgs.empty?

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -90,7 +90,6 @@ namespace :pl do
     modern_rpms = Dir["#{rpm_dir}/el/6/**/*.rpm"] +
       Dir["#{rpm_dir}/el/7/**/*.rpm"] +
       Dir["#{rpm_dir}/fedora/**/*.rpm"] +
-      Dir["#{rpm_dir}/huaweios/**/**/*.rpm"] +
       Dir["#{rpm_dir}/nxos/**/*.rpm"] +
       Dir["#{rpm_dir}/cisco-wrlinux/**/*.rpm"] +
       Dir["#{rpm_dir}/sles/12/**/*.rpm"] +


### PR DESCRIPTION
Platform has changed from RPM to DEB.

I'm not seeing any need to specify cumulus as a DEB platform, so this PR only removes huawei from the RPM tasks. Please let me know if I need to explicitly add huawei to the DEB tasks.