### PR TITLE
Polish up the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'rake', "~> 0.9.6"
-  gem 'rspec', "~> 2.14.1"
+  gem 'rake', '~> 0.9.6'
+  gem 'rspec', '~> 2.14.1'
   gem 'pry'
-  gem 'win32console', :platforms => [:mingw_18, :mingw_19]
-  gem 'rubocop', "~> 0.24.1", :require => false
+  gem 'win32console', platforms: [:mingw_18, :mingw_19]
+  gem 'rubocop', '~> 0.24.1', require: false
 end
 
 group :jira do
@@ -18,7 +18,7 @@ group :jira do
   #
   # - Ryan McKern, 2016-01-19
   if RUBY_REVISION < 50295
-    gem 'activesupport', "< 5.0.0", require: false
+    gem 'activesupport', '< 5.0.0', require: false
   end
   gem 'jira-ruby'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,16 @@ group :development, :test do
 end
 
 group :jira do
-  # After 0.1.12 the jira-ruby gem depends on the latest activesupport,
-  # which in turn requires ruby >= 2.2.2. So until we move to ruby 2.2,
-  # lock the version of jira-ruby to 0.1.12:
-  gem 'jira-ruby', "0.1.12"
+  # The latest versions of ActiveSupport require Ruby 2.2 or greater.
+  # Instead of forcing a Ruby upgrade, we should constrain the version
+  # of ActiveSupport to anything less than 5.0.0, where the requirement
+  # was introduced. I mean, we could probably constrain this in general
+  # because ActiveSupport is not a thing we want to rely on, but
+  # being conservative is probably safest.
+  #
+  # - Ryan McKern, 2016-01-19
+  if RUBY_REVISION < 50295
+    gem 'activesupport', "< 5.0.0", require: false
+  end
+  gem 'jira-ruby'
 end


### PR DESCRIPTION
![gemcut011](https://cloud.githubusercontent.com/assets/344926/12437597/0b926e10-bed4-11e5-9421-3d5190b5ee6c.jpg)

This PR adds a constraint around ActiveRecord, depending on the Ruby revision (which should be safe as this is an integer which only goes up, and is sane; unlike `RUBY_VERSION`). This will let us use newer versions of `jira-ruby` without worrying about accidentally pulling in ActiveRecord 5 now that `jira-ruby` has unconstrained their ActiveRecord requirements.

While I was in there, I also updated the Ruby hash syntax (since a `Gemfile` is kinda just a big dumb Ruby hash) and mangled quotes so that they're consistent across the file.