### PR TITLE
(RE-6150) Adding Ubuntu 15.10 to the platforms hash

### DIFF
--- a/lib/packaging/config/platforms.rb
+++ b/lib/packaging/config/platforms.rb
@@ -56,6 +56,7 @@ module Pkg::Platforms
       '12.04' => { :codename => 'precise', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
       '14.04' => { :codename => 'trusty', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
       '15.04' => { :codename => 'vivid', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
+      '15.10' => { :codename => 'wily', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
     },
 
     'windows' => {


### PR DESCRIPTION
As part of ongoing processes to support Ubuntu 15.10 this commit
adds Ubuntu 15.10 to the platforms hash in order to facilitate
shipping 15.10