### PR TITLE
(RE-6493) explicitly require 'set'

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Pkg
   module Platforms
     # Each element in this hash


### PR DESCRIPTION
Without requiring 'set', the #to_set method will not be available on Arrays.