### PR TITLE
(maint) Allow package:apple task to load regardless

### DIFF
--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -242,10 +242,10 @@ def pack_source
   end
 end
 
-if Pkg::Config.build_dmg
-  namespace :package do
-    desc "Task for building an Apple Package"
-    task :apple => [:setup] do
+namespace :package do
+  desc "Task for building an Apple Package"
+  task :apple => [:setup] do
+    if Pkg::Config.build_dmg
       bench = Benchmark.realtime do
         # Test for pkgbuild binary
         fail "pkgbuild must be installed." unless \
@@ -258,10 +258,9 @@ if Pkg::Config.build_dmg
       puts "Finished building in: #{bench}"
     end
   end
-
-  # An alias task to simplify our remote logic in jenkins.rake
-  namespace :pl do
-    task :dmg => "package:apple"
-  end
 end
 
+# An alias task to simplify our remote logic in jenkins.rake
+namespace :pl do
+  task :dmg => "package:apple"
+end


### PR DESCRIPTION
Without this change, rake fails to execute successfully unless the
project has `build_dmg: TRUE`. Given that we do not build dmgs for most
of our projects, this is a problem. The issue originates at
https://github.com/puppetlabs/puppet/commit/307c653ac361682609b6226d861de61946c1df9e#diff-0704014ee01c1d6dd1028f281ec1dc4cR55

I have no idea why that was added in or what it does, but in order to
handle the change, this commit allows the 'package:apple' task to be
loaded, but effectively created an empty task unless the project has
`build_dmg: TRUE`.