### PR TITLE
(maint) Create tickets in "Ready for Engineering"

### DIFF
--- a/lib/packaging/util/jira.rb
+++ b/lib/packaging/util/jira.rb
@@ -156,7 +156,7 @@ module Pkg::Util
 
       if options_hash[:status]
         transition = issue.transitions.build
-        transition.save!("transition" => {"id" => options_hash[:status]})
+        transition.save!("transition" => { "id" => options_hash[:status] })
       end
 
       return issue.key, issue.id

--- a/lib/packaging/util/jira.rb
+++ b/lib/packaging/util/jira.rb
@@ -154,6 +154,11 @@ module Pkg::Util
       issue = @client.Issue.build
       issue.save!({ 'fields' => fields })
 
+      if options_hash[:status]
+        transition = issue.transitions.build
+        transition.save!("transition" => {"id" => options_hash[:status]})
+      end
+
       return issue.key, issue.id
     rescue Exception => e
       fail "Cannot create Jira Ticket with fields #{fields}"

--- a/tasks/tickets.rake
+++ b/tasks/tickets.rake
@@ -1,3 +1,5 @@
+require 'pp'
+
 # This rake task creates tickets in jira for a release.
 #
 
@@ -485,7 +487,6 @@ EOS
     validate_release_ticket_vars(jira, vars)
 
     puts "Creating release tickets based on:"
-    require 'pp'
     pp vars.select { |k, v| k != :password }
 
     create_release_tickets(jira, vars)

--- a/tasks/tickets.rake
+++ b/tasks/tickets.rake
@@ -319,7 +319,7 @@ DOC
     {
       :summary     => 'Is the Jira tidy-up done for this release and prepared for the next one?',
       :description => description[:jira_maintenance],
-     :assignee    => vars[:developer]
+      :assignee    => vars[:developer]
     },
     {
       :summary     => 'Prepare long form release notes and short form release story',

--- a/tasks/tickets.rake
+++ b/tasks/tickets.rake
@@ -1,6 +1,10 @@
 # This rake task creates tickets in jira for a release.
 #
 
+# Magic transition ID for "Ready for Engineering" state in jira
+# (for the full list, see https://tickets.puppetlabs.com/rest/api/2/issue/$ticket_number/transitions)
+READY_FOR_ENGINEERING = 111
+
 def get_release_ticket_vars
   vars = {}
 
@@ -385,6 +389,7 @@ DOC
   subtickets.each {|t|
     t[:summary] << " (#{vars[:project]} #{vars[:release]})"
     t[:description] = "(Initial planned release date: #{vars[:date]})\n\n" + t[:description]
+    t[:status] = READY_FOR_ENGINEERING
   }
 
   # Use the human-friendly project name in the summary
@@ -410,6 +415,7 @@ DOC
     :description => description[:top_level_ticket],
     :project => project,
     :assignee => assignee,
+    :status => READY_FOR_ENGINEERING,
   }
 
   # Create the main ticket
@@ -441,6 +447,7 @@ DOC
     :summary => "Release #{Pkg::Config.project} #{vars[:release]} (#{vars[:date]})",
     :project => 'RE',
     :assignee => vars[:builder],
+    :status => READY_FOR_ENGINEERING,
   }
 
   release_key, _ = jira.create_issue(release_ticket)


### PR DESCRIPTION
Previously tickets were created in the default open status, which means
that a human needs to update them to be ready for engineering so that
they appear on agile boards. This commit updates the tickets to be
created in the "Ready for Engineering" state to avoid this manual step.