### PR TITLE
(RE-6596) Fix missing argument to File.directory?

### DIFF
--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -9,7 +9,7 @@ module Pkg::Util::File
     end
     alias_method :exists?, :exist?
 
-    def directory?
+    def directory?(file)
       ::File.directory?(file)
     end
 


### PR DESCRIPTION
This was left off of the last hotfix, and it causes Packaging
to explode in new and interesting ways.