### PR TITLE
(RE-8179) Add the ability to ubership quietly

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -3,7 +3,8 @@ require "packaging/platforms"
 # These are all of the parameters known to our packaging system.
 # They are ingested by the config class as class instance variables
 module Pkg::Params
-  BUILD_PARAMS = [:apt_host,
+  BUILD_PARAMS = [:answer_override,
+                  :apt_host,
                   :apt_releases,
                   :apt_repo_command,
                   :apt_repo_name,
@@ -174,6 +175,7 @@ module Pkg::Params
   #           Note: :type is assumed :string if not present
   #
   ENV_VARS = [
+              { :var => :answer_override,         :envvar => :ANSWER_OVERRIDE },
               { :var => :apt_host,                :envvar => :APT_HOST },
               { :var => :apt_releases,            :envvar => :APT_RELEASES,    :type => :array },
               { :var => :apt_repo_path,           :envvar => :APT_REPO },

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -196,7 +196,7 @@ module Pkg::Params
               { :var => :dmg_host,                :envvar => :DMG_HOST },
               { :var => :dmg_staging_server,      :envvar => :DMG_STAGING_SERVER },
               { :var => :final_mocks,             :envvar => :MOCK },
-              { :var => :foss_only,               :envvar => :FOSS_ONLY },
+              { :var => :foss_only,               :envvar => :FOSS_ONLY,       :type => :bool },
               { :var => :foss_platforms,          :envvar => :FOSS_PLATFORMS,  :type => :array },
               { :var => :gem_host,                :envvar => :GEM_HOST },
               { :var => :gpg_key,                 :envvar => :GPG_KEY },

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -85,8 +85,11 @@ module Pkg::Util
     rand.to_s.split('.')[1]
   end
 
-  def self.ask_yes_or_no
-    return Pkg::Util.boolean_value(ENV['ANSWER_OVERRIDE']) unless ENV['ANSWER_OVERRIDE'].nil?
+  def self.ask_yes_or_no(force = false)
+    unless force
+      return Pkg::Util.boolean_value(ENV['ANSWER_OVERRIDE']) unless ENV['ANSWER_OVERRIDE'].nil?
+    end
+
     answer = Pkg::Util.get_input
     return true if answer =~ /^y$|^yes$/
     return false if answer =~ /^n$|^no$/
@@ -98,7 +101,7 @@ module Pkg::Util
     $stdout.puts "The following files have been built and are ready to ship:"
     files.each { |file| puts "\t#{file}\n" unless File.directory?(file) }
     $stdout.puts "Ship these files?? [y,n]"
-    Pkg::Util.ask_yes_or_no
+    Pkg::Util.ask_yes_or_no(true)
   end
 
   # Construct a probably-correct (or correct-enough) URI for

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -87,7 +87,7 @@ module Pkg::Util
 
   def self.ask_yes_or_no(force = false)
     unless force
-      return Pkg::Util.boolean_value(ENV['ANSWER_OVERRIDE']) unless ENV['ANSWER_OVERRIDE'].nil?
+      return Pkg::Util.boolean_value(Pkg::Config.answer_override) unless Pkg::Config.answer_override.nil?
     end
 
     answer = Pkg::Util.get_input

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -273,33 +273,33 @@ namespace :pl do
 
       # Don't update and deploy repos if packages don't exist
       # If we can't find a certain file type, delete the task
-      unless Dir.glob("pkg/**/*.deb")
+      if Dir.glob("pkg/**/*.deb").empty?
         uber_tasks.delete("remote:update_apt_repo")
         uber_tasks.delete("remote:deploy_apt_repo")
       end
 
-      unless Dir.glob("pkg/**/*.rpm")
+      if Dir.glob("pkg/**/*.rpm").empty?
         uber_tasks.delete("remote:update_yum_repo")
         uber_tasks.delete("remote:deploy_yum_repo")
       end
 
-      unless Dir.glob("pkg/**/*.p5p")
+      if Dir.glob("pkg/**/*.p5p").empty?
         uber_tasks.delete("remote:update_ips_repo")
       end
 
-      unless Dir.glob("pkg/**/*.dmg")
+      if Dir.glob("pkg/**/*.dmg").empty?
         uber_tasks.delete("remote:deploy_dmg_repo")
       end
 
-      unless Dir.glob("pkg/**/*.swix")
+      if Dir.glob("pkg/**/*.swix").empty?
         uber_tasks.delete("remote:deploy_swix_repo")
       end
 
-      unless Dir.glob("pkg/**/*.msi")
+      if Dir.glob("pkg/**/*.msi").empty?
         uber_tasks.delete("remote:deploy_msi_repo")
       end
 
-      unless Dir.glob("pkg/*.tar.gz")
+      if Dir.glob("pkg/*.tar.gz").empty?
         uber_tasks.delete("remote:deploy_tar_repo")
       end
 

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -265,6 +265,11 @@ namespace :pl do
         remote:deploy_msi_repo
         remote:deploy_tar_repo
       )
+
+      if ENV['ANSWER_OVERRIDE'] && ! Pkg::Config.foss_only
+        fail "Using ANSWER_OVERRIDE without FOSS_ONLY=true is dangerous!"
+      end
+
       # Some projects such as pl-build-tools do not stage to a separate server - so we do to deploy
       uber_tasks.delete("remote:deploy_apt_repo") if Pkg::Config.apt_host == Pkg::Config.apt_signing_server
       uber_tasks.delete("remote:deploy_yum_repo") if Pkg::Config.yum_host == Pkg::Config.yum_staging_server

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -266,7 +266,7 @@ namespace :pl do
         remote:deploy_tar_repo
       )
 
-      if ENV['ANSWER_OVERRIDE'] && ! Pkg::Config.foss_only
+      if Pkg::Util.boolean_value(Pkg::Config.answer_override) && !Pkg::Config.foss_only
         fail "Using ANSWER_OVERRIDE without FOSS_ONLY=true is dangerous!"
       end
 

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -254,6 +254,7 @@ namespace :pl do
         jenkins:retrieve
         jenkins:sign_all
         uber_ship
+        ship_gem
         remote:update_apt_repo
         remote:deploy_apt_repo
         remote:update_yum_repo

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -21,13 +21,13 @@ namespace :pl do
       if wget = Pkg::Util::Tool.find_tool("wget")
         if Pkg::Config.foss_only && !Pkg::Config.foss_platforms
           warn "FOSS_ONLY specified, but I don't know anything about FOSS_PLATFORMS. Fetch everything?"
-          unless Pkg::Util.ask_yes_or_no
+          unless Pkg::Util.ask_yes_or_no(true)
             warn "Retrieve cancelled"
             exit
           end
         elsif Pkg::Config.foss_only && remote_target != 'artifacts'
           warn "I only know how to fetch from remote_target 'artifacts' with FOSS_ONLY. Fetch everything?"
-          unless Pkg::Util.ask_yes_or_no
+          unless Pkg::Util.ask_yes_or_no(true)
             warn "Retrieve cancelled"
             exit
           end

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -33,21 +33,16 @@ namespace :pl do
           end
         end
         if Pkg::Config.foss_only && Pkg::Config.foss_platforms && remote_target == 'artifacts'
-          urls = Hash.new
           Pkg::Config.foss_platforms.each do |platform|
             platform_path = Pkg::Util::Platform.artifacts_path(platform, package_url)
+            _, _, arch = Pkg::Util::Platform.parse_platform_tag(platform)
             url = "#{package_url}/#{platform_path}"
-            if urls.has_key? url
-              puts "Skipping fetch for #{platform}, #{url} has already been fetched"
-            else
-              urls[url] = true
-              puts "Fetching: Platform = #{platform}, URL = #{url}"
-              sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{url}/"
-            end
+            puts "Fetching: Platform = #{platform}, URL = #{url}"
+            sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*#{arch}*' #{url}/"
           end
           # also want to fetch the yaml and the signing bundle
-          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' -A '*.yaml' #{package_url}/#{remote_target}/"
-          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' -A '*.tar.gz' #{package_url}/#{remote_target}/"
+          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.yaml' #{package_url}/#{remote_target}/"
+          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.tar.gz' #{package_url}/#{remote_target}/"
         else
           # For the next person who needs to look these flags up:
           # -r = recursive

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -39,15 +39,15 @@ namespace :pl do
               _, _, arch = Pkg::Util::Platform.parse_platform_tag(platform)
               url = "#{package_url}/#{platform_path}"
               puts "Fetching: Platform = #{platform}, URL = #{url}"
-              sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*#{arch}*' #{url}/"
+              sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*#{arch}*' #{url}/"
             rescue => e
               warn "Encountered error fetching #{platform}:"
               warn e
             end
           end
           # also want to fetch the yaml and the signing bundle
-          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.yaml' #{package_url}/#{remote_target}/"
-          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.tar.gz' #{package_url}/#{remote_target}/"
+          sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.yaml' #{package_url}/#{remote_target}/"
+          sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.tar.gz' #{package_url}/#{remote_target}/"
         else
           # For the next person who needs to look these flags up:
           # -r = recursive
@@ -57,7 +57,7 @@ namespace :pl do
           # -nH = Discard http://#{Pkg::Config.builds_server} when saving to disk
           # --reject = Reject all hits that match the supplied regex
           # -P = where to save to disk (defaults to ./)
-          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{package_url}/#{remote_target}/"
+          sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{package_url}/#{remote_target}/"
         end
       else
         warn "Could not find `wget` tool. Falling back to rsyncing from #{Pkg::Config.distribution_server}"

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -45,6 +45,9 @@ namespace :pl do
               sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{url}/"
             end
           end
+          # also want to fetch the yaml and the signing bundle
+          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' -A '*.yaml' #{package_url}/#{remote_target}/"
+          sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' -A '*.tar.gz' #{package_url}/#{remote_target}/"
         else
           # For the next person who needs to look these flags up:
           # -r = recursive

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -34,11 +34,16 @@ namespace :pl do
         end
         if Pkg::Config.foss_only && Pkg::Config.foss_platforms && remote_target == 'artifacts'
           Pkg::Config.foss_platforms.each do |platform|
-            platform_path = Pkg::Util::Platform.artifacts_path(platform, package_url)
-            _, _, arch = Pkg::Util::Platform.parse_platform_tag(platform)
-            url = "#{package_url}/#{platform_path}"
-            puts "Fetching: Platform = #{platform}, URL = #{url}"
-            sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*#{arch}*' #{url}/"
+            begin
+              platform_path = Pkg::Util::Platform.artifacts_path(platform, package_url)
+              _, _, arch = Pkg::Util::Platform.parse_platform_tag(platform)
+              url = "#{package_url}/#{platform_path}"
+              puts "Fetching: Platform = #{platform}, URL = #{url}"
+              sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*#{arch}*' #{url}/"
+            rescue => e
+              warn "Encountered error fetching #{platform}:"
+              warn e
+            end
           end
           # also want to fetch the yaml and the signing bundle
           sh "#{wget} -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.yaml' #{package_url}/#{remote_target}/"

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -381,7 +381,6 @@ namespace :pl do
   desc "UBER ship: ship all the things in pkg"
   task :uber_ship => 'pl:fetch' do
     if Pkg::Util.confirm_ship(FileList["pkg/**/*"])
-      Rake::Task["pl:ship_gem"].invoke
       Rake::Task["pl:ship_rpms"].invoke
       Rake::Task["pl:ship_debs"].invoke
       Rake::Task["pl:ship_dmg"].invoke


### PR DESCRIPTION
This PR includes a number of stability improvements and safety checks to make it more reliable to run pl:jenkins:uber_ship with FOSS_ONLY=true.

Still todo:

- [x]  Make ANSWER_OVERRIDE work more like the normal config parameters
- [x]  Clean up retrieve output so we can actually see the warnings
- [x]  PR to add foss_platforms to the release team build_data. -- https://github.com/puppetlabs/build-data/pull/77