### PR TITLE
(maint) cleanup config printing

### DIFF
--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -104,6 +104,12 @@ module Pkg::Util
     Pkg::Util.ask_yes_or_no(true)
   end
 
+  def self.filter_configs(filter = nil)
+    return Pkg::Config.instance_values.select { |key, _| key.match(/#{filter}/) } if filter
+    Pkg::Config.instance_values
+  end
+
+
   # Construct a probably-correct (or correct-enough) URI for
   # tools like ssh or rsync. Currently lacking support for intuitive
   # joins, ports, protocols, fragments, or 75% of what Addressable::URI

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -98,6 +98,10 @@ module Pkg::Util
   end
 
   def self.confirm_ship(files)
+    $stdout.puts "Artifacts will be shipped to the following hosts:"
+    Pkg::Util.filter_configs('host').each { |key, value| puts "#{key}: #{value}" }
+    $stdout.puts "Does this look right?? [y,n]"
+    Pkg::Util.ask_yes_or_no(true)
     $stdout.puts "The following files have been built and are ready to ship:"
     files.each { |file| puts "\t#{file}\n" unless File.directory?(file) }
     $stdout.puts "Ship these files?? [y,n]"

--- a/tasks/config.rake
+++ b/tasks/config.rake
@@ -1,8 +1,14 @@
 namespace :config do
   desc "print Pkg::Config values for this repo"
   task :print => 'pl:fetch' do
-    Pkg::Config.instance_values.each do |key, value|
+    Pkg::Util.filter_configs.each do |key, value|
       puts "#{key}: #{value}"
+    end
+  end
+
+  task :print_hosts => 'pl:fetch' do
+    Pkg::Util.filter_configs('host').each do |key, value|
+        puts "#{key}: #{value}"
     end
   end
 

--- a/tasks/config.rake
+++ b/tasks/config.rake
@@ -8,7 +8,7 @@ namespace :config do
 
   task :print_hosts => 'pl:fetch' do
     Pkg::Util.filter_configs('host').each do |key, value|
-        puts "#{key}: #{value}"
+      puts "#{key}: #{value}"
     end
   end
 

--- a/tasks/config.rake
+++ b/tasks/config.rake
@@ -1,6 +1,6 @@
 namespace :config do
   desc "print Pkg::Config values for this repo"
-  task :print do
+  task :print => 'pl:fetch' do
     Pkg::Config.instance_values.each do |key, value|
       puts "#{key}: #{value}"
     end


### PR DESCRIPTION
This modifies config:print to call pl:fetch first so that you see the actual variables that will be loaded during the ship, and also adds a config:print_hosts to allow you to check where things will be shipping.