### PR TITLE
(MAINT) Wouldn't it be rad to view Pkg::Config in a readable format?

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -9,6 +9,13 @@ module Pkg
     require 'yaml'
 
     class << self
+      ##
+      #   Returns a hash with string keys that maps instance variable
+      #   names without "@"" to their corresponding values.
+      #
+      def instance_values
+        Hash[instance_variables.map { |name| [name[1..-1], instance_variable_get(name)] }]
+      end
 
       #   Every element in Pkg::Params::BUILD_PARAMS is a configurable setting
       #   for the build. We use Pkg::Params::BUILD_PARAMS as the source of

--- a/lib/packaging/util/rake_utils.rb
+++ b/lib/packaging/util/rake_utils.rb
@@ -99,6 +99,7 @@ module Pkg::Util::RakeUtils
         'vendor_gems.rake',
         'version.rake',
         'z_data_dump.rake',
+        'config.rake',
       ]
 
       tasks.each do |task|

--- a/tasks/config.rake
+++ b/tasks/config.rake
@@ -1,0 +1,8 @@
+namespace :config do
+  desc "print Pkg::Config values for this repo"
+  task :print do
+    Pkg::Config.instance_values.each do |key, value|
+      puts "#{key}: #{value}"
+    end
+  end
+end

--- a/tasks/config.rake
+++ b/tasks/config.rake
@@ -5,4 +5,20 @@ namespace :config do
       puts "#{key}: #{value}"
     end
   end
+
+  desc "print environment variables that can override build-data and build_defaults"
+  task :environment_variables do
+    Pkg::Params::ENV_VARS.each do |values|
+      type = case values[:type]
+      when :array
+        "expects one or more space, comma, or semicolon delimited value; treated as an array"
+      when :bool
+        "expects a boolean value"
+      end
+
+      msg = "#{values[:var]}: #{values[:envvar]}"
+      msg += " (#{type})" if type
+      puts msg
+    end
+  end
 end


### PR DESCRIPTION
I thought it would be, so in service of some of my other work I bashed two rocks together to make this. It'll add two rake tasks to make validating/viewing the current state of a project's config easier.

![giphy 2](https://cloud.githubusercontent.com/assets/344926/13262815/a92547b2-da1b-11e5-9bad-d6cab60bdace.gif)
