### PR TITLE
(RE-7411) Sign MSIs prior to s3/agent ship

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -35,6 +35,7 @@ namespace :pl do
       Pkg::Deb::Repo.sign_repos('repos', 'Apt repository for signed builds')
       Pkg::OSX.sign('repos') unless Dir['repos/apple/**/*.dmg'].empty?
       Pkg::IPS.sign('repos') unless Dir['repos/solaris/11/**/*.p5p'].empty?
+      Pkg::MSI.sign('repos') unless Dir['repos/windows/**/*.msi'].empty?
     end
 
     task :ship_signed_repos, [:target_prefix] => "pl:fetch" do |t, args|


### PR DESCRIPTION
Prior to this commit, the s3/internal puppet-agent ship called this rake
task to generate signed repos to ship out. This task called automation
to sign both packages and repos prior to bundling them up and shipping
them out. We thought for some reason that the sign_all task was used to
sign the packages. This was an incorrect assumption. In order to sign
the MSI packages, we need to explicitly invoke the msi sign method on
the packages. This commit adds that logic to ensure we are actually
signing our packages.

Hopefully I'm not missing anything this time.