### PR TITLE
(RE-7841) Add osx 10.12 (Sierra) platform

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -47,6 +47,7 @@ module Pkg
         '10.9' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
         '10.10' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
         '10.11' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
+        '10.12' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
       },
 
       'sles' => {


### PR DESCRIPTION
In preparation for buliding OS X 10.12 "Sierra" agents.