### PR TITLE
(RE-6070) Ship RPMS to YUM_STAGING_SERVER

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -141,6 +141,7 @@ module Pkg::Params
                   :yum_repo_path,
                   :yum_repo_name,
                   :yum_repo_command,
+                  :yum_staging_server,
   ]
 
   # Environment variable overrides for Pkg::Config parameters
@@ -206,6 +207,7 @@ module Pkg::Params
               { :var => :update_version_file,     :envvar => :NEW_STYLE_PACKAGE },
               { :var => :yum_repo_path,           :envvar => :YUM_REPO },
               { :var => :yum_host,                :envvar => :YUM_HOST },
+              { :var => :yum_staging_server,      :envvar => :YUM_STAGING_SERVER },
               { :var => :pe_feature_branch,       :envvar => :PE_FEATURE_BRANCH }]
   # Default values that are supplied if the user does not supply them
   #
@@ -236,6 +238,7 @@ module Pkg::Params
   #
   REASSIGNMENTS = [{ :oldvar => :name,                   :newvar => :project },
                    { :oldvar => :yum_host,               :newvar => :tar_host },
+                   { :oldvar => :yum_staging_server,     :newvar => :yum_host },
                    { :oldvar => :gem_devel_dependencies, :newvar => :gem_development_dependencies },
                    { :oldvar => :pe_name,                :newvar => :project },
                    { :oldvar => :project,                :newvar => :gem_name },

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -44,8 +44,8 @@ module Pkg::Rpm::Repo
     # @return [String] an rsync command that can be executed on a remote host
     #   to copy local content from that host to a remote node.
     def repo_deployment_command(origin_path, destination_path, destination, dryrun = false)
-      path = Pathname.new(origin_path)
-      dest_path = Pathname.new(destination_path)
+      path = Pathname.new(origin_path).cleanpath
+      dest_path = Pathname.new(destination_path).cleanpath
 
       # You may think "rsync doesn't actually remove the sticky bit, let's
       # remove the Dugo-s from the chmod". However, that will make your rsyncs

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -257,6 +257,7 @@ namespace :pl do
         remote:update_apt_repo
         remote:deploy_apt_repo
         remote:update_yum_repo
+        remote:deploy_yum_repo
         remote:update_ips_repo
       )
       uber_tasks.map { |t| "pl:#{t}" }.each { |t| Rake::Task[t].invoke }

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -1,12 +1,12 @@
 namespace :pl do
-  desc "Ship mocked rpms to #{Pkg::Config.yum_host}"
+  desc "Ship mocked rpms to #{Pkg::Config.yum_staging_server}"
   task :ship_rpms do
     ["aix", "cisco-wrlinux", "el", "eos", "fedora", "nxos", "sles"].each do |dist|
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
         pkgs = Dir["pkg/#{dist}/**/*.rpm"].map { |f| "'#{f.gsub("pkg/#{dist}/", "#{Pkg::Config.yum_repo_path}/#{dist}/")}'" }
         unless pkgs.empty?
-          Pkg::Util::Net.rsync_to("pkg/#{dist}", Pkg::Config.yum_host, Pkg::Config.yum_repo_path)
-          remote_set_immutable(Pkg::Config.yum_host, pkgs)
+          Pkg::Util::Net.rsync_to("pkg/#{dist}", Pkg::Config.yum_staging_server, Pkg::Config.yum_repo_path)
+          remote_set_immutable(Pkg::Config.yum_staging_server, pkgs)
         end
       end if File.directory?("pkg/#{dist}")
     end
@@ -18,21 +18,21 @@ namespace :pl do
     # to various target yum and apt repositories based on their specific type
     # e.g., final vs devel vs PE vs FOSS packages
 
-    desc "Update remote yum repository on '#{Pkg::Config.yum_host}'"
+    desc "Update remote yum repository on '#{Pkg::Config.yum_staging_server}'"
     task :update_yum_repo do
       yum_whitelist = {
         :yum_repo_name => "__REPO_NAME__",
         :yum_repo_path => "__REPO_PATH__",
-        :yum_host      => "__REPO_HOST__",
-        :gpg_key       => "__GPG_KEY__",
+        :yum_staging_server => "__REPO_HOST__",
+        :gpg_key => "__GPG_KEY__",
       }
 
-      STDOUT.puts "Really run remote repo update on '#{Pkg::Config.yum_host}'? [y,n]"
+      STDOUT.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       if ask_yes_or_no
         if Pkg::Config.yum_repo_command
-          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_host, Pkg::Util::Misc.search_and_replace(Pkg::Config.yum_repo_command, yum_whitelist))
+          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_staging_server, Pkg::Util::Misc.search_and_replace(Pkg::Config.yum_repo_command, yum_whitelist))
         else
-          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_host, 'rake -f /opt/repository/Rakefile mk_repo')
+          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_staging_server, 'rake -f /opt/repository/Rakefile mk_repo')
         end
       end
     end
@@ -138,6 +138,21 @@ namespace :pl do
         end
       end
     end
+
+    desc "Copy rpm repos from #{Pkg::Config.yum_staging_server} to #{Pkg::Config.yum_host}"
+    task :deploy_yum_repos do
+      puts "Really run remote rsync to deploy yum repos from #{Pkg::Config.yum_staging_server} to #{Pkg::Config.yum_host}? [y,n]"
+      if ask_yes_or_no
+        Pkg::Util::Execution.retry_on_fail(:times => 3) do
+          Pkg::Rpm::Repo.deploy_repos(
+            Pkg::Config.yum_repo_path,
+            Pkg::Config.yum_staging_server,
+            Pkg::Config.yum_host,
+            ENV['DRYRUN']
+          )
+        end
+      end
+    end
   end
 
   # We want to ship a gem only for projects that build gems
@@ -158,13 +173,13 @@ namespace :pl do
     end
   end
 
-  desc "ship apple dmg to #{Pkg::Config.yum_host}"
+  desc "ship apple dmg to #{Pkg::Config.yum_staging_server}"
   task :ship_dmg => 'pl:fetch' do
     if Dir['pkg/apple/**/*.dmg'].empty?
       STDOUT.puts "There aren't any dmg packages in pkg/apple. Maybe something went wrong?"
     else
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
-        Pkg::Util::Net.rsync_to('pkg/apple/', Pkg::Config.yum_host, Pkg::Config.dmg_path)
+        Pkg::Util::Net.rsync_to('pkg/apple/', Pkg::Config.yum_staging_server, Pkg::Config.dmg_path)
       end
     end
   end if Pkg::Config.build_dmg || Pkg::Config.vanagon_project


### PR DESCRIPTION
We used to ship our RPM repos directly to our perimeter nodes, which in the new world is sort of not getting the job done anymore. We should be shipping them to a staging server instead. This PR is tracking the work needed to move new RPMs from our local machine to our staging server, and then from our staging server to our production infrastructure.