### PR TITLE
(RE-6147) Internal Puppet Agent Shipping Creates Recursive Symlink

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -141,7 +141,7 @@ namespace :pl do
         end
 
         # Make a latest symlink for the project
-        FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))
+        FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
       end
     end
 


### PR DESCRIPTION
This commit adds a 'verbose" to one of the lines in order to debug the issue with the recursive symlink