### PR TITLE
(maint) Add the ability to push gems to both destinations

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -70,6 +70,8 @@ module Pkg::Params
                   :gpg_name,
                   :homepage,
                   :internal_gem_host,
+                  :internal_nexus_host,
+                  :internal_stickler_host,
                   :ips_build_host,
                   :ips_host,
                   :ips_inter_cert,
@@ -247,6 +249,8 @@ module Pkg::Params
               { :var => :yum_repo_path,           :envvar => :YUM_REPO },
               { :var => :yum_staging_server,      :envvar => :YUM_STAGING_SERVER },
               { :var => :internal_gem_host,       :envvar => :INTERNAL_GEM_HOST },
+              { :var => :internal_nexus_host,     :envvar => :INTERNAL_NEXUS_HOST },
+              { :var => :internal_stickler_host,  :envvar => :INTERNAL_STICKLER_HOST },
              ]
   # Default values that are supplied if the user does not supply them
   #
@@ -280,6 +284,8 @@ module Pkg::Params
   # in case it is not set.
   #
   REASSIGNMENTS = [
+                    { :oldvar => :internal_gem_host,      :newvar => :internal_nexus_host },
+                    { :oldvar => :internal_gem_host,      :newvar => :internal_stickler_host },
                     # These are fall-through values for shipping endpoints
                     { :oldvar => :staging_server,         :newvar => :apt_staging_server },
                     { :oldvar => :staging_server,         :newvar => :dmg_staging_server },

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -28,8 +28,8 @@ module Pkg::Gem
         password = Pkg::Util.get_input(false)
         hash["GEM_INTERNAL"] = { :authorization => "Basic #{Pkg::Util.base64_encode("#{username}:#{password}")}" }
       end
-      if hash["GEM_INTERNAL"][:url].nil? || hash["GEM_INTERNAL"][:url] != Pkg::Config.internal_gem_host
-        hash["GEM_INTERNAL"][:url] = Pkg::Config.internal_gem_host
+      if hash["GEM_INTERNAL"][:url].nil? || hash["GEM_INTERNAL"][:url] != Pkg::Config.internal_nexus_host
+        hash["GEM_INTERNAL"][:url] = Pkg::Config.internal_nexus_host
       end
       File.open(@nexus_config, "w") do |file|
         file.write(hash.to_yaml)
@@ -52,12 +52,12 @@ module Pkg::Gem
         # to debug the failure, and potentially update this fail case if
         # needed.
         fail unless ret.include? "Created"
-        puts "#{file} pushed to nexus server at #{Pkg::Config.internal_gem_host}"
+        puts "#{file} pushed to nexus server at #{Pkg::Config.internal_nexus_host}"
       end
     rescue
       puts "###########################################"
       puts "#  Nexus failed, ensure the nexus gem is installed,"
-      puts "#  you have access to #{Pkg::Config.internal_gem_host}"
+      puts "#  you have access to #{Pkg::Config.internal_nexus_host}"
       puts "#  and your settings in #{@nexus_config} are correct"
       puts "###########################################"
     end
@@ -66,17 +66,17 @@ module Pkg::Gem
     # you've lost the ability to feel joy anymore.
     def ship_to_stickler(file)
       Pkg::Util::Tool.check_tool("stickler")
-      cmd = "stickler push #{file} --server=#{Pkg::Config.internal_gem_host} 2>/dev/null"
+      cmd = "stickler push #{file} --server=#{Pkg::Config.internal_stickler_host} 2>/dev/null"
       if ENV['DRYRUN']
         puts "[DRY-RUN] #{cmd}"
       else
         Pkg::Util::Execution.ex(cmd)
-        puts "#{file} pushed to stickler server at #{Pkg::Config.internal_gem_host}"
+        puts "#{file} pushed to stickler server at #{Pkg::Config.internal_stickler_host}"
       end
     rescue
       puts "###########################################"
       puts "#  Stickler failed, ensure it's installed"
-      puts "#  and you have access to #{Pkg::Config.internal_gem_host}"
+      puts "#  and you have access to #{Pkg::Config.internal_stickler_host}"
       puts "###########################################"
     end
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -271,11 +271,18 @@ namespace :pl do
         warn "Value `Pkg::Config.internal_gem_host` not defined; skipping internal ship"
       end
 
-      puts "Do you want to ship #{args[:file]} to the internal Gem server?"
+      puts "Do you want to ship #{args[:file]} to the internal stickler server(#{Pkg::Config.internal_stickler_host})?"
       if Pkg::Util.ask_yes_or_no
-        puts "Shipping gem #{args[:file]} to internal Gem server (#{Pkg::Config.internal_gem_host})"
+        puts "Shipping gem #{args[:file]} to internal Gem server (#{Pkg::Config.internal_stickler_host})"
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
           Pkg::Gem.ship_to_stickler(args[:file])
+        end
+      end
+
+      puts "Do you want to ship #{args[:file]} to the internal nexus server(#{Pkg::Config.internal_nexus_host})?"
+      if Pkg::Util.ask_yes_or_no
+        puts "Shipping gem #{args[:file]} to internal Gem server (#{Pkg::Config.internal_nexus_host})"
+        Pkg::Util::Execution.retry_on_fail(:times => 3) do
           Pkg::Gem.ship_to_nexus(args[:file])
         end
       end


### PR DESCRIPTION
We need to be able to ship gems to both nexus and stickler. This commit
splits out the internal_gem_host to allow us to either default to the
original value or to assign each separately.