### PR TITLE
DO NOT MERGE (RE-6263) Update huaweios platform hash

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -38,7 +38,7 @@ module Pkg
       },
 
       'huaweios' => {
-        '6' => { :codename => 'huaweios', :architectures => ['powerpc'], :repo => true, :package_format => 'deb', },
+        '6' => { :codename => 'huaweios', :architectures => ['ppc'], :repo => true, :package_format => 'deb', },
       },
 
       'osx' => {


### PR DESCRIPTION
The current packages use ppc as the arch; this will be changed back
to powerpc when the remaining code has been thoroughly tested.