### PR TITLE
(work in progress) The Great Packaging Refactor: Pkg::Uti::Net

### DIFF
--- a/lib/packaging/util/jenkins.rb
+++ b/lib/packaging/util/jenkins.rb
@@ -82,5 +82,13 @@ module Pkg::Util::Jenkins
       wait_for_build job_hash['lastBuild']['url']
     end
 
+    # Use the provided URL string to print important information with
+    # ASCII emphasis
+    def print_url_info(url_string)
+      str = "\n////////////////////////////////////////////////////////////////////////////////\n\n\n"
+      str += "\s\sBuild submitted. To view your build progress, go to\n#{url_string}\n\n\n"
+      str += "////////////////////////////////////////////////////////////////////////////////\n\n"
+      puts str
+    end
   end
 end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -110,16 +110,6 @@ module Pkg
         end
       end
       module_function :curl_form_data
-
-      # Use the provided URL string to print important information with
-      # ASCII emphasis
-      def print_url_info(url_string)
-        str = "\n////////////////////////////////////////////////////////////////////////////////\n\n\n"
-        str += "\s\sBuild submitted. To view your build progress, go to\n#{url_string}\n\n\n"
-        str += "////////////////////////////////////////////////////////////////////////////////\n\n"
-        puts str
-      end
-      module_function :print_url_info
     end
   end
 end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -1,12 +1,15 @@
 # Utility methods for handling network calls and interactions
 
+require 'open-uri'
+require 'open3'
+require 'socket'
+
 module Pkg
   module Util
     module Net
       # This simple method does an HTTP get of a URI and writes it to a file
       # in a slightly more platform agnostic way than curl/wget
       def fetch_uri(uri, target)
-        require 'open-uri'
         if Pkg::Util::File.file_writable?(File.dirname(target))
           File.open(target, 'w') { |f| f.puts(open(uri).read) }
         end
@@ -15,7 +18,6 @@ module Pkg
 
       # Get the hostname of the current host
       def hostname
-        require 'socket'
         Socket.gethostname
       end
       module_function :hostname
@@ -49,7 +51,6 @@ module Pkg
 
         puts "Executing '#{command}' on #{target}"
         if capture_output
-          require 'open3'
           stdout, stderr, exitstatus = Open3.capture3(cmd)
           Pkg::Util::Execution.success?(exitstatus) or raise "Remote ssh command failed."
           return stdout, stderr

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -1,21 +1,11 @@
 # Utility methods for handling network calls and interactions
 
-require 'open-uri'
 require 'open3'
 require 'socket'
 
 module Pkg
   module Util
     module Net
-      # This simple method does an HTTP get of a URI and writes it to a file
-      # in a slightly more platform agnostic way than curl/wget
-      def fetch_uri(uri, target)
-        if Pkg::Util::File.file_writable?(File.dirname(target))
-          File.open(target, 'w') { |f| f.puts(open(uri).read) }
-        end
-      end
-      module_function :fetch_uri
-
       # Get the hostname of the current host
       def hostname
         Socket.gethostname

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -74,10 +74,10 @@ module Pkg
       def s3sync_to(source, target_bucket, target_directory = "", flags = [])
         s3cmd = Pkg::Util::Tool.check_tool('s3cmd')
 
-        if Pkg::Util::File.file_exists?(File.join(ENV['HOME'], '.s3cfg'))
+        if Pkg::Util::File.file_exists?(::File.join(ENV['HOME'], '.s3cfg'))
           Pkg::Util::Execution.ex("#{s3cmd} sync #{flags.join(' ')} '#{source}' s3://#{target_bucket}/#{target_directory}/")
         else
-          fail "#{File.join(ENV['HOME'], '.s3cfg')} does not exist. It is required to ship files using s3cmd."
+          fail "#{::File.join(ENV['HOME'], '.s3cfg')} does not exist. It is required to ship files using s3cmd."
         end
       end
       module_function :s3sync_to

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -12,17 +12,6 @@ module Pkg
       end
       module_function :hostname
 
-      # Check that the current host matches the one we think it should
-      def check_host(host, args = { :required => true })
-        if hostname == host
-          return true
-        else
-          fail "#{hostname} does not match #{host}" if args[:required]
-          return nil
-        end
-      end
-      module_function :check_host
-
       def remote_ssh_cmd(target, command, capture_output = false)
         ssh = Pkg::Util::Tool.check_tool('ssh')
         cmd = "#{ssh} -t #{target} '#{command.gsub("'", "'\\\\''")}'"

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -1,135 +1,145 @@
 # Utility methods for handling network calls and interactions
 
-module Pkg::Util::Net
-
-  class << self
-
-    # This simple method does an HTTP get of a URI and writes it to a file
-    # in a slightly more platform agnostic way than curl/wget
-    def fetch_uri(uri, target)
-      require 'open-uri'
-      if Pkg::Util::File.file_writable?(File.dirname(target))
-        File.open(target, 'w') { |f| f.puts(open(uri).read) }
+module Pkg
+  module Util
+    module Net
+      # This simple method does an HTTP get of a URI and writes it to a file
+      # in a slightly more platform agnostic way than curl/wget
+      def fetch_uri(uri, target)
+        require 'open-uri'
+        if Pkg::Util::File.file_writable?(File.dirname(target))
+          File.open(target, 'w') { |f| f.puts(open(uri).read) }
+        end
       end
-    end
+      module_function :fetch_uri
 
-    # Get the hostname of the current host
-    def hostname
-      require 'socket'
-      Socket.gethostname
-    end
-
-    # Check that the current host matches the one we think it should
-    def check_host(host, args = { :required => true })
-      if hostname == host
-        return true
-      else
-        fail "#{hostname} does not match #{host}" if args[:required]
-        return nil
+      # Get the hostname of the current host
+      def hostname
+        require 'socket'
+        Socket.gethostname
       end
-    end
+      module_function :hostname
 
-    def remote_ssh_cmd(target, command, capture_output = false)
-      ssh = Pkg::Util::Tool.check_tool('ssh')
-      cmd = "#{ssh} -t #{target} '#{command.gsub("'", "'\\\\''")}'"
-
-      # This is NOT a good way to support this functionality.
-      # It needs to be refactored into a set of methods that
-      # other methods can use to safely and deterministically
-      # support dry-run operations.
-      # But I need to ship packages RIGHT NOW.
-      # - Ryan McKern, 13/01/2016
-      if ENV['DRYRUN']
-        puts "[DRY-RUN] Executing '#{command}' on #{target}"
-        puts "[DRY-RUN] #{cmd}"
-        return
+      # Check that the current host matches the one we think it should
+      def check_host(host, args = { :required => true })
+        if hostname == host
+          return true
+        else
+          fail "#{hostname} does not match #{host}" if args[:required]
+          return nil
+        end
       end
+      module_function :check_host
 
-      puts "Executing '#{command}' on #{target}"
-      if capture_output
-        require 'open3'
-        stdout, stderr, exitstatus = Open3.capture3(cmd)
-        Pkg::Util::Execution.success?(exitstatus) or raise "Remote ssh command failed."
-        return stdout, stderr
-      else
-        Kernel.system(cmd)
-        Pkg::Util::Execution.success? or raise "Remote ssh command failed."
+      def remote_ssh_cmd(target, command, capture_output = false)
+        ssh = Pkg::Util::Tool.check_tool('ssh')
+        cmd = "#{ssh} -t #{target} '#{command.gsub("'", "'\\\\''")}'"
+
+        # This is NOT a good way to support this functionality.
+        # It needs to be refactored into a set of methods that
+        # other methods can use to safely and deterministically
+        # support dry-run operations.
+        # But I need to ship packages RIGHT NOW.
+        # - Ryan McKern, 13/01/2016
+        if ENV['DRYRUN']
+          puts "[DRY-RUN] Executing '#{command}' on #{target}"
+          puts "[DRY-RUN] #{cmd}"
+          return
+        end
+
+        puts "Executing '#{command}' on #{target}"
+        if capture_output
+          require 'open3'
+          stdout, stderr, exitstatus = Open3.capture3(cmd)
+          Pkg::Util::Execution.success?(exitstatus) or raise "Remote ssh command failed."
+          return stdout, stderr
+        else
+          Kernel.system(cmd)
+          Pkg::Util::Execution.success? or raise "Remote ssh command failed."
+        end
       end
-    end
+      module_function :remote_ssh_cmd
 
-    def rsync_to(source, target, dest, extra_flags = ["--ignore-existing"])
-      rsync = Pkg::Util::Tool.check_tool('rsync')
-      flags = "-rHlv -O --no-perms --no-owner --no-group"
-      unless extra_flags.empty?
-        flags << " " << extra_flags.join(" ")
+      def rsync_to(source, target, dest, extra_flags = ["--ignore-existing"])
+        rsync = Pkg::Util::Tool.check_tool('rsync')
+        flags = "-rHlv -O --no-perms --no-owner --no-group"
+        unless extra_flags.empty?
+          flags << " " << extra_flags.join(" ")
+        end
+        Pkg::Util::Execution.ex("#{rsync} #{flags} #{source} #{target}:#{dest}", true)
       end
-      Pkg::Util::Execution.ex("#{rsync} #{flags} #{source} #{target}:#{dest}", true)
-    end
+      module_function :rsync_to
 
-    def rsync_from(source, target, dest, extra_flags = [])
-      rsync = Pkg::Util::Tool.check_tool('rsync')
-      flags = "-rHlv -O --no-perms --no-owner --no-group"
-      unless extra_flags.empty?
-        flags << " " << extra_flags.join(" ")
+      def rsync_from(source, target, dest, extra_flags = [])
+        rsync = Pkg::Util::Tool.check_tool('rsync')
+        flags = "-rHlv -O --no-perms --no-owner --no-group"
+        unless extra_flags.empty?
+          flags << " " << extra_flags.join(" ")
+        end
+        Pkg::Util::Execution.ex("#{rsync} #{flags} #{target}:#{source} #{dest}", true)
       end
-      Pkg::Util::Execution.ex("#{rsync} #{flags} #{target}:#{source} #{dest}", true)
-    end
+      module_function :rsync_from
 
-    def s3sync_to(source, target_bucket, target_directory = "", flags = [])
-      s3cmd = Pkg::Util::Tool.check_tool('s3cmd')
+      def s3sync_to(source, target_bucket, target_directory = "", flags = [])
+        s3cmd = Pkg::Util::Tool.check_tool('s3cmd')
 
-      if Pkg::Util::File.file_exists?(File.join(ENV['HOME'], '.s3cfg'))
-        Pkg::Util::Execution.ex("#{s3cmd} sync #{flags.join(' ')} '#{source}' s3://#{target_bucket}/#{target_directory}/")
-      else
-        fail "#{File.join(ENV['HOME'], '.s3cfg')} does not exist. It is required to ship files using s3cmd."
+        if Pkg::Util::File.file_exists?(File.join(ENV['HOME'], '.s3cfg'))
+          Pkg::Util::Execution.ex("#{s3cmd} sync #{flags.join(' ')} '#{source}' s3://#{target_bucket}/#{target_directory}/")
+        else
+          fail "#{File.join(ENV['HOME'], '.s3cfg')} does not exist. It is required to ship files using s3cmd."
+        end
       end
-    end
+      module_function :s3sync_to
 
-    # This is fairly absurd. We're implementing curl by shelling out. What do I
-    # wish we were doing? Using a sweet ruby wrapper around curl, such as Curb or
-    # Curb-fu. However, because we're using clean build systems and trying to
-    # make this portable with minimal system requirements, we can't very well
-    # depend on libraries that aren't in the ruby standard libaries. We could
-    # also do this using Net::HTTP but that set of libraries is a rabbit hole to
-    # go down when what we're trying to accomplish is posting multi-part form
-    # data that includes file uploads to jenkins. It gets hairy fairly quickly,
-    # but, as they say, pull requests accepted.
-    #
-    # This method takes three arguments
-    # 1) String - the URL to post to
-    # 2) Array  - Ordered array of name=VALUE curl form parameters
-    # 3) Hash - Options to be set
-    def curl_form_data(uri, form_data = [], options = {})
-      curl = Pkg::Util::Tool.check_tool("curl")
+      # This is fairly absurd. We're implementing curl by shelling out. What do I
+      # wish we were doing? Using a sweet ruby wrapper around curl, such as Curb or
+      # Curb-fu. However, because we're using clean build systems and trying to
+      # make this portable with minimal system requirements, we can't very well
+      # depend on libraries that aren't in the ruby standard libaries. We could
+      # also do this using Net::HTTP but that set of libraries is a rabbit hole to
+      # go down when what we're trying to accomplish is posting multi-part form
+      # data that includes file uploads to jenkins. It gets hairy fairly quickly,
+      # but, as they say, pull requests accepted.
       #
-      # Begin constructing the post string.
-      # First, assemble the form_data arguments
-      #
-      post_string = "-i "
-      form_data.each do |param|
-        post_string << "#{param} "
-      end
+      # This method takes three arguments
+      # 1) String - the URL to post to
+      # 2) Array  - Ordered array of name=VALUE curl form parameters
+      # 3) Hash - Options to be set
+      def curl_form_data(uri, form_data = [], options = {})
+        curl = Pkg::Util::Tool.check_tool("curl")
+        #
+        # Begin constructing the post string.
+        # First, assemble the form_data arguments
+        #
+        post_string = "-i "
+        form_data.each do |param|
+          post_string << "#{param} "
+        end
 
-      # Add the uri
-      post_string << "#{uri}"
+        # Add the uri
+        post_string << "#{uri}"
 
-      # If this is quiet, we're going to silence all output
-      if options[:quiet]
-        post_string << " >#{Pkg::Util::OS::DEVNULL} 2>&1"
+        # If this is quiet, we're going to silence all output
+        if options[:quiet]
+          post_string << " >#{Pkg::Util::OS::DEVNULL} 2>&1"
+        end
+        begin
+          Pkg::Util::Execution.ex("#{curl} #{post_string}")
+        rescue RuntimeError
+          return false
+        end
       end
-      begin
-        Pkg::Util::Execution.ex("#{curl} #{post_string}")
-      rescue RuntimeError
-        return false
-      end
-    end
+      module_function :curl_form_data
 
-    # Use the provided URL string to print important information with
-    # ASCII emphasis
-    def print_url_info(url_string)
-      puts "\n////////////////////////////////////////////////////////////////////////////////\n\n
-  Build submitted. To view your build progress, go to\n#{url_string}\n\n
-////////////////////////////////////////////////////////////////////////////////\n\n"
+      # Use the provided URL string to print important information with
+      # ASCII emphasis
+      def print_url_info(url_string)
+        str = "\n////////////////////////////////////////////////////////////////////////////////\n\n\n"
+        str += "\s\sBuild submitted. To view your build progress, go to\n#{url_string}\n\n\n"
+        str += "////////////////////////////////////////////////////////////////////////////////\n\n"
+        puts str
+      end
+      module_function :print_url_info
     end
   end
 end

--- a/lib/packaging/util/shell_constructor.rb
+++ b/lib/packaging/util/shell_constructor.rb
@@ -1,0 +1,159 @@
+require 'pathname'
+
+module Pkg
+  module Util
+    # ShellConstructor builds strings that can be used by shelling
+    # out or feeding them into remote ssh executors.
+    module ShellConstructor
+      # Construct a valid rsync command
+      # @return [String] a rsync command that can be used in shell or ssh methods
+      # @param [String, Pathname] origin_path the path to sync from; if opts[:target_path]
+      #   is not passed, then the parent directory of `origin_path` will be used to
+      #   construct a target path to sync to.
+      # @param [Hash] opts additional options that can be used to construct
+      #   the rsync command.
+      # @option opts [String] :bin ('rsync') the path to rsync
+      #   (can be relative or fully qualified).
+      # @option opts [String] :origin_host the remote host to sync data from; cannot
+      #   be specified alongside :target_host
+      # @option opts [String] :target_host the remote host to sync data to; cannot
+      #   be specified alongside :origin_host.
+      # @option opts [String] :dryrun (false) tell rsync to perform a trial run
+      #   with no changes made.
+      # @raise [ArgumentError] if opts[:origin_host] and opts[:target_host] names
+      #   are both defined.
+      # @raise [ArgumentError] if :origin_path exists without opts[:target_path],
+      #   opts[:origin_host], remote target is defined.
+      def rsync(origin_path, opts = {})
+        options = {
+          bin: 'rsync',
+          origin_host: nil,
+          target_path: nil,
+          target_host: nil,
+          dryrun: false }.merge(opts)
+        origin = cleanpath(origin_path)
+        target = cleanpath(options[:target_path]) || origin.parent
+
+        raise(ArgumentError, "Cannot sync between two remote hosts") if
+          options[:origin_host] && options[:target_host]
+
+        raise(ArgumentError, "Cannot sync path '#{origin}' to itself") unless
+          options[:origin_host] || options[:target_host]
+
+        cmd = %W(
+          #{options[:bin]}
+          --recursive
+          --links
+          --hard-links
+          --update
+          --human-readable
+          --itemize-changes
+          --progress
+          --verbose
+          --perms
+          --omit-dir-times
+          --no-group
+          --no-owner
+          --delay-updates
+        )
+
+        cmd << '--dry-run' if options[:dryrun]
+        cmd << pseudo_uri(path: origin, host: options[:origin_host])
+        cmd << pseudo_uri(path: target, host: options[:target_host])
+
+        cmd.join("\s")
+      end
+      module_function :rsync
+
+      # Construct a valid chmod command
+      # @return [String] a chmod command that can be used in shell or ssh methods
+      # @param [String, Pathname] path the path to run chmod on
+      # @param [Hash] opts additional options that can be used to construct
+      #   a chmod command.
+      # @option opts [String] :bin ('chmod') the path to chmod
+      #   (can be relative or fully qualified).
+      # @option opts [String] :permissions ('u=rwX,g=rwX,a=rX') the permissions to use
+      #   when constructing a chmod command; can be octal or symbolic. Note that this
+      #   is not sanity checked for accuracy or validity.
+      # @option opts [Boolean] :recursive ('false') whether or not chmod should
+      #   be invoked recursively.
+      def chmod(path, opts = {})
+        options = {
+          bin: 'chmod',
+          permissions: 'ug=rwX,o=rX',
+          recursive: false
+        }.merge(opts)
+
+        cmd = %W(
+          #{options[:bin]}
+          #{options[:permissions]}
+          #{path}
+        )
+
+        # Insert '-R' into the array after the command name
+        # if this should be a recursive call.
+        cmd.insert(1, '-R') if options[:recursive]
+
+        cmd.join("\s")
+      end
+      module_function :chmod
+
+      # Construct a valid sudo command
+      # @return [String] a sudo command that can be used in shell or ssh methods
+      # @param [String] cmd a command-line string to preface with `sudo`
+      # @param [Hash] opts additional options that can be used to construct
+      #   the sudo command
+      # @option opts [String] :bin ('sudo') the path to sudo
+      #   (can be relative or fully qualified)
+      # @option opts [String] :flags ('-E') flags to use when constructing a
+      #   sudo command; defaults to inheriting the current environment of the
+      #   user that runs the sudo command.
+      def sudo(cmd, opts = {})
+        options = { bin: 'sudo', flags: '-E' }.merge(opts)
+        "#{options[:bin]} #{options[:flags]} #{cmd}"
+      end
+      module_function :sudo
+
+      # Construct a probably-correct (or correct-enough) URI for
+      # tools like ssh or rsync. Currently lacking support for intuitive
+      # joins, ports, protocols, fragments, or 75% of what Addressable::URI
+      # or URI would provide out of the box. The "win" here is that
+      # the returned String should "just work".
+      # @private pseudo_uri
+      # @return [String, nil] a string representing either a hostname:/path pair,
+      #   a hostname without a path, or a path without a hostname. Returns nil
+      #   if it is unable to construct a useful URI-like string.
+      # @param [Hash] opts fragments used to build the pseudo URI
+      # @option opts [String] :path URI-ish path component
+      # @option opts [String] :host URI-ish host component
+      def pseudo_uri(opts = {})
+        options = { path: nil, host: nil }.merge(opts)
+
+        # Prune empty values to determine what is returned
+        options.delete_if { |_, v| v.to_s.empty? }
+        return nil if options.empty?
+
+        [options[:host], options[:path]].compact.join(':')
+      end
+      module_function :pseudo_uri
+
+      # Use the Pathname class from Ruby's Stdlib to coerce a
+      # path into something relatively clean and concise.
+      # @return [Pathname, nil] the cleanest version of a passed path.
+      #   Returns nil if it is unable to parse or clean the passed path.
+      # @param [String] path a path that should be sanitized
+      def cleanpath(path)
+        return path.cleanpath if path.respond_to? :cleanpath
+        ::Pathname.new(path).cleanpath
+      rescue
+        nil
+      end
+      module_function :cleanpath
+
+      class << self
+        private :pseudo_uri
+        private :cleanpath
+      end
+    end
+  end
+end

--- a/spec/lib/packaging/util/jenkins_spec.rb
+++ b/spec/lib/packaging/util/jenkins_spec.rb
@@ -2,7 +2,8 @@
 require 'spec_helper'
 
 describe Pkg::Util::Jenkins do
-  let(:build_host) {"Jenkins-foo"}
+  let(:build_host) {"jenkins.example.com"}
+  let(:target_uri) { "https://#{build_host}" }
   let(:name) {"job-foo"}
   around do |example|
     old_build_host = Pkg::Config.jenkins_build_host
@@ -98,6 +99,15 @@ describe Pkg::Util::Jenkins do
           subject.get_jenkins_info(url)
         }.to raise_error(Exception, /Unable to query .*, please check that it is valid./)
       end
+    end
+  end
+
+  describe "#print_url_info" do
+    it "should contain the URL for a Jenkins job" do
+      Pkg::Util::Jenkins.should_receive(:puts) do |argument|
+        argument.should include target_uri
+      end
+      Pkg::Util::Jenkins.print_url_info(target_uri)
     end
   end
 

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -4,8 +4,8 @@ require 'open3'
 
 describe "Pkg::Util::Net" do
   let(:target)     { "/tmp/placething" }
-  let(:target_uri) { "http://google.com" }
-  let(:content)    { "stuff" }
+  let(:target_uri) { "http://example.com" }
+  let(:content)    { "some stuff in a string\nwith newlines\aand\ttabs" }
   let(:rsync)      { "/bin/rsync" }
   let(:ssh)        { "/usr/local/bin/ssh" }
   let(:s3cmd)      { "/usr/local/bin/s3cmd" }
@@ -178,14 +178,5 @@ describe "Pkg::Util::Net" do
       Pkg::Util::Net.curl_form_data(target_uri, form_data, options)
     end
 
-  end
-
-  describe "#print_job_url_info" do
-    it "should output correct formatting" do
-      Pkg::Util::Net.should_receive(:puts).with("\n////////////////////////////////////////////////////////////////////////////////\n\n
-  Build submitted. To view your build progress, go to\n#{target_uri}\n\n
-////////////////////////////////////////////////////////////////////////////////\n\n")
-      Pkg::Util::Jenkins.print_job_url_info(target_uri)
-    end
   end
 end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -10,22 +10,6 @@ describe "Pkg::Util::Net" do
   let(:ssh)        { "/usr/local/bin/ssh" }
   let(:s3cmd)      { "/usr/local/bin/s3cmd" }
 
-  describe "#fetch_uri" do
-    context "given a target directory" do
-      it "does nothing if the directory isn't writable" do
-        File.stub(:writable?).with(File.dirname(target)) { false }
-        File.should_receive(:open).never
-        Pkg::Util::Net.fetch_uri(target_uri, target)
-      end
-
-      it "writes the content of the uri to a file if directory is writable" do
-        File.should_receive(:writable?).once.with(File.dirname(target)) { true }
-        File.should_receive(:open).once.with(target, 'w')
-        Pkg::Util::Net.fetch_uri(target_uri, target)
-      end
-    end
-  end
-
   describe "hostname utils" do
 
     describe "hostname" do

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -18,23 +18,6 @@ describe "Pkg::Util::Net" do
         Pkg::Util::Net.hostname.should eq("foo")
       end
     end
-
-    describe "check_host" do
-      context "with required :true" do
-        it "should raise an exception if the passed host does not match the current host" do
-          Socket.stub(:gethostname) { "foo" }
-          Pkg::Util::Net.should_receive(:check_host).and_raise(RuntimeError)
-          expect{ Pkg::Util::Net.check_host("bar", :required => true) }.to raise_error(RuntimeError)
-        end
-      end
-
-      context "with required :false" do
-        it "should return nil if the passed host does not match the current host" do
-          Socket.stub(:gethostname) { "foo" }
-          Pkg::Util::Net.check_host("bar", :required => false).should be_nil
-        end
-      end
-    end
   end
 
   describe "remote_ssh_cmd" do
@@ -197,12 +180,12 @@ describe "Pkg::Util::Net" do
 
   end
 
-  describe "#print_url_info" do
+  describe "#print_job_url_info" do
     it "should output correct formatting" do
       Pkg::Util::Net.should_receive(:puts).with("\n////////////////////////////////////////////////////////////////////////////////\n\n
   Build submitted. To view your build progress, go to\n#{target_uri}\n\n
 ////////////////////////////////////////////////////////////////////////////////\n\n")
-      Pkg::Util::Net.print_url_info(target_uri)
+      Pkg::Util::Jenkins.print_job_url_info(target_uri)
     end
   end
 end

--- a/tasks/00_utils.rake
+++ b/tasks/00_utils.rake
@@ -232,8 +232,8 @@ def jenkins_job_exists?(name)
 end
 
 def print_url_info(url_string)
-  deprecate("print_url_info", "Pkg::Util::Net.print_url_info")
-  Pkg::Util::Net.print_url_info(url_string)
+  deprecate("print_url_info", "Pkg::Util::Jenkins.print_url_info")
+  Pkg::Util::Jenkins.print_url_info(url_string)
 end
 
 def retry_on_fail(args, &block)

--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -176,7 +176,7 @@ namespace :pl do
       trigger_url = "#{Pkg::Config.jenkins_build_host}/job/#{name}/build"
 
       if Pkg::Util::Net.curl_form_data(trigger_url, curl_args)
-        Pkg::Util::Net.print_url_info("http://#{Pkg::Config.jenkins_build_host}/job/#{name}")
+        Pkg::Util::Jenkins.print_url_info("http://#{Pkg::Config.jenkins_build_host}/job/#{name}")
         puts "Your packages will be available at http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       else
         fail "An error occurred submitting the job to jenkins. Take a look at the preceding http response for more info."


### PR DESCRIPTION
There's a LOT of duplication between the new rsync calls in the `deb` and `rpm` `repo` classes. This is because the `rsync_to` and `rsync_from` methods were not flexible enough to support our needs here. This refactoring aims to make constructing `rsync` helpers easier while reducing code repetition whenever possible.