### PR TITLE
(MAINT) Change how rsync copies rpm & deb repos

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -194,15 +194,20 @@ SignWith: #{Pkg::Config.gpg_key}"
       # fail due to permission errors.
       options = %w(
         rsync
+        --delay-updates
+        --links
         --hard-links
         --copy-links
         --omit-dir-times
         --progress
-        --archive
+        --recursive
         --update
+        --human-readable
+        --itemize-changes
         --verbose
         --perms
         --no-group
+        --no-owner
         --chmod='Dugo-s,Dug=rwx,Do=rx,Fug=rw,Fo=r'
         --exclude='dists/*-*'
         --exclude='pool/*-*'

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -52,7 +52,8 @@ module Pkg::Rpm::Repo
       # fail due to permission errors.
       options = %w(
         rsync
-        --archive
+        --recursive
+        --links
         --hard-links
         --update
         --human-readable


### PR DESCRIPTION
These new settings should hopefully lead to less conflict
and gnashing of teeth and rending of garments and lamentations
from our loved ones.