### PR TITLE
Deferred maintenance for health and safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ if File.exist?(build_defs_file)
     require 'yaml'
     @build_defaults ||= YAML.load_file(build_defs_file)
   rescue Exception => e
-    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
+    $stderr.puts "Unable to load yaml from #{build_defs_file}:"
     raise e
   end
   @packaging_url  = @build_defaults['packaging_url']
@@ -908,14 +908,14 @@ files:
 
 * **pl:print_build_params**
 
-    Print all build parameters to STDOUT as they would be used in a package
+    Print all build parameters to $stdout as they would be used in a package
     build. This prints data that is loaded from `ext/build_defaults.yaml` and
     `ext/project_data.yaml`, as well as whatever is overridden with environment
     variables. Useful for debugging problems with parameter values.
 
 * **pl:print_build_param[param]**
 
-    Print a specific build parameter to STDOUT as it would be used in a package
+    Print a specific build parameter to $stdout as it would be used in a package
     build. This prints data that is loaded from `ext/build_defaults.yaml` and
     `ext/project_data.yaml`, as well as whatever is overridden with environment
     variables. Useful for debugging problems with parameter values. param
@@ -1017,7 +1017,7 @@ files:
     build_extras.yaml(s) via `pl:fetch`, and any environment variables. This
     file can be used by the packaging repo as a single source of truth for
     build data via `pl:build_from_params`. By default it is written to a
-    temporary location and its location is printed to STDOUT. To override the
+    temporary location and its location is printed to $stdout. To override the
     destination, pass OUTPUT_DIR as a environment variable to the task. By
     default, the name of the file will be either the git tag, if HEAD of the
     project repository is a tag, or the git sha of HEAD.

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -194,6 +194,7 @@ SignWith: #{Pkg::Config.gpg_key}"
       # fail due to permission errors.
       options = %w(
         rsync
+        --itemize-changes
         --hard-links
         --copy-links
         --omit-dir-times
@@ -201,8 +202,12 @@ SignWith: #{Pkg::Config.gpg_key}"
         --archive
         --update
         --verbose
-        --perms
-        --chmod='Dugo-s,Dug=rwx,Do=rx,Fug=rw,Fo=r'
+        --super
+        --delay-updates
+        --omit-dir-times
+        --no-perms
+        --no-owner
+        --no-group
         --exclude='dists/*-*'
         --exclude='pool/*-*'
       )

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -1,21 +1,39 @@
 module Pkg::Gem
   class << self
+    # This is preserved because I don't want to update the deprecated code path
+    # yet; I'm not entirely sure I've fixed everything that might attempt
+    # to call this method so this is now a wrapper for a wrapper.
     def ship(file)
+      ship_stickler(file)
+      rsync_to_downloads(file)
+      ship_to_rubygems(file)
+    end
+
+    # Ship a Ruby gem file to a Stickler server, because
+    # you've lost the ability to feel joy anymore.
+    def ship_to_stickler(file)
+      Pkg::Util::Tool.check_tool("stickler")
+      Pkg::Util::Execution.ex("stickler push #{file} --server=#{Pkg::Config.internal_gem_host} 2>/dev/null")
+      puts "#{file} pushed to stickler server at #{Pkg::Config.internal_gem_host}"
+    rescue
+      puts "###########################################"
+      puts "#  Stickler failed, ensure it's installed"
+      puts "#  and you have access to #{Pkg::Config.internal_gem_host}"
+      puts "###########################################"
+    end
+
+    # Use rsync to deploy a file and any associated detached signatures,
+    # checksums, or other glob-able artifacts to an external download server.
+    def rsync_to_downloads(file)
+      Pkg::Util::Net.rsync_to("#{file}*", Pkg::Config.gem_host, Pkg::Config.gem_path)
+    end
+
+    # Ship a Ruby gem file to rubygems.org. Requires the existence
+    # of a ~/.gem/credentials file or else rubygems.org won't have
+    # any idea who you are.
+    def ship_to_rubygems(file)
       Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
       Pkg::Util::Execution.ex("gem push #{file}")
-      begin
-        Pkg::Util::Tool.check_tool("stickler")
-        Pkg::Util::Execution.ex("stickler push #{file} --server=#{Pkg::Config.internal_gem_host} 2>/dev/null")
-        puts "#{file} pushed to stickler server at #{Pkg::Config.internal_gem_host}"
-      rescue
-        puts "##########################################\n#"
-        puts "#  Stickler failed, ensure it's installed"
-        puts "#  and you have access to #{Pkg::Config.internal_gem_host} \n#"
-        puts "##########################################"
-      end
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
-        Pkg::Util::Net.rsync_to("#{file}*", Pkg::Config.gem_host, Pkg::Config.gem_path)
-      end
     end
   end
 end

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -13,8 +13,13 @@ module Pkg::Gem
     # you've lost the ability to feel joy anymore.
     def ship_to_stickler(file)
       Pkg::Util::Tool.check_tool("stickler")
-      Pkg::Util::Execution.ex("stickler push #{file} --server=#{Pkg::Config.internal_gem_host} 2>/dev/null")
-      puts "#{file} pushed to stickler server at #{Pkg::Config.internal_gem_host}"
+      cmd = "stickler push #{file} --server=#{Pkg::Config.internal_gem_host} 2>/dev/null"
+      if ENV['DRYRUN']
+        puts "[DRY-RUN] #{cmd}"
+      else
+        Pkg::Util::Execution.ex(cmd)
+        puts "#{file} pushed to stickler server at #{Pkg::Config.internal_gem_host}"
+      end
     rescue
       puts "###########################################"
       puts "#  Stickler failed, ensure it's installed"
@@ -25,7 +30,7 @@ module Pkg::Gem
     # Use rsync to deploy a file and any associated detached signatures,
     # checksums, or other glob-able artifacts to an external download server.
     def rsync_to_downloads(file)
-      Pkg::Util::Net.rsync_to("#{file}*", Pkg::Config.gem_host, Pkg::Config.gem_path)
+      Pkg::Util::Net.rsync_to("#{file}*", Pkg::Config.gem_host, Pkg::Config.gem_path, dryrun: ENV['DRYRUN'])
     end
 
     # Ship a Ruby gem file to rubygems.org. Requires the existence

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -59,10 +59,12 @@ module Pkg::Rpm::Repo
         --itemize-changes
         --progress
         --verbose
-        --perms
-        --chmod='Dugo-s,Dug=rwx,Do=rx,Fug=rw,Fo=r'
+        --super
+        --delay-updates
         --omit-dir-times
-        --no-times
+        --no-perms
+        --no-owner
+        --no-group
         --delay-updates
       )
 

--- a/lib/packaging/tar.rb
+++ b/lib/packaging/tar.rb
@@ -47,7 +47,7 @@ module Pkg
       patterns =
         case @files
         when String
-          STDERR.puts "warning: `files` should be an array, not a string"
+          $stderr.puts "warning: `files` should be an array, not a string"
           @files.split(' ')
         when Array
           @files

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -95,9 +95,9 @@ module Pkg::Util
   end
 
   def self.confirm_ship(files)
-    STDOUT.puts "The following files have been built and are ready to ship:"
+    $stdout.puts "The following files have been built and are ready to ship:"
     files.each { |file| puts "\t#{file}\n" unless File.directory?(file) }
-    STDOUT.puts "Ship these files?? [y,n]"
+    $stdout.puts "Ship these files?? [y,n]"
     Pkg::Util.ask_yes_or_no
   end
 
@@ -128,6 +128,6 @@ module Pkg::Util
     if new_cmd
       msg << " Please use #{new_cmd} instead."
     end
-    STDOUT.puts("\n#{msg}\n")
+    $stdout.puts("\n#{msg}\n")
   end
 end

--- a/lib/packaging/util/execution.rb
+++ b/lib/packaging/util/execution.rb
@@ -23,6 +23,11 @@ module Pkg::Util::Execution
     # while also raising an exception if a command does not succeed (ala `sh "cmd"`).
     def ex(command, debug = false)
       puts "Executing '#{command}'..." if debug
+      if ENV['DRYRUN']
+        puts "[DRY-RUN] #{command}"
+        return true
+      end
+
       ret = `#{command}`
       unless Pkg::Util::Execution.success?
         raise RuntimeError

--- a/tasks/ips.rake
+++ b/tasks/ips.rake
@@ -103,7 +103,7 @@ if @build_ips
         # retrieve the signed package in a .p5p archive file format
         Rake::Task['package:ips:receive'].invoke
         # clean up the workdir area
-        Rake::Task['package:ips:clean'].execute
+        Rake::Task['package:ips:clean'].invoke
         STDOUT.puts "Created #{Dir['pkg/ips/pkgs/*']}"
       end
     end

--- a/tasks/ips.rake
+++ b/tasks/ips.rake
@@ -104,7 +104,7 @@ if @build_ips
         Rake::Task['package:ips:receive'].invoke
         # clean up the workdir area
         Rake::Task['package:ips:clean'].invoke
-        STDOUT.puts "Created #{Dir['pkg/ips/pkgs/*']}"
+        $stdout.puts "Created #{Dir['pkg/ips/pkgs/*']}"
       end
     end
 

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -270,8 +270,13 @@ namespace :pl do
       uber_tasks.delete("remote:deploy_swix_rep") if Pkg::Config.swix_host == Pkg::Config.swix_staging_server
       uber_tasks.delete("remote:deploy_tar_repo") if Pkg::Config.tar_host == Pkg::Config.tar_staging_server
 
-      uber_tasks.map { |t| "pl:#{t}" }.each { |t| Rake::Task[t].invoke }
-      Rake::Task["pl:jenkins:ship"].invoke("shipped")
+      uber_tasks.map { |t| "pl:#{t}" }.each do |t|
+        puts "Do you want run #{t}?"
+        Rake::Task[t].invoke if Pkg::Util.ask_yes_or_no
+      end
+
+      puts "Do you want to mark this release as successfully shipped?"
+      Rake::Task["pl:jenkins:ship"].invoke("shipped") if Pkg::Util.ask_yes_or_no
     end
   end
 end

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -44,10 +44,10 @@ def mock_artifact(mock_config, cmd_args, mockfile)
     content   = File.read(build_log) if File.readable?(build_log)
 
     if File.readable?(root_log)
-      STDERR.puts File.read(root_log)
+      $stderr.puts File.read(root_log)
     end
     if content and content.lines.count > 2
-      STDERR.puts content
+      $stderr.puts content
     end
 
     # Any useful info has now been gleaned from the logs in the case of a

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -282,12 +282,12 @@ namespace :pl do
       Rake::Task["pl:ship_gem"].invoke if Pkg::Config.build_gem
       Rake::Task["pl:ship_rpms"].invoke if Pkg::Config.final_mocks || Pkg::Config.vanagon_project
       Rake::Task["pl:ship_debs"].invoke if Pkg::Config.cows || Pkg::Config.vanagon_project
-      Rake::Task["pl:ship_dmg"].execute if Pkg::Config.build_dmg || Pkg::Config.vanagon_project
-      Rake::Task["pl:ship_swix"].execute if Pkg::Config.vanagon_project
-      Rake::Task["pl:ship_nuget"].execute if Pkg::Config.vanagon_project
-      Rake::Task["pl:ship_tar"].execute if Pkg::Config.build_tar
-      Rake::Task["pl:ship_svr4"].execute if Pkg::Config.vanagon_project
-      Rake::Task["pl:ship_p5p"].execute if Pkg::Config.build_ips || Pkg::Config.vanagon_project
+      Rake::Task["pl:ship_dmg"].invoke if Pkg::Config.build_dmg || Pkg::Config.vanagon_project
+      Rake::Task["pl:ship_swix"].invoke if Pkg::Config.vanagon_project
+      Rake::Task["pl:ship_nuget"].invoke if Pkg::Config.vanagon_project
+      Rake::Task["pl:ship_tar"].invoke if Pkg::Config.build_tar
+      Rake::Task["pl:ship_svr4"].invoke if Pkg::Config.vanagon_project
+      Rake::Task["pl:ship_p5p"].invoke if Pkg::Config.build_ips || Pkg::Config.vanagon_project
       Rake::Task["pl:jenkins:ship"].invoke("shipped")
       add_shipped_metrics(:pe_version => ENV['PE_VER'], :is_rc => (!Pkg::Util::Version.is_final?)) if Pkg::Config.benchmark
       post_shipped_metrics if Pkg::Config.benchmark

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -224,14 +224,14 @@ namespace :pl do
       # strategies, we only want to ship final gems because otherwise a
       # development gem would be preferred over the last final gem
       if Pkg::Config.version_strategy !~ /odd_even|zero_based/ || Pkg::Util::Version.is_final?
-        FileList["pkg/#{Pkg::Config.gem_name}-#{Pkg::Config.gemversion}*.gem"].each do |file|
+        FileList["pkg/#{Pkg::Config.gem_name}-#{Pkg::Config.gemversion}*.gem"].each do |gem_file|
           puts "This will ship to an internal gem mirror, a public file server, and rubygems.org"
-          puts "Do you want to start shipping the rubygem '#{file}'?"
-          next unless Pkg::Util.ask_yes_or_no
-
-          Rake::Task["pl:ship_gem_to_rubygems"].invoke(file)
-          Rake::Task["pl:ship_gem_to_internal_mirror"].invoke(file)
-          Rake::Task["pl:ship_gem_to_downloads"].invoke(file)
+          puts "Do you want to start shipping the rubygem '#{gem_file}'?"
+          if Pkg::Util.ask_yes_or_no
+            Rake::Task["pl:ship_gem_to_rubygems"].execute(file: gem_file)
+            Rake::Task["pl:ship_gem_to_internal_mirror"].execute(file: gem_file)
+            Rake::Task["pl:ship_gem_to_downloads"].execute(file: gem_file)
+          end
         end
       else
         $stderr.puts "Not shipping development gem using odd_even strategy for the sake of your users."

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -41,7 +41,7 @@ namespace :pl do
         __GPG_KEY__: Pkg::Config.gpg_key,
       }
 
-      STDOUT.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
+      $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
         if Pkg::Config.yum_repo_command
           Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_staging_server, Pkg::Util::Misc.search_and_replace(Pkg::Config.yum_repo_command, yum_whitelist))
@@ -64,7 +64,7 @@ namespace :pl do
         __GPG_KEY__: Pkg::Config.gpg_key,
       }
 
-      STDOUT.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
+      $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
         if Pkg::Config.apt_repo_command
           Pkg::Util::Net.remote_ssh_cmd(
@@ -121,7 +121,7 @@ namespace :pl do
     desc "Update remote ips repository on #{Pkg::Config.ips_host}"
     task :update_ips_repo  => 'pl:fetch' do
       if Dir['pkg/ips/pkgs/**/*'].empty? && Dir['pkg/solaris/11/**/*'].empty?
-        STDOUT.puts "There aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11. Maybe something went wrong?"
+        $stdout.puts "There aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11. Maybe something went wrong?"
       else
 
         if !Dir['pkg/ips/pkgs/**/*'].empty?
@@ -229,7 +229,7 @@ namespace :pl do
           Rake::Task["pl:ship_gem_to_downloads"].invoke
         end
       else
-        STDERR.puts "Not shipping development gem using odd_even strategy for the sake of your users."
+        $stderr.puts "Not shipping development gem using odd_even strategy for the sake of your users."
       end
     end
 
@@ -278,7 +278,7 @@ namespace :pl do
   desc "ship apple dmg to #{Pkg::Config.dmg_staging_server}"
   task :ship_dmg => 'pl:fetch' do
     if Dir['pkg/apple/**/*.dmg'].empty?
-      STDOUT.puts "There aren't any dmg packages in pkg/apple. Maybe something went wrong?"
+      $stdout.puts "There aren't any dmg packages in pkg/apple. Maybe something went wrong?"
     else
       puts "Do you want to ship dmg files to (#{Pkg::Config.dmg_staging_server})?"
       if Pkg::Util.ask_yes_or_no
@@ -293,7 +293,7 @@ namespace :pl do
   task :ship_swix => 'pl:fetch' do
     packages = Dir['pkg/eos/**/*.swix']
     if packages.empty?
-      STDOUT.puts "There aren't any swix packages in pkg/eos. Maybe something went wrong?"
+      $stdout.puts "There aren't any swix packages in pkg/eos. Maybe something went wrong?"
     else
       Pkg::Util::Execution.retry_on_fail(:times => 3) do
         Pkg::Util::Net.rsync_to("pkg/eos/", Pkg::Config.swix_staging_server, Pkg::Config.swix_path)
@@ -319,7 +319,7 @@ namespace :pl do
   task :ship_nuget => 'pl:fetch' do
     packages = Dir['pkg/windows/**/*.nupkg']
     if packages.empty?
-      STDOUT.puts "There aren't any nuget packages in pkg/windows. Maybe something went wrong?"
+      $stdout.puts "There aren't any nuget packages in pkg/windows. Maybe something went wrong?"
     else
       Pkg::Nuget.ship(packages)
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -171,9 +171,14 @@ namespace :pl do
     task :deploy_tar_repo => 'pl:fetch' do
       puts "Really run remote rsync to deploy source tarballs from #{Pkg::Config.tar_staging_server} to #{Pkg::Config.tar_host}? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.tarball_path, target_host: Pkg::Config.tar_host)
-          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.tar_staging_server, cmd)
+        files = Dir.glob("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*")
+        if files.empty?
+          puts "There are no tarballs to ship"
+        else
+          Pkg::Util::Execution.retry_on_fail(:times => 3) do
+            cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.tarball_path, target_host: Pkg::Config.tar_host)
+            Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.tar_staging_server, cmd)
+          end
         end
       end
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -280,8 +280,11 @@ namespace :pl do
     if Dir['pkg/apple/**/*.dmg'].empty?
       STDOUT.puts "There aren't any dmg packages in pkg/apple. Maybe something went wrong?"
     else
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
-        Pkg::Util::Net.rsync_to('pkg/apple/', Pkg::Config.dmg_staging_server, Pkg::Config.dmg_path)
+      puts "Do you want to ship dmg files to (#{Pkg::Config.dmg_staging_server})?"
+      if Pkg::Util.ask_yes_or_no
+        Pkg::Util::Execution.retry_on_fail(:times => 3) do
+          Pkg::Util::Net.rsync_to('pkg/apple/', Pkg::Config.dmg_staging_server, Pkg::Config.dmg_path)
+        end
       end
     end
   end if Pkg::Config.build_dmg || Pkg::Config.vanagon_project

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -333,7 +333,6 @@ namespace :pl do
   desc "UBER ship: ship all the things in pkg"
   task :uber_ship => 'pl:fetch' do
     if Pkg::Util.confirm_ship(FileList["pkg/**/*"])
-      ENV['ANSWER_OVERRIDE'] = 'yes'
       Rake::Task["pl:ship_gem"].invoke if Pkg::Config.build_gem
       Rake::Task["pl:ship_rpms"].invoke if Pkg::Config.final_mocks || Pkg::Config.vanagon_project
       Rake::Task["pl:ship_debs"].invoke if Pkg::Config.cows || Pkg::Config.vanagon_project

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -229,9 +229,9 @@ namespace :pl do
           puts "Do you want to start shipping the rubygem '#{file}'?"
           next unless Pkg::Util.ask_yes_or_no
 
-          Rake::Task["pl:ship_gem_to_rubygems"].invoke
-          Rake::Task["pl:ship_gem_to_internal_mirror"].invoke
-          Rake::Task["pl:ship_gem_to_downloads"].invoke
+          Rake::Task["pl:ship_gem_to_rubygems"].invoke(file)
+          Rake::Task["pl:ship_gem_to_internal_mirror"].invoke(file)
+          Rake::Task["pl:ship_gem_to_downloads"].invoke(file)
         end
       else
         $stderr.puts "Not shipping development gem using odd_even strategy for the sake of your users."
@@ -239,42 +239,42 @@ namespace :pl do
     end
 
     desc "Ship built gem to rubygems.org"
-    task :ship_gem_to_rubygems => 'pl:fetch' do
-      puts "Do you want to ship #{file} to rubygems.org?"
+    task :ship_gem_to_rubygems, [:file] => 'pl:fetch' do |t, args|
+      puts "Do you want to ship #{args[:file]} to rubygems.org?"
       if Pkg::Util.ask_yes_or_no
-        puts "Shipping gem #{file} to rubygems.org"
+        puts "Shipping gem #{args[:file]} to rubygems.org"
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          Pkg::Gem.ship_to_rubygems(gem)
+          Pkg::Gem.ship_to_rubygems(args[:file])
         end
       end
     end
 
     desc "Ship built gems to internal Gem server (#{Pkg::Config.internal_gem_host})"
-    task :ship_gem_to_internal_mirror => 'pl:fetch' do
+    task :ship_gem_to_internal_mirror, [:file] => 'pl:fetch' do |t, args|
       unless Pkg::Config.internal_gem_host
         warn "Value `Pkg::Config.internal_gem_host` not defined; skipping internal ship"
       end
 
-      puts "Do you want to ship #{file} to the internal Gem server?"
+      puts "Do you want to ship #{args[:file]} to the internal Gem server?"
       if Pkg::Util.ask_yes_or_no
-        puts "Shipping gem #{file} to internal Gem server (#{Pkg::Config.internal_gem_host})"
+        puts "Shipping gem #{args[:file]} to internal Gem server (#{Pkg::Config.internal_gem_host})"
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          Pkg::Gem.ship_to_stickler(gem)
+          Pkg::Gem.ship_to_stickler(args[:file])
         end
       end
     end
 
     desc "Ship built gems to public Downloads server (#{Pkg::Config.gem_host})"
-    task :ship_gem_to_downloads => 'pl:fetch' do
+    task :ship_gem_to_downloads, [:file] => 'pl:fetch' do |t, args|
       unless Pkg::Config.gem_host
         warn "Value `Pkg::Config.gem_host` not defined; skipping shipping to public Download server"
       end
 
-      puts "Do you want to ship #{file} to public file server (#{Pkg::Config.gem_host})?"
+      puts "Do you want to ship #{args[:file]} to public file server (#{Pkg::Config.gem_host})?"
       if Pkg::Util.ask_yes_or_no
-        puts "Shipping gem #{file} to public file server (#{Pkg::Config.gem_host})"
+        puts "Shipping gem #{args[:file]} to public file server (#{Pkg::Config.gem_host})"
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          Pkg::Gem.ship_to_stickler(gem)
+          Pkg::Gem.ship_to_stickler(args[:file])
         end
       end
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -246,6 +246,10 @@ namespace :pl do
 
     desc "Ship built gems to internal Gem server (#{Pkg::Config.internal_gem_host})"
     task :ship_gem_to_internal_mirror => 'pl:fetch' do
+      unless Pkg::Config.internal_gem_host
+        warn "Value `Pkg::Config.internal_gem_host` not defined; skipping internal ship"
+      end
+
       puts "Do you want to ship #{file} to the internal Gem server?"
       if Pkg::Util.ask_yes_or_no
         puts "Shipping gem #{file} to internal Gem server (#{Pkg::Config.internal_gem_host})"
@@ -257,6 +261,10 @@ namespace :pl do
 
     desc "Ship built gems to public Downloads server (#{Pkg::Config.gem_host})"
     task :ship_gem_to_downloads => 'pl:fetch' do
+      unless Pkg::Config.gem_host
+        warn "Value `Pkg::Config.gem_host` not defined; skipping shipping to public Download server"
+      end
+
       puts "Do you want to ship #{file} to public file server (#{Pkg::Config.gem_host})?"
       if Pkg::Util.ask_yes_or_no
         puts "Shipping gem #{file} to public file server (#{Pkg::Config.gem_host})"

--- a/tasks/update.rake
+++ b/tasks/update.rake
@@ -5,8 +5,8 @@ namespace :package do
       remote = Pkg::Config.packaging_url.split(' ')[0]
       branch = Pkg::Config.packaging_url.split(' ')[1].split('=')[1]
       if branch.nil? or remote.nil?
-        STDERR.puts "Couldn't parse the packaging repo URL from 'ext/build_defaults.yaml'."
-        STDERR.puts "Normally this is a string in the format git@github.com:<User>/<packaging_repo> --branch=<branch>"
+        $stderr.puts "Couldn't parse the packaging repo URL from 'ext/build_defaults.yaml'."
+        $stderr.puts "Normally this is a string in the format git@github.com:<User>/<packaging_repo> --branch=<branch>"
       else
         Pkg::Util::Git.git_pull(remote, branch)
       end

--- a/tasks/version.rake
+++ b/tasks/version.rake
@@ -26,7 +26,7 @@ namespace :package do
   # A set of tasks for printing the version
   [:version, :rpmversion, :rpmrelease, :debversion, :release].each do |task|
     task "#{task}" do
-      STDOUT.puts Pkg::Config.instance_variable_get("@#{task}")
+      $stdout.puts Pkg::Config.instance_variable_get("@#{task}")
     end
   end
 end

--- a/tasks/z_data_dump.rake
+++ b/tasks/z_data_dump.rake
@@ -23,7 +23,7 @@ namespace :pl do
   end
 
   ##
-  # Print all build parameters to STDOUT.
+  # Print all build parameters to $stdout.
   #
   desc "Print all package build parameters"
   task :print_build_params do
@@ -31,7 +31,7 @@ namespace :pl do
   end
 
   ##
-  # Print a parameter passed as an argument to STDOUT.
+  # Print a parameter passed as an argument to $stdout.
   desc "Print a build parameter"
   task :print_build_param, :param do |t, args|
     # We want a string that is the from "@<param name>"


### PR DESCRIPTION
I've got a laundry list of nitpicks that are making shipping painful. Let's do some laundry.

### Preamble
What I'm aiming for is giving us the ability to selectively skip jobs when running `pl:jenkins:uber_ship` and breaking apart large tasks until they're functionally irreducible (while preserving existing interfaces as much as possible). My hope is that once we've reduced the quantity of work to irreducible tasks that we can then start recomposing the rollups (tasks like `pl:jenkins:uber_ship` or `pl:uber_ship`) into tools more resilient tasks with less churn around the process of getting software someplace our customers can see it.

### Obligatory dumb image for a new PR

![laundry-list-pre-treat today-sort tomorrow-wash later-dry soon-fold maybe-iron get-real-vinyl-wall-art-lettering-49f4b322-656d-411e-b871-3defe1f0fb28_600](https://cloud.githubusercontent.com/assets/344926/13806100/9464fb36-eb16-11e5-84cb-04c9d1a45557.jpg)
