### PR TITLE
(maint) Ensure aptly directories not hidden

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -96,10 +96,10 @@ module Pkg::Deb::Repo
       architectures = %w(i386 amd64 arm64 armel armhf powerpc sparc mips mipsel)
       description = "Apt repository for acceptance testing"
       aptly_config_path = "#{artifact_directory}/repos/apt"
-      aptly_config_file = "#{aptly_config_path}/.aptly.conf"
+      aptly_config_file = "#{aptly_config_path}/aptly.conf"
       aptly_flags = "-config='#{aptly_config_file}' -component='#{subrepo}' -distribution=$dist"
       aptly_config_contents = {
-        :rootDir => File.join(aptly_config_path, '.aptly'),
+        :rootDir => File.join(aptly_config_path, 'aptly'),
         :architectures => architectures
       }
       cmd << %Q(echo '#{aptly_config_contents.to_json}' > #{aptly_config_file} ; )
@@ -125,12 +125,12 @@ module Pkg::Deb::Repo
       # Now we have to publish the repo to make it available
       cmd << %Q($aptly publish repo #{aptly_flags} --skip-signing #{Pkg::Config.project}-#{Pkg::Config.ref}-$dist #{Pkg::Config.project}-#{Pkg::Config.ref}-$dist; )
 
-      # Aptly publishes repos under a public directory in the .aptly dir. We
+      # Aptly publishes repos under a public directory in the aptly dir. We
       # need to add symlinks from this directory in order to maintain the
       # currently expected structure. Otherwise, this would break a lot of
       # code currently in use.
-      cmd << %Q(ln -s ../.aptly/public/#{Pkg::Config.project}-#{Pkg::Config.ref}-$dist/dists ; )
-      cmd << %Q(ln -s ../.aptly/public/#{Pkg::Config.project}-#{Pkg::Config.ref}-$dist/pool ; )
+      cmd << %Q(ln -s ../aptly/public/#{Pkg::Config.project}-#{Pkg::Config.ref}-$dist/dists ; )
+      cmd << %Q(ln -s ../aptly/public/#{Pkg::Config.project}-#{Pkg::Config.ref}-$dist/pool ; )
       cmd << "popd ; done ; popd ; popd "
 
       return cmd
@@ -181,14 +181,14 @@ module Pkg::Deb::Repo
       if dists
         dists.each do |dist|
           Dir.chdir("#{target}/apt/#{dist}") do
-            if File.exists?("../.aptly.conf")
+            if File.exists?("../aptly.conf")
               aptly = Pkg::Util::Tool.check_tool('aptly')
             else
               reprepro = Pkg::Util::Tool.check_tool('reprepro')
             end
 
             if aptly
-              Pkg::Util::Execution.ex(%Q(#{aptly} -config='../.aptly.conf' publish update -gpg-key="#{Pkg::Config.gpg_key}" #{dist} "#{Pkg::Config.project}-#{Pkg::Config.ref}-#{dist}"))
+              Pkg::Util::Execution.ex(%Q(#{aptly} -config='../aptly.conf' publish update -gpg-key="#{Pkg::Config.gpg_key}" #{dist} "#{Pkg::Config.project}-#{Pkg::Config.ref}-#{dist}"))
             elsif reprepro
               # This block can be removed once we are sure there are no more
               # reprepro based repos that need to be signed.

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -125,7 +125,7 @@ describe "Pkg::Deb::Repo" do
       Pkg::Util::File.should_receive(:directories).with("repos/apt").and_return(dists)
 
       Dir.should_receive(:chdir).with("repos/apt/#{dists[0]}").and_yield
-      File.should_receive(:exists?).with('../.aptly.conf').and_return(true)
+      File.should_receive(:exists?).with('../aptly.conf').and_return(true)
       Pkg::Util::Tool.should_receive(:find_tool).with('aptly', {:required => true}).and_raise(RuntimeError)
       Pkg::Util::Tool.should_not_receive(:find_tool).with('reprepro', {:required => true})
       expect { Pkg::Deb::Repo.sign_repos }.to raise_error(RuntimeError)
@@ -137,7 +137,7 @@ describe "Pkg::Deb::Repo" do
       Pkg::Util::File.should_receive(:directories).with("repos/apt").and_return(dists)
 
       Dir.should_receive(:chdir).with("repos/apt/#{dists[0]}").and_yield
-      File.should_receive(:exists?).with('../.aptly.conf').and_return(false)
+      File.should_receive(:exists?).with('../aptly.conf').and_return(false)
       Pkg::Util::Tool.should_receive(:find_tool).with('reprepro', {:required => true}).and_raise(RuntimeError)
       Pkg::Util::Tool.should_not_receive(:find_tool).with('aptly', {:required => true})
       expect { Pkg::Deb::Repo.sign_repos }.to raise_error(RuntimeError)
@@ -150,9 +150,9 @@ describe "Pkg::Deb::Repo" do
 
       dists.each do |dist|
         Dir.should_receive(:chdir).with("repos/apt/#{dist}").and_yield
-        File.should_receive(:exists?).with('../.aptly.conf').and_return(true)
+        File.should_receive(:exists?).with('../aptly.conf').and_return(true)
         Pkg::Util::Tool.should_receive(:check_tool).with("aptly").and_return(aptly)
-        Pkg::Util::Execution.should_receive(:ex).with("#{aptly} -config='../.aptly.conf' publish update -gpg-key=\"#{Pkg::Config.gpg_key}\" #{dist} \"#{Pkg::Config.project}-#{Pkg::Config.ref}-#{dist}\"")
+        Pkg::Util::Execution.should_receive(:ex).with("#{aptly} -config='../aptly.conf' publish update -gpg-key=\"#{Pkg::Config.gpg_key}\" #{dist} \"#{Pkg::Config.project}-#{Pkg::Config.ref}-#{dist}\"")
       end
 
       Pkg::Deb::Repo.sign_repos
@@ -167,7 +167,7 @@ describe "Pkg::Deb::Repo" do
       dists.each do |dist|
         distfiles[dist] = double
         Dir.should_receive(:chdir).with("repos/apt/#{dist}").and_yield
-        File.should_receive(:exists?).with('../.aptly.conf').and_return(false)
+        File.should_receive(:exists?).with('../aptly.conf').and_return(false)
         Pkg::Util::Tool.should_receive(:check_tool).with("reprepro").and_return(reprepro)
         Pkg::Util::Execution.should_receive(:ex).with("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
         File.should_receive(:open).with("conf/distributions", "w").and_yield(distfiles[dist])


### PR DESCRIPTION
We need to access the aptly files via wget. However, wget doesn't
retrieve hidden files. This commit removes that quality of the aptly
config file and directory