### PR TITLE
(RE-5813) Use PA as the parent project for agent platform tickets

### DIFF
--- a/tasks/agent-tickets.rake
+++ b/tasks/agent-tickets.rake
@@ -206,7 +206,7 @@ DOC
     },
     {
       :short_name   => 'puppet_agent_configuration',
-      :project      => 'RE',
+      :project      => 'PA',
       :summary      => "Add #{vars[:platform_tag]} platform definition to puppet-agent",
       :description  => description[:puppet_agent_configuration],
       :story_points => '2',
@@ -353,7 +353,7 @@ platform will happen in a separate epic.
 DOC
 
   # Values for the main ticket
-  parent_project  = vars[:pe_only] == "true" ? 'RE' : 'CPR'
+  parent_project  = 'PA'
   parent_assignee = vars[:username]
 
   jira.user(parent_assignee)
@@ -417,8 +417,8 @@ DOC
     if subticket[:epic_parent]
       subticket[:epic_parent] = subticket_hash[subticket[:epic_parent]]['key']
     else # otherwise, we definitely need to link it to the main epic ticket somehow
-      if (subticket[:project] == 'RE' || subticket[:project] == 'CPR') && (!subticket[:type] || subticket[:type] != 'Epic')
-        # If the ticket is not an epic and is a part of the RE or CPR projects, we can make it a part of the main epic
+      if subticket[:project] == 'PA' && (!subticket[:type] || subticket[:type] != 'Epic')
+        # Add any PA tickets to this epic
         subticket[:epic_parent] = parent_key
       elsif !subticket[:parent]
         # If the ticket isn't a sub-task (meaning it doesn't have a parent, otherwise the parent ticket will be linked against


### PR DESCRIPTION
Since the PA project exists we should always use that for platform
additions. We also always want puppet_agent_configuration to be part of
the PA project, and c_toolchain and build tools should be either in PA
or RE depending on whether or not the platform is PE only.