### PR TITLE
(RE-8190) add first acceptance test

### DIFF
--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -1,0 +1,10 @@
+# beaker logs
+junit
+log
+
+# generic ruby things
+.bundle
+Gemfile.lock
+
+# IDE-specific things
+.idea

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,0 +1,4 @@
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+gem 'beaker', '~> 3.0'
+gem 'rake', '~> 11.0'

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,0 +1,70 @@
+# Acceptance Testing
+
+## Running Them
+
+At this point, we're only testing public build servers. We're testing
+that they install correctly by running installation & using some
+simple smoke tests against them.
+
+To run them, just run rake (in the acceptance directory). The default
+task points to our public testing, which will run automatically with
+the defaults. If you'd like to change any settings, checkout the next
+section.
+
+## Customizing a Run
+
+There are two values that are customizable in the public testing rake
+task. Those are included below as sub-sections. If you'd like to
+customize more than that, please run beaker itself rather than using
+rake.
+
+### Beaker Hosts
+
+By default, beaker will use the `ubuntu1604-64a` beaker-hostgenerator
+string. This will generate a beaker hosts file using the vmpooler to
+provision the host.
+
+To change this, use the `BEAKER_HOSTS` environment variable. Whatever
+you have as that value will be used as the value to beaker's `--hosts`
+command line option. For more information on beaker's hosts files,
+checkout our
+[Creating a Test Environment doc](https://github.com/puppetlabs/beaker/blob/master/docs/tutorials/creating_a_test_environment.md).
+
+### Tests
+
+By default, beaker will use the `tests` folder in this directory. This
+means it will run all tests in that folder.
+
+To change this, you can specify either the `TESTS` or `TEST` environment
+variable. Whatever you enter here will be used for beaker's `--tests`
+argument.
+
+### Keyfile
+
+This is the keyfile that beaker will use to ssh to the Systems Under
+Test (SUTs). If you don't provide one, then this argument won't be
+passed to beaker. You can set this using the `BEAKER_KEYFILE`
+environment variable.
+
+### Log Level
+
+This is beaker's log output level. If you don't provide a setting,
+beaker's default will be used as the option won't be provided. You
+can set this with the `BEAKER_LOG_LEVEL` environment variable.
+
+## Public Test Customization: Installation
+
+These values are ones used by the public builds server tests,
+specifically to control the versions of our software installed on the
+Systems Under Test (SUTs).
+
+### Puppet-Agent Version
+
+By default, the public test pre-suite uses '1.8.0' as the puppet-agent
+version. To change this, use the `PUPPET_AGENT_VERSION` environment
+variable.
+
+### Puppet Version
+
+By default, the public test pre-suite uses '4.8.0' as the puppet 
+version. To change this, use the `PUPPET_VERSION` environment variable.

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -1,0 +1,62 @@
+require 'rake'
+# This Rakefile is here to provide convenience for a few things:
+# 1. Getting a new user to easily be able to run acceptance tests
+#     for the first time
+# 2. Providing CI tasks, so that they're maintained in-repo, and
+#     that it's easy for a user to reproduce CI failures
+# 3. Providing shortcuts to the most often used test configs
+#
+# Providing a shortcut to a one-off beaker config that's not
+# used in automation or often by people should be suspect
+# and removed, if possible.
+
+desc 'default rake task, symlink -> "test:public"'
+task :default => ['test:public']
+# Couldn't specify a namespace default, looks like
+# I have to use the name twice. ugh. -ki 11.8.16
+desc 'test rake task, symlink -> "test:public"'
+task :test    => ['test:public']
+
+namespace :test do
+  desc 'Tests installs from publicly available build servers'
+  task :public do
+    args = [
+      "--hosts=#{beaker_hosts}",
+      "--tests=#{beaker_tests}",
+      '--pre-suite=pre_suite/public.rb',
+      keyfile_arg,
+      log_level_arg
+    ]
+    sh('beaker', *args)
+  end
+end
+
+# The default here is to provide a beaker-hostgenerator
+# string, which will use beaker's vmpooler hypervisor.
+# If that doesn't work for you, you'll need to use the
+# BEAKER_HOSTS env var to override this argument.
+def beaker_hosts
+  ENV['BEAKER_HOSTS'] || 'centos7-64a'
+end
+
+# This defaults to using all tests in the `tests` dir.
+def beaker_tests
+  ENV['TESTS'] || ENV['TEST'] || 'tests'
+end
+
+# Default for keyfile is to not be provided keyfile is the
+# key that beaker will use to SSH into the Systems Under
+# Test (SUTs).
+def keyfile_arg
+  return '' unless ENV['BEAKER_KEYFILE']
+  "--keyfile=#{ENV['BEAKER_KEYFILE']}"
+end
+
+# Beaker's log level argument
+# defaults to not being provided, so beaker's default
+# will be used.
+def log_level_arg
+  return '' unless ENV['BEAKER_LOG_LEVEL']
+  "--log-level=#{ENV['BEAKER_LOG_LEVEL']}"
+end
+

--- a/acceptance/pre_suite/public.rb
+++ b/acceptance/pre_suite/public.rb
@@ -1,0 +1,23 @@
+# This pre-suite file installs puppet-agent
+# from the public build servers. These are
+# listed below (append `.puppetlabs.com` to get
+# the build server URL):
+# - yum
+# - apt
+# - downloads
+
+# Note that the PUPPET_VERSION is only required
+# on apt build server URLs, as the install file
+# name changes depending on which overall Puppet
+# version is in use. This beaker method defaults
+# to installing from the Puppet 3.x line, so the
+# filename will not include the Puppet Collection:
+# example:
+# http://apt.puppetlabs.com/puppetlabs-release-wily.deb
+# becomes
+# http://apt.puppetlabs.com/puppetlabs-release-pc1-wily.deb
+# at Puppet 4.x.
+install_puppet_on(hosts, {
+  :version              => ENV['PUPPET_VERSION']        || '4.8.0',
+  :puppet_agent_version => ENV['PUPPET_AGENT_VERSION']  || '1.8.0'
+})

--- a/acceptance/tests/install_smoke_test.rb
+++ b/acceptance/tests/install_smoke_test.rb
@@ -1,0 +1,26 @@
+test_name 'puppet install smoketest' do
+
+  step 'puppet install smoketest: verify \'facter --help\' can be successfully called on all hosts' do
+    hosts.each do |host|
+      on host, facter('--help')
+    end
+  end
+
+  step 'puppet install smoketest: verify \'hiera --help\' can be successfully called on all hosts' do
+    hosts.each do |host|
+      on host, hiera('--help')
+    end
+  end
+
+  step 'puppet install smoketest: verify \'puppet help\' can be successfully called on all hosts' do
+    hosts.each do |host|
+      on host, puppet('help')
+    end
+  end
+
+  step 'puppet install smoketest: can get a configprint of the puppet server setting on all hosts' do
+    hosts.each do |host|
+      assert(!host.puppet['server'].empty?, 'can get a configprint of the puppet server setting')
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the acceptance testing structure to the packaging repo, and adds a test for public build servers. This test simply installs puppet-agent from those locations, and does a smoke test to verify that the tools are callable once installed.