### PR TITLE
(maint) RPM rsyncs failed while shipping today

### DIFF
--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -52,7 +52,8 @@ module Pkg::Rpm::Repo
       # fail due to permission errors.
       options = %w(
         rsync
-        --archive
+        --recursive
+        --links
         --hard-links
         --update
         --human-readable
@@ -65,7 +66,6 @@ module Pkg::Rpm::Repo
         --no-perms
         --no-owner
         --no-group
-        --delay-updates
       )
 
       options << '--dry-run' if dryrun


### PR DESCRIPTION
We don't want all the options --archive brings in, we actually only want
--recursive and --links. --archive was causing issues with timestamps on
symlinks. Manually syncing with --recursive and --links instead of
--archive allowed the rsync to run successfully.