### PR TITLE
(RE-5982) Add ship check task

### DIFF
--- a/lib/packaging/util/misc.rb
+++ b/lib/packaging/util/misc.rb
@@ -37,5 +37,33 @@ module Pkg::Util::Misc
       #               -Sean P. M. 05/11/2016
       data
     end
+
+    # @param gem the name of the gem to see if it is installed
+    # @return boolean for whether or not the gem is installed
+    def check_gem(gem)
+      if %x(gem list -q #{gem}).chomp.empty?
+        return false
+      else
+        return true
+      end
+    end
+
+    # This loads your ~/.gem/credentials file and uses your api key
+    # to query rubygems.org for which gems you own. There may be better ways
+    # to query this but having to pull this information using curl is sort of
+    # gross. It works though, so ¯\_(ツ)_/¯
+    # @param gem_name the gem to check if you are an owner
+    # @return boolean whether or not you own the gem
+    def check_rubygems_ownership(gem_name)
+      require 'yaml'
+      credentials = YAML.load_file("#{ENV['HOME']}/.gem/credentials")
+      gems = YAML.load(%x(curl -H 'Authorization:#{credentials[:rubygems_api_key]}' https://rubygems.org/api/v1/gems.yaml))
+      gems.each do |gem|
+        if gem['name'] == gem_name
+          return true
+        end
+      end
+      return false
+    end
   end
 end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -56,7 +56,7 @@ module Pkg::Util::Net
       errs = []
       Array(hosts).flatten.each do |host|
         begin
-          remote_ssh_cmd(host, "gpg --list-secret-keys #{gpg} > /dev/null 2&>1")
+          remote_ssh_cmd(host, "gpg --list-secret-keys #{gpg} > /dev/null 2&>1", false, '-oBatchMode=yes')
         rescue
           errs << host
         end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -63,21 +63,21 @@ describe "Pkg::Util::Net" do
     context "without output captured" do
       it "should execute a command :foo on a host :bar using Kernel" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh} -t foo 'bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar")
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh} -t foo 'b'\\''ar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar")
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh} -t foo 'bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end
@@ -86,21 +86,21 @@ describe "Pkg::Util::Net" do
     context "with output captured" do
       it "should execute a command :foo on a host :bar using Open3" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh} -t foo 'bar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true)
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh} -t foo 'b'\\''ar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar", true)
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh} -t foo 'bar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true) }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end


### PR DESCRIPTION
This commit adds pl:ship_check to verify that shipping should work
before we actually try to ship. This will check things such as ssh
access to the necessary boxes, gpg keys available everywhere they are
needed, the needed gems are installed, and ownership is correct on the
gems on rubygems.