### PR TITLE
(maint) Don't fail if nil

### DIFF
--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -167,7 +167,7 @@ if Pkg::Config.build_pe
           fi
           ", true)
 
-        output = stdout + stderr
+        output = stdout.to_s + stderr.to_s
 
         if output.include?("ERROR:") || output.include?("There have been errors!")
           # We shouldn't ever get here if aptly returns non-zero on failure, but just in case...


### PR DESCRIPTION
We recently ran into an issue where one or the other of these values
return nil, which broke the automation. This should fix it.