### PR TITLE
(PA-552) OSX signing should not echo the command output

### DIFF
--- a/lib/packaging/osx.rb
+++ b/lib/packaging/osx.rb
@@ -13,15 +13,16 @@ module Pkg::OSX
       dmgs = Dir.glob("#{target_dir}/apple/**/*.dmg")
       Pkg::Util::Net.rsync_to(dmgs.join(" "), rsync_host_string, work_dir)
       Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, %Q[for dmg in #{dmgs.map { |d| File.basename(d, ".dmg") }.join(" ")}; do
-        /usr/bin/hdiutil attach #{work_dir}/$dmg.dmg -mountpoint #{mount} -nobrowse -quiet ;
-        /usr/bin/security -v unlock-keychain -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" ;
+        /usr/bin/hdiutil attach #{work_dir}/$dmg.dmg -mountpoint #{mount} -nobrowse -quiet &&
+        /usr/bin/security -v unlock-keychain -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" &&
           for pkg in $(ls #{mount}/*.pkg | xargs -n 1 basename); do
-            /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}" --sign "#{Pkg::Config.osx_signing_cert}" #{mount}/$pkg #{signed}/$pkg ;
-          done
-        /usr/bin/hdiutil detach #{mount} -quiet ;
-        /bin/rm #{work_dir}/$dmg.dmg ;
-        /usr/bin/hdiutil create -volname $dmg -srcfolder #{signed}/ #{work_dir}/$dmg.dmg ;
-        /bin/rm #{signed}/* ; done])
+            /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}" --sign "#{Pkg::Config.osx_signing_cert}" #{mount}/$pkg #{signed}/$pkg &&
+            /usr/sbin/pkgutil --check-signature #{signed}/$pkg
+          done &&
+        /usr/bin/hdiutil detach #{mount} -quiet &&
+        /bin/rm #{work_dir}/$dmg.dmg &&
+        /usr/bin/hdiutil create -volname $dmg -srcfolder #{signed}/ #{work_dir}/$dmg.dmg &&
+        /bin/rm #{signed}/* ; done], false)
       dmgs.each do | dmg |
         Pkg::Util::Net.rsync_from("#{work_dir}/#{File.basename(dmg)}", rsync_host_string, File.dirname(dmg))
       end

--- a/lib/packaging/osx.rb
+++ b/lib/packaging/osx.rb
@@ -13,15 +13,15 @@ module Pkg::OSX
       dmgs = Dir.glob("#{target_dir}/apple/**/*.dmg")
       Pkg::Util::Net.rsync_to(dmgs.join(" "), rsync_host_string, work_dir)
       Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, %Q[for dmg in #{dmgs.map { |d| File.basename(d, ".dmg") }.join(" ")}; do
-        /usr/bin/hdiutil attach #{work_dir}/$dmg.dmg -mountpoint #{mount} -nobrowse -quiet &&
+        /usr/bin/hdiutil attach #{work_dir}/${dmg}.dmg -mountpoint #{mount} -nobrowse -quiet &&
         /usr/bin/security -v unlock-keychain -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" &&
           for pkg in $(ls #{mount}/*.pkg | xargs -n 1 basename); do
-            /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}" --sign "#{Pkg::Config.osx_signing_cert}" #{mount}/$pkg #{signed}/$pkg &&
-            /usr/sbin/pkgutil --check-signature #{signed}/$pkg
+            /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}" --sign "#{Pkg::Config.osx_signing_cert}" #{mount}/${pkg} #{signed}/${pkg} &&
+            /usr/sbin/pkgutil --check-signature #{signed}/${pkg}
           done &&
         /usr/bin/hdiutil detach #{mount} -quiet &&
-        /bin/rm #{work_dir}/$dmg.dmg &&
-        /usr/bin/hdiutil create -volname $dmg -srcfolder #{signed}/ #{work_dir}/$dmg.dmg &&
+        /bin/rm #{work_dir}/${dmg}.dmg &&
+        /usr/bin/hdiutil create -volname ${dmg} -srcfolder #{signed}/ #{work_dir}/${dmg}.dmg &&
         /bin/rm #{signed}/* ; done], false)
       dmgs.each do | dmg |
         Pkg::Util::Net.rsync_from("#{work_dir}/#{File.basename(dmg)}", rsync_host_string, File.dirname(dmg))

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -49,10 +49,10 @@ module Pkg::Util::Net
       if capture_output
         require 'open3'
         stdout, stderr, exitstatus = Open3.capture3(cmd)
-        Pkg::Util::Execution.success?(exitstatus) or raise "Remote ssh command failed."
-        return stdout, stderr
+        Pkg::Util::Execution.success?(exitstatus) or raise "Remote ssh command failed: #{stdout} #{stderr}"
+        puts stdout, stderr
       else
-        Kernel.system(cmd)
+        Kernel.system("#{cmd} > /dev/null 2>&1")
         Pkg::Util::Execution.success? or raise "Remote ssh command failed."
       end
     end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -49,11 +49,11 @@ module Pkg::Util::Net
       if capture_output
         require 'open3'
         stdout, stderr, exitstatus = Open3.capture3(cmd)
-        Pkg::Util::Execution.success?(exitstatus) or raise "Remote ssh command failed: #{stdout} #{stderr}"
+        Pkg::Util::Execution.success?(exitstatus) || raise("Remote ssh command failed: #{stdout} #{stderr}")
         puts stdout, stderr
       else
         Kernel.system("#{cmd} > /dev/null 2>&1")
-        Pkg::Util::Execution.success? or raise "Remote ssh command failed."
+        Pkg::Util::Execution.success? || raise("Remote ssh command failed.")
       end
     end
 

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -63,21 +63,21 @@ describe "Pkg::Util::Net" do
     context "without output captured" do
       it "should execute a command :foo on a host :bar using Kernel" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh} -t foo 'bar'")
+        Kernel.should_receive(:system).with("#{ssh} -t foo 'bar' > /dev/null 2>&1")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar")
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh} -t foo 'b'\\''ar'")
+        Kernel.should_receive(:system).with("#{ssh} -t foo 'b'\\''ar' > /dev/null 2>&1")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar")
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh} -t foo 'bar'")
+        Kernel.should_receive(:system).with("#{ssh} -t foo 'bar' > /dev/null 2>&1")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end


### PR DESCRIPTION
This fixes a couple of issues with the remote_ssh_command method to prevent it from echoing output when we don't want it, and to actually return output when we want it to.

This also updates the OSX signing command to correctly exit on errors instead of proceeding and potentially silently failing while returning unsigned packages.