### PR TITLE
(maint) Update aptly check

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -178,15 +178,15 @@ module Pkg::Deb::Repo
 
       dists = Pkg::Util::File.directories("#{target}/apt")
 
-      if File.exists?("../.aptly.conf")
-        aptly = Pkg::Util::Tool.check_tool('aptly')
-      else
-        reprepro = Pkg::Util::Tool.check_tool('reprepro')
-      end
-
       if dists
         dists.each do |dist|
           Dir.chdir("#{target}/apt/#{dist}") do
+            if File.exists?("../.aptly.conf")
+              aptly = Pkg::Util::Tool.check_tool('aptly')
+            else
+              reprepro = Pkg::Util::Tool.check_tool('reprepro')
+            end
+
             if aptly
               Pkg::Util::Execution.ex(%Q(#{aptly} -config='../.aptly.conf' publish update -gpg-key="#{Pkg::Config.gpg_key}" #{dist} "#{Pkg::Config.project}-#{Pkg::Config.ref}-#{dist}"))
             elsif reprepro


### PR DESCRIPTION
Previously the check to see if we were using reprepro or aptly was in
the wrong place. This was failing in such a way that all repos were
reprepro based. This commit fixes that mistake.