### PR TITLE
(maint) Update to use a new key

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ deb_build_mirrors:
 # Who is packaging. Turns up in various packaging artifacts
 packager: 'puppetlabs'
 # GPG key ID of the signer
-gpg_key: '4BD6EC30'
+gpg_key: '7F438280EF8D349F'
 # Whether to require tarball signing as a prerequisite of other package building
 sign_tar: FALSE
 # a space separated list of mock configs. These are the rpm distributions to package for. If a noarch package, only one arch of each is needed.


### PR DESCRIPTION
The exiting key is expiring soon, so update the readme to use the new
one.