### PR TITLE
(RE-7052) Allow setting required ruby and rubygems versions

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -62,6 +62,8 @@ module Pkg::Params
                   :gem_platform_dependencies,
                   :gem_rdoc_options,
                   :gem_require_path,
+                  :gem_required_ruby_version,
+                  :gem_required_rubygems_version,
                   :gem_runtime_dependencies,
                   :gem_summary,
                   :gem_test_files,

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -53,6 +53,8 @@ describe "Pkg::Config" do
                   :gem_platform_dependencies,
                   :gem_rdoc_options,
                   :gem_require_path,
+                  :gem_required_ruby_version,
+                  :gem_required_rubygems_version,
                   :gem_runtime_dependencies,
                   :gem_summary,
                   :gem_test_files,


### PR DESCRIPTION
When executing `package:gem`, copy the `gem_required_ruby_version` and
`gem_required_rubygems_version` from the project_data.yaml to the
Gem::Specification so that the resulting gem can be constrained on
unsupported ruby/rubygem versions.