### PR TITLE
(RE-6498) Fix permissions when shipping

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -235,14 +235,7 @@ SignWith: #{Pkg::Config.gpg_key}"
     def deploy_repos(apt_path, destination_staging_path, origin_server, destination_server, dryrun = false)
       rsync_command = repo_deployment_command(apt_path, destination_staging_path, destination_server, dryrun)
       cp_command = repo_deployment_command(destination_staging_path, apt_path, nil, dryrun)
-      # Defensive permissions setting are defensive
-      chmod_command = "sudo chmod -R g=rwX #{destination_staging_path}; sudo chmod -R g-s,g=rwX #{apt_path}"
 
-      if dryrun
-        puts "[DRYRUN] not executing #{chmod_command} on #{destination_server}"
-      else
-        Pkg::Util::Net.remote_ssh_cmd(destination_server, chmod_command)
-      end
       Pkg::Util::Net.remote_ssh_cmd(origin_server, rsync_command)
       if dryrun
         puts "[DRYRUN] not executing #{cp_command} on #{destination_server}"

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -202,7 +202,6 @@ SignWith: #{Pkg::Config.gpg_key}"
         --update
         --verbose
         --perms
-        --no-group
         --chmod='Dugo-s,Dug=rwx,Do=rx,Fug=rw,Fo=r'
         --exclude='dists/*-*'
         --exclude='pool/*-*'

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -63,8 +63,6 @@ module Pkg::Rpm::Repo
         --chmod='Dugo-s,Dug=rwx,Do=rx,Fug=rw,Fo=r'
         --omit-dir-times
         --no-times
-        --no-group
-        --no-owner
         --delay-updates
       )
 

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -62,6 +62,7 @@ module Pkg::Rpm::Repo
         --perms
         --chmod='Dugo-s,Dug=rwx,Do=rx,Fug=rw,Fo=r'
         --omit-dir-times
+        --no-times
         --no-group
         --no-owner
         --delay-updates

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -79,19 +79,6 @@ module Pkg::Rpm::Repo
       options.join("\s")
     end
 
-    # @param path [String] The path to mangle permissions for
-    # @param sudo [Boolean] Whether or not the chmod command
-    #   should be wrapped by sudo
-    #
-    # @return [String] a chmod command (optionally wrapped in sudo)
-    #   that can be executed on a remote host
-    #   to mangle/reset permissions for a given directory
-    def repo_permissions_command(path, sudo = true)
-      cmd = "chmod -R g-s,g=rwX #{path}"
-      cmd = "sudo -E #{cmd}" if sudo
-      cmd
-    end
-
     def create_repos(directory = "repos")
       Dir.chdir(directory) do
         createrepo = Pkg::Util::Tool.check_tool('createrepo')
@@ -242,13 +229,6 @@ module Pkg::Rpm::Repo
     # @param dryrun [Boolean] whether or not to use '--dry-run'
     def deploy_repos(yum_path, origin_server, destination_server, dryrun = false)
       rsync_command = repo_deployment_command(yum_path, yum_path, destination_server, dryrun)
-      chmod_command = repo_permissions_command(yum_path)
-
-      if dryrun
-        puts "[DRYRUN] not executing #{chmod_command} on #{destination_server}"
-      else
-        Pkg::Util::Net.remote_ssh_cmd(destination_server, chmod_command)
-      end
 
       Pkg::Util::Net.remote_ssh_cmd(origin_server, rsync_command)
     end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -131,5 +131,13 @@ module Pkg::Util::Net
   Build submitted. To view your build progress, go to\n#{url_string}\n\n
 ////////////////////////////////////////////////////////////////////////////////\n\n"
     end
+
+    def remote_set_ownership(host, owner, group, files)
+      Pkg::Util::Net.remote_ssh_cmd(host, "sudo chown #{owner}:#{group} #{files.join(" ")}")
+    end
+
+    def remote_set_permissions(host, permissions, files)
+      Pkg::Util::Net.remote_ssh_cmd(host, "sudo chmod #{permissions} #{files.join(" ")}")
+    end
   end
 end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -133,11 +133,13 @@ module Pkg::Util::Net
     end
 
     def remote_set_ownership(host, owner, group, files)
-      Pkg::Util::Net.remote_ssh_cmd(host, "sudo chown #{owner}:#{group} #{files.join(" ")}")
+      remote_cmd = "for file in #{files.join(" ")}; do lsattr $file | grep -q '\\-i\\-'; if [ $? -eq 1 ]; then sudo chown #{owner}:#{group} $file; else echo \"$file is immutable\"; fi; done"
+      Pkg::Util::Net.remote_ssh_cmd(host, remote_cmd)
     end
 
     def remote_set_permissions(host, permissions, files)
-      Pkg::Util::Net.remote_ssh_cmd(host, "sudo chmod #{permissions} #{files.join(" ")}")
+      remote_cmd = "for file in #{files.join(" ")}; do lsattr $file | grep -q '\\-i\\-'; if [ $? -eq 1 ]; then sudo chmod #{permissions} $file; else echo \"$file is immutable\"; fi; done"
+      Pkg::Util::Net.remote_ssh_cmd(host, remote_cmd)
     end
   end
 end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -85,6 +85,11 @@ namespace :pl do
   task :ship_debs => 'pl:fetch' do
     Pkg::Util::Execution.retry_on_fail(:times => 3) do
       if File.directory?("pkg/deb")
+
+        pkgs = Dir["pkg/deb/**/*\.*"]
+        pkgs = pkgs.map { |f| f.gsub("pkg/deb", Pkg::Config.apt_repo_staging_path) }
+        puts "pkgs = #{pkgs}"
+
         Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.apt_signing_server, Pkg::Config.apt_repo_staging_path)
         Pkg::Util::Net.remote_set_ownership(Pkg::Config.apt_signing_server, 'root', 'release', pkgs)
         Pkg::Util::Net.remote_set_permissions(Pkg::Config.apt_signing_server, '0664', pkgs)
@@ -315,8 +320,8 @@ namespace :pl do
         "#{artifact_dir}/#{file.sub(/^#{local_dir}\//, '')}"
       end
 
-      Pkg::Util::Net.remote_set_ownership(Pkg::Config.distribution_server, 'root', 'release', pkgs)
-      Pkg::Util::Net.remote_set_permissions(Pkg::Config.distribution_server, '0664', pkgs)
+      Pkg::Util::Net.remote_set_ownership(Pkg::Config.distribution_server, 'root', 'release', files)
+      Pkg::Util::Net.remote_set_permissions(Pkg::Config.distribution_server, '0664', files)
       remote_set_immutable(Pkg::Config.distribution_server, files)
     end
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -19,6 +19,8 @@ namespace :pl do
           extra_flags
         )
 
+        Pkg::Util::Net.remote_set_ownership(Pkg::Config.yum_staging_server, 'root', 'release', pkgs)
+        Pkg::Util::Net.remote_set_permissions(Pkg::Config.yum_staging_server, '0664', pkgs)
         remote_set_immutable(Pkg::Config.yum_staging_server, pkgs)
       end
     end
@@ -84,6 +86,8 @@ namespace :pl do
     Pkg::Util::Execution.retry_on_fail(:times => 3) do
       if File.directory?("pkg/deb")
         Pkg::Util::Net.rsync_to('pkg/deb/', Pkg::Config.apt_signing_server, Pkg::Config.apt_repo_staging_path)
+        Pkg::Util::Net.remote_set_ownership(Pkg::Config.apt_signing_server, 'root', 'release', pkgs)
+        Pkg::Util::Net.remote_set_permissions(Pkg::Config.apt_signing_server, '0664', pkgs)
       else
         warn "No deb packages found to ship; nothing to do"
       end
@@ -310,6 +314,9 @@ namespace :pl do
       files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) }.map do |file|
         "#{artifact_dir}/#{file.sub(/^#{local_dir}\//, '')}"
       end
+
+      Pkg::Util::Net.remote_set_ownership(Pkg::Config.distribution_server, 'root', 'release', pkgs)
+      Pkg::Util::Net.remote_set_permissions(Pkg::Config.distribution_server, '0664', pkgs)
       remote_set_immutable(Pkg::Config.distribution_server, files)
     end
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -8,7 +8,7 @@ namespace :pl do
       prefix = File.join(Pkg::Config.yum_repo_path, dist)
       pkgs = pkgs.map { |f| f.gsub("pkg/#{dist}", prefix) }
 
-      extra_flags = ['--delay-updates']
+      extra_flags = ['--ignore-existing', '--delay-updates']
       extra_flags << '--dry-run' if ENV['DRYRUN']
 
       Pkg::Util::Execution.retry_on_fail(:times => 3) do


### PR DESCRIPTION
We want to set group and ownership correctly on staging, then preserve these permissions when shipping.

This also addresses a few failures we were seeing.