### PR TITLE
(MAINT) Fix broken calls to ::File class methods

### DIFF
--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -4,6 +4,15 @@ require 'fileutils'
 module Pkg::Util::File
 
   class << self
+    def exist?(file)
+      ::File.exist?(file)
+    end
+    alias_method :exists?, :exist?
+
+    def directory?
+      ::File.directory?(file)
+    end
+
     def mktemp
       mktemp = Pkg::Util::Tool.find_tool('mktemp', :required => true)
       Pkg::Util::Execution.ex("#{mktemp} -d -t pkgXXXXXX").strip


### PR DESCRIPTION
Namespacing is hard, and we use `File#directory?` and `File#exist?` all over Packaging. When I tried fixing them, I gave up around the 170th instance of `File#somethingorother` and instead made some passthrough methods in the existing `Pkg::Util::File` class.

This is a dirty hack, and it shouldn't be how we do business. But it'll unblock things while we rename the `Pkg::Util` classes that conflict with core or stdlib classes.