### PR TITLE
(maint) update P-A ticket automation to mention vanagon:build_all

### DIFF
--- a/tasks/puppet-agent-release-tickets.rake
+++ b/tasks/puppet-agent-release-tickets.rake
@@ -178,7 +178,7 @@ Tag and create packages
     * You need to know the pass phrase for this to complete successfully. It's important that we make sure all releases are signed to verify authenticity.
   * {{git describe}} will show you the tag. Make sure you're building what you think you're building.
   * Make sure you look over the code that has changed since the previous release so we know what's going out the door.
-  * run {{rake package:implode package:bootstrap pl:jenkins:uber_build}} when you've verified what version you're building (this uses the latest version of the packaging repo to build the packages).
+  * run {{rake package:implode package:bootstrap vanagon:build_all}} when you've verified what version you're building (this uses the latest version of the packaging repo to build the packages).
   * Push the tag.
 
 3) [~#{vars[:builder]}]: make a pull request against puppet-agent#stable to bump each component to the freshly pushed tags from above:


### PR DESCRIPTION
We now have a vanagon:build_all rake task that humans should use when shipping
puppet-agent. the task is a wrapper around pl:jenkins:uber_build that adds a
tag check beforehand. update the ticket automation to reference this task.