### PR TITLE
(maint) Update linking to be smarter

### DIFF
--- a/tasks/education.rake
+++ b/tasks/education.rake
@@ -38,6 +38,10 @@ namespace :pl do
 
       # Update symlink to point to the VM we just shipped
       link_target.each do |link|
+        link_path = File.join(target_directory, link)
+        link_md5_path = "#{link_path}.md5"
+        Pkg::Util::Net.remote_ssh_cmd(target_host, "if [[ ! -e '#{link_path}' ]] ; then echo '#{link_path} is a broken link, deleting' ; unlink '#{link_path}' ; fi")
+        Pkg::Util::Net.remote_ssh_cmd(target_host, "if [[ ! -e '#{link_md5_path}' ]] ; then echo '#{link_md5_path} is a broken link, deleting' ; unlink '#{link_md5_path}' ; fi")
         Pkg::Util::Net.remote_ssh_cmd(target_host, "cd #{target_directory} ; ln -sf #{File.basename(vm)} #{link}")
         Pkg::Util::Net.remote_ssh_cmd(target_host, "cd #{target_directory} ; ln -sf #{File.basename(md5)} #{link}.md5")
       end


### PR DESCRIPTION
This commit adds in logic to check to see if the symlink to be
replaced is broken. If it is, then it removes the symlink so it can
create a new one. This will help reduce manual intervention when the
symlinks get all strange, because computers.