### PR TITLE
(maint) add additional architectures available for deb repo generation

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -94,7 +94,7 @@ module Pkg::Deb::Repo
 Origin: Puppet Labs
 Label: Puppet Labs
 Codename: $dist
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64 armel armhf powerpc sparc mips mipsel
 Components: #{subrepo}
 Description: Apt repository for acceptance testing" >> conf/distributions ; )
 

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -17,7 +17,7 @@ module Pkg
       'debian' => {
         '6' => { :codename => 'squeeze', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
         '7' => { :codename => 'wheezy', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
-        '8' => { :codename => 'jessie', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
+        '8' => { :codename => 'jessie', :architectures  => ['i386', 'amd64', 'powerpc'], :repo => true, :package_format => 'deb', },
         '9' => { :codename => 'stretch', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
       },
 


### PR DESCRIPTION
This enables the creation of powerpc deb repos, which we need now
that we're including huaweios builds for that platform.