### PR TITLE
(maint) Unlink only if it's actually a broken link

### DIFF
--- a/tasks/education.rake
+++ b/tasks/education.rake
@@ -40,8 +40,8 @@ namespace :pl do
       link_target.each do |link|
         link_path = File.join(target_directory, link)
         link_md5_path = "#{link_path}.md5"
-        Pkg::Util::Net.remote_ssh_cmd(target_host, "if [[ ! -e '#{link_path}' ]] ; then echo '#{link_path} is a broken link, deleting' ; unlink '#{link_path}' ; fi")
-        Pkg::Util::Net.remote_ssh_cmd(target_host, "if [[ ! -e '#{link_md5_path}' ]] ; then echo '#{link_md5_path} is a broken link, deleting' ; unlink '#{link_md5_path}' ; fi")
+        Pkg::Util::Net.remote_ssh_cmd(target_host, "if [[ -L '#{link_path}' ]] && [[ ! -e '#{link_path}' ]] ; then echo '#{link_path} is a broken link, deleting' ; unlink '#{link_path}' ; fi")
+        Pkg::Util::Net.remote_ssh_cmd(target_host, "if [[ -L '#{link_md5_path}' ]] && [[ ! -e '#{link_md5_path}' ]] ; then echo '#{link_md5_path} is a broken link, deleting' ; unlink '#{link_md5_path}' ; fi")
         Pkg::Util::Net.remote_ssh_cmd(target_host, "cd #{target_directory} ; ln -sf #{File.basename(vm)} #{link}")
         Pkg::Util::Net.remote_ssh_cmd(target_host, "cd #{target_directory} ; ln -sf #{File.basename(md5)} #{link}.md5")
       end


### PR DESCRIPTION
Previously, this could would attempt to unlink if the link didn't even
exist or if it was truly a broken symlink. This commit updates the check
to be sure there is actually a link that points to a non-existent file.
This means if we're creating a brand new set of links, then our
automation won't bomb out on us.