### PR TITLE
(maint) add a bundler group for jira tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,10 @@ group :development, :test do
   gem 'win32console', :platforms => [:mingw_18, :mingw_19]
   gem 'rubocop', "~> 0.24.1", :require => false
 end
+
+group :jira do
+  # After 0.1.12 the jira-ruby gem depends on the latest activesupport,
+  # which in turn requires ruby >= 2.2.2. So until we move to ruby 2.2,
+  # lock the version of jira-ruby to 0.1.12:
+  gem 'jira-ruby', "0.1.12"
+end


### PR DESCRIPTION
The jira ticket rake tasks depend on the jira-ruby gem, so this
adds a bundler gem group for jira functionality.