### PR TITLE
(maint) Update permissions for the deb deployment

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -199,7 +199,8 @@ SignWith: #{Pkg::Config.gpg_key}"
         --update
         --verbose
         --perms
-        --chmod='Dugo-s,Dug=rwx,Do=rx,Fug=rw,Fo=r'
+        --no-group
+        --chmod='Dug=rwx,Do=rx,Fug=rw,Fo=r'
         --exclude='dists/*-*'
         --exclude='pool/*-*'
       )
@@ -232,7 +233,7 @@ SignWith: #{Pkg::Config.gpg_key}"
       rsync_command = repo_deployment_command(apt_path, destination_staging_path, destination_server, dryrun)
       cp_command = repo_deployment_command(destination_staging_path, apt_path, nil, dryrun)
       # Defensive permissions setting are defensive
-      chmod_command = "sudo chmod -R g=rwX #{destination_staging_path}; sudo chmod -R g=rwX #{apt_path}"
+      chmod_command = "sudo chmod -R g=rwX #{destination_staging_path}; sudo chmod -R g-s,g=rwX #{apt_path}"
 
       if dryrun
         puts "[DRYRUN] not executing #{chmod_command} on #{destination_server}"


### PR DESCRIPTION
Manually mangling permissions is the worst. Except for maybe the sticky
bit. The sticky bit is definitely terrible. This stops rsync from
trying to set the group of things on apt.puppetlabs.com and removes the
sticky bit, because rsync does not listen to -s with its chmod.