### PR TITLE
(RE-6147) Fix recursive links in internal puppet-agent ship

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -187,6 +187,10 @@ namespace :pl do
         local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]
         FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))
 
+        #test print for local_target
+        puts "HERE IS OUR SECOND PRINT OF LOCAL TARGET BELOW"
+        puts local_target
+
         # Ship it to the target for consumption
         # First we ship the latest and clean up any repo-configs that are no longer valid with --delete-after
         Pkg::Util::Net.rsync_to("#{Pkg::Config.project}-latest", target_host, target_basedir, extra_flags: ["--delete-after", "--keep-dirlinks"])

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -145,6 +145,8 @@ namespace :pl do
         FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
         puts "THE FOLLOWING LINE IS THE LOCAL TARGET"
         puts local_target
+        puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY"
+        puts Dir.pwd
       end
     end
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -181,7 +181,7 @@ namespace :pl do
 
       Dir.chdir("tmp/pkg") do
         # Link the latest repo that was trimmed down
-        local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]
+        local_target = Dir.glob(File.join(Pkg::Config.project, "repos"))[0].split("/")[-2]
         FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))
 
         #test print for local_target

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -172,7 +172,11 @@ namespace :pl do
         include_paths = ["./"]
       end
 
+      Pkg::Util::Execution.ex(%(ls -l pkg/#{File.join(Pkg::Config.project, "*", "repos")}), true)
 
+      Pkg::Util::Execution.ex(%(ls -l pkg/#{File.join(Pkg::Config.project + "-latest", "repos")}), true)
+
+      #debugging: can delete
       puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY dsr2"
       puts Dir.pwd
       # Get the directories together - we need to figure out which bits to ship based on the include_path
@@ -197,15 +201,27 @@ namespace :pl do
 
       Dir.chdir("tmp/pkg") do
 
-        # debugging: looking at contents of directory
+        # debugging: can be deleted
         puts "THE FOLLOWING IS OUR CONTENTS OF THE DIRECTORY"
         Pkg::Util::Execution.ex(%(find .), true)
 
         # Link the latest repo that was trimmed down
         local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]
-        FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))
 
-        #test print for local_target (can be deleted)
+        # debugging: can delete
+        puts "ABOUT TO SET THE SYM 2nd CHECK"
+
+        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project, local_target, "repos")}), true)
+
+        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project + "-latest", "repos")}), true)
+
+        FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
+
+        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project, local_target, "repos")}), true)
+
+        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project + "-latest", "repos")}), true)
+
+        #debugging: can be deleted
         puts "HERE IS OUR SECOND PRINT OF LOCAL TARGET BELOW"
         puts local_target
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -181,7 +181,7 @@ namespace :pl do
 
       Dir.chdir("tmp/pkg") do
         # Link the latest repo that was trimmed down
-        local_target = Dir.glob(File.join(Pkg::Config.project, "repos"))[0].split("/")[-2]
+        local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]
         FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))
 
         #test print for local_target

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -142,6 +142,7 @@ namespace :pl do
 
         # Make a latest symlink for the project
         FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
+        puts local_target
       end
     end
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -173,20 +173,29 @@ namespace :pl do
       # Get the directories together - we need to figure out which bits to ship based on the include_path
       # First we get the build itself
       Pkg::Util::Execution.ex(%(find #{include_paths.map { |path| "pkg/#{Pkg::Config.project}/**/#{path}" }.join(' ') } | sort > include_file))
-      Pkg::Util::Execution.ex(%(cat include_file))
 
       #debugging: looking at file contents
+      puts "THE FOLLOWING IS THE CONTENTS OF THE INCLUDE_FILE"
+      Pkg::Util::Execution.ex(%(cat include_file))
+
+
       Pkg::Util::Execution.ex(%(mkdir -p tmp && tar -T include_file -cf - | (cd ./tmp && tar -xf -)))
 
       # Then we find grab the appropriate meta-data only
       Pkg::Util::Execution.ex(%(find #{include_paths.map { |path| "pkg/#{Pkg::Config.project}-latest/#{path}" unless path.include? "repos" }.join(' ') } | sort > include_file_latest))
 
       #debugging: looking at file contents
+      puts "THE FOLLOWING IS THE CONTENTS OF INCLUDE_FILE_LATEST"
       Pkg::Util::Execution.ex(%(cat include_file_latest))
 
       Pkg::Util::Execution.ex(%(tar -T include_file_latest -cf - | (cd ./tmp && tar -xf -)))
 
       Dir.chdir("tmp/pkg") do
+
+        # debugging: looking at contents of directory
+        puts "THE FOLLOWING IS OUR CONTENTS OF THE DIRECTORY"
+        Pkg::Util::Execution.ex(%(find .))
+
         # Link the latest repo that was trimmed down
         local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]
         FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -155,6 +155,8 @@ namespace :pl do
     end
 
     task :deploy_signed_repos, [:target_host, :target_basedir, :foss_only] => "pl:fetch" do |t, args|
+      puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY dsr1"
+        puts Dir.pwd
       target_host = args.target_host or fail ":target_host is a required argument to #{t}"
       target_basedir = args.target_basedir or fail ":target_basedir is a required argument to #{t}"
       include_paths = []
@@ -170,6 +172,9 @@ namespace :pl do
         include_paths = ["./"]
       end
 
+
+      puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY dsr2"
+      puts Dir.pwd
       # Get the directories together - we need to figure out which bits to ship based on the include_path
       # First we get the build itself
       Pkg::Util::Execution.ex(%(find #{include_paths.map { |path| "pkg/#{Pkg::Config.project}/**/#{path}" }.join(' ') } | sort > include_file))
@@ -206,6 +211,10 @@ namespace :pl do
 
         # Ship it to the target for consumption
         # First we ship the latest and clean up any repo-configs that are no longer valid with --delete-after
+
+        puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY dsr3"
+        puts Dir.pwd
+
         Pkg::Util::Net.rsync_to("#{Pkg::Config.project}-latest", target_host, target_basedir, extra_flags: ["--delete-after", "--keep-dirlinks"])
         # Then we ship the sha version with default rsync flags
         Pkg::Util::Net.rsync_to("#{Pkg::Config.project}", target_host, target_basedir)

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -209,7 +209,7 @@ namespace :pl do
       Dir.chdir("tmp/pkg") do
 
 
-        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project, local_target, "repos")}), true)
+        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project, "*", "repos")}), true)
 
         Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project + "-latest", "repos")}), true)
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -86,7 +86,14 @@ namespace :pl do
           local_target = File.join(Pkg::Config.project, Pkg::Util::Version.get_dot_version)
         end
 
-        FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
+        if Dir.exists?(local_target)
+          FileUtils.mkdir_p([Pkg::Config.project + "-latest"])
+        else
+          FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
+          puts "THE FOLLOWING LINE IS THE LOCAL_TARGET (when making the dir)"
+          puts local_target
+        end
+
 
         # Rake task dependencies with arguments are nuts, so we just directly
         # invoke them here.  We want the signed_* directories staged as

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -173,10 +173,17 @@ namespace :pl do
       # Get the directories together - we need to figure out which bits to ship based on the include_path
       # First we get the build itself
       Pkg::Util::Execution.ex(%(find #{include_paths.map { |path| "pkg/#{Pkg::Config.project}/**/#{path}" }.join(' ') } | sort > include_file))
+      Pkg::Util::Execution.ex(%(cat include_file))
+
+      #debugging: looking at file contents
       Pkg::Util::Execution.ex(%(mkdir -p tmp && tar -T include_file -cf - | (cd ./tmp && tar -xf -)))
 
       # Then we find grab the appropriate meta-data only
       Pkg::Util::Execution.ex(%(find #{include_paths.map { |path| "pkg/#{Pkg::Config.project}-latest/#{path}" unless path.include? "repos" }.join(' ') } | sort > include_file_latest))
+
+      #debugging: looking at file contents
+      Pkg::Util::Execution.ex(%(cat include_file_latest))
+
       Pkg::Util::Execution.ex(%(tar -T include_file_latest -cf - | (cd ./tmp && tar -xf -)))
 
       Dir.chdir("tmp/pkg") do
@@ -184,7 +191,7 @@ namespace :pl do
         local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]
         FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"))
 
-        #test print for local_target
+        #test print for local_target (can be deleted)
         puts "HERE IS OUR SECOND PRINT OF LOCAL TARGET BELOW"
         puts local_target
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -142,7 +142,7 @@ namespace :pl do
 
         # Make a latest symlink for the project
         puts "ABOUT TO SET THE SYM LINK"
-        FileUtils.ln_s(File.expand_path(File.join("..", local_target, "repos")),File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
+        FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
         puts "THE FOLLOWING LINE IS THE LOCAL TARGET"
         puts local_target
         puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY"

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -86,7 +86,7 @@ namespace :pl do
           local_target = File.join(Pkg::Config.project, Pkg::Util::Version.get_dot_version)
         end
 
-        FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
+        FileUtils.mkdir([local_target, Pkg::Config.project + "-latest"])
 
         # Rake task dependencies with arguments are nuts, so we just directly
         # invoke them here.  We want the signed_* directories staged as

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -142,7 +142,7 @@ namespace :pl do
 
         # Make a latest symlink for the project
         puts "ABOUT TO SET THE SYM LINK"
-        FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
+        FileUtils.ln_s(File.expand_path(File.join("..", local_target, "repos")),File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
         puts "THE FOLLOWING LINE IS THE LOCAL TARGET"
         puts local_target
         puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY"

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -176,7 +176,7 @@ namespace :pl do
 
       #debugging: looking at file contents
       puts "THE FOLLOWING IS THE CONTENTS OF THE INCLUDE_FILE"
-      Pkg::Util::Execution.ex(%(cat include_file))
+      Pkg::Util::Execution.ex(%(cat include_file), true)
 
 
       Pkg::Util::Execution.ex(%(mkdir -p tmp && tar -T include_file -cf - | (cd ./tmp && tar -xf -)))
@@ -186,7 +186,7 @@ namespace :pl do
 
       #debugging: looking at file contents
       puts "THE FOLLOWING IS THE CONTENTS OF INCLUDE_FILE_LATEST"
-      Pkg::Util::Execution.ex(%(cat include_file_latest))
+      Pkg::Util::Execution.ex(%(cat include_file_latest), true)
 
       Pkg::Util::Execution.ex(%(tar -T include_file_latest -cf - | (cd ./tmp && tar -xf -)))
 
@@ -194,7 +194,7 @@ namespace :pl do
 
         # debugging: looking at contents of directory
         puts "THE FOLLOWING IS OUR CONTENTS OF THE DIRECTORY"
-        Pkg::Util::Execution.ex(%(find .))
+        Pkg::Util::Execution.ex(%(find .), true)
 
         # Link the latest repo that was trimmed down
         local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -141,7 +141,9 @@ namespace :pl do
         end
 
         # Make a latest symlink for the project
+        puts "ABOUT TO SET THE SYM LINK"
         FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
+        puts "THE FOLLOWING LINE IS THE LOCAL TARGET"
         puts local_target
       end
     end

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -86,9 +86,11 @@ namespace :pl do
           local_target = File.join(Pkg::Config.project, Pkg::Util::Version.get_dot_version)
         end
 
-          FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
-          puts "THE FOLLOWING LINE IS THE LOCAL_TARGET (when making the dir)"
-          puts local_target
+        FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
+
+        #debugging: can delete
+        puts "THE FOLLOWING LINE IS THE LOCAL_TARGET (when making the dir)"
+        puts local_target
 
 
 
@@ -146,7 +148,9 @@ namespace :pl do
 
         # Make a latest symlink for the project
         puts "ABOUT TO SET THE SYM LINK"
+
         FileUtils.ln_s(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
+
         puts "THE FOLLOWING LINE IS THE LOCAL TARGET"
         puts local_target
         puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY"
@@ -155,8 +159,11 @@ namespace :pl do
     end
 
     task :deploy_signed_repos, [:target_host, :target_basedir, :foss_only] => "pl:fetch" do |t, args|
+
+      #debugging: can delete
       puts "THE FOLLOWING LINE IS OUR CURRENT DIRECTORY dsr1"
-        puts Dir.pwd
+      puts Dir.pwd
+
       target_host = args.target_host or fail ":target_host is a required argument to #{t}"
       target_basedir = args.target_basedir or fail ":target_basedir is a required argument to #{t}"
       include_paths = []
@@ -201,29 +208,11 @@ namespace :pl do
 
       Dir.chdir("tmp/pkg") do
 
-        # debugging: can be deleted
-        puts "THE FOLLOWING IS OUR CONTENTS OF THE DIRECTORY"
-        Pkg::Util::Execution.ex(%(find .), true)
-
-        # Link the latest repo that was trimmed down
-        local_target = Dir.glob(File.join(Pkg::Config.project, "/*/repos"))[0].split("/")[-2]
-
-        # debugging: can delete
-        puts "ABOUT TO SET THE SYM 2nd CHECK"
 
         Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project, local_target, "repos")}), true)
 
         Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project + "-latest", "repos")}), true)
 
-        FileUtils.ln_s(File.join("..", Pkg::Config.project, local_target, "repos"), File.join(Pkg::Config.project + "-latest", "repos"), :verbose => true)
-
-        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project, local_target, "repos")}), true)
-
-        Pkg::Util::Execution.ex(%(ls -l #{File.join(Pkg::Config.project + "-latest", "repos")}), true)
-
-        #debugging: can be deleted
-        puts "HERE IS OUR SECOND PRINT OF LOCAL TARGET BELOW"
-        puts local_target
 
         # Ship it to the target for consumption
         # First we ship the latest and clean up any repo-configs that are no longer valid with --delete-after

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -86,7 +86,7 @@ namespace :pl do
           local_target = File.join(Pkg::Config.project, Pkg::Util::Version.get_dot_version)
         end
 
-        FileUtils.mkdir([local_target, Pkg::Config.project + "-latest"])
+        FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
 
         # Rake task dependencies with arguments are nuts, so we just directly
         # invoke them here.  We want the signed_* directories staged as

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -86,13 +86,10 @@ namespace :pl do
           local_target = File.join(Pkg::Config.project, Pkg::Util::Version.get_dot_version)
         end
 
-        if Dir.exists?(local_target)
-          FileUtils.mkdir_p([Pkg::Config.project + "-latest"])
-        else
           FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
           puts "THE FOLLOWING LINE IS THE LOCAL_TARGET (when making the dir)"
           puts local_target
-        end
+
 
 
         # Rake task dependencies with arguments are nuts, so we just directly


### PR DESCRIPTION
When running the nightly_repos.rake file there would be a circular symlink and directories would be recursively made indefinitely. This fix takes out one of the calls to create a symlink (because it was called twice and should not have been) which fixes the issue. The symlink is set properly and the correct directories are made in the correct locations. 

(Absolutely do not merge this yet; it's being "tuned")