### PR TITLE
(maint) Add ticket to compile facter with java

### DIFF
--- a/tasks/agent-tickets.rake
+++ b/tasks/agent-tickets.rake
@@ -67,6 +67,14 @@ This means you'll have to verify the build to resolve this ticket. If vanagon do
 you need to create a new ticket, block this ticket against that one, and add in vanagon support!
 DOC
 
+  description[:facter_java] = <<-DOC
+Facter, in order to properly interact with the Clojure Puppet Server, must be compiled with Java.
+
+Edit config/component/facter.rb to ensure the new platform has java as a build time dependency.
+This is only strictly required for platforms that will also be a new master platform, however it
+it a good thing to be consistent about providing facter.jar
+DOC
+
   description[:hostgenerator] = <<-DOC
 Update beaker-hostgenerator (https://github.com/puppetlabs/beaker-hostgenerator) for #{vars[:platform_tag]}.
 DOC
@@ -201,6 +209,14 @@ DOC
       :description  => description[:puppet_agent_configuration],
       :story_points => '2',
       :blocked_by   => ['c_toolchain'],
+    },
+    {
+      :short_name   => 'build_facter_with_java',
+      :project      => 'PA',
+      :summary      => "Ensure Facter is compiled with Java JNI support and is producing facter.jar",
+      :description  => description[:facter_java],
+      :story_points => '2',
+      :blocked_by   => ['puppet_agent_configuration'],
     },
     {
       :short_name   => 'hostgenerator',


### PR DESCRIPTION
I keep forgetting to ensure facter is compiled for new platforms with
java. This isn't an issue until we try to add a server package for the
new platform, and everything fails because the server package can't
utilize the facter available via puppet-agent. Rather than try to
remember this, let's just be explicit and get facter.jar for all
platforms.