### PR TITLE
(RE-8186) Improved error handling in packaging

### DIFF
--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -96,6 +96,13 @@ module Pkg::Gem
     def ship_to_rubygems(file)
       Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
       Pkg::Util::Execution.capture3("gem push #{file}")
+    rescue => e
+      puts "###########################################"
+      puts "#  Publishing to rubygems failed. Make sure your .gem/credentials"
+      puts "#  file is set up and you are an owner of #{Pkg::Config.gem_name}"
+      puts "###########################################"
+      puts
+      puts e
     end
   end
 end

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -54,12 +54,14 @@ module Pkg::Gem
         fail unless ret.include? "Created"
         puts "#{file} pushed to nexus server at #{Pkg::Config.internal_nexus_host}"
       end
-    rescue
+    rescue => e
       puts "###########################################"
       puts "#  Nexus failed, ensure the nexus gem is installed,"
       puts "#  you have access to #{Pkg::Config.internal_nexus_host}"
       puts "#  and your settings in #{@nexus_config} are correct"
       puts "###########################################"
+      puts
+      puts e
     end
 
     # Ship a Ruby gem file to a Stickler server, because
@@ -73,11 +75,13 @@ module Pkg::Gem
         Pkg::Util::Execution.ex(cmd)
         puts "#{file} pushed to stickler server at #{Pkg::Config.internal_stickler_host}"
       end
-    rescue
+    rescue => e
       puts "###########################################"
       puts "#  Stickler failed, ensure it's installed"
       puts "#  and you have access to #{Pkg::Config.internal_stickler_host}"
       puts "###########################################"
+      puts
+      puts e
     end
 
     # Use rsync to deploy a file and any associated detached signatures,

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -44,14 +44,14 @@ module Pkg::Gem
       if ENV['DRYRUN']
         puts "[DRY-RUN] #{cmd}"
       else
-        ret = Pkg::Util::Execution.ex(cmd, true)
+        stdout, _, _ = Pkg::Util::Execution.capture3(cmd, true)
         # The `gem nexus` command always returns `0` regardless of what the
         # command results in. In order to properly handle fail cases, this
         # checks for the success case and fails otherwise. The `ex` command
         # above will print any output, so the user should have enough info
         # to debug the failure, and potentially update this fail case if
         # needed.
-        fail unless ret.include? "Created"
+        fail unless stdout.include? "Created"
         puts "#{file} pushed to nexus server at #{Pkg::Config.internal_nexus_host}"
       end
     rescue => e
@@ -72,7 +72,7 @@ module Pkg::Gem
       if ENV['DRYRUN']
         puts "[DRY-RUN] #{cmd}"
       else
-        Pkg::Util::Execution.ex(cmd)
+        Pkg::Util::Execution.capture3(cmd)
         puts "#{file} pushed to stickler server at #{Pkg::Config.internal_stickler_host}"
       end
     rescue => e
@@ -95,7 +95,7 @@ module Pkg::Gem
     # any idea who you are.
     def ship_to_rubygems(file)
       Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
-      Pkg::Util::Execution.ex("gem push #{file}")
+      Pkg::Util::Execution.capture3("gem push #{file}")
     end
   end
 end

--- a/lib/packaging/nuget.rb
+++ b/lib/packaging/nuget.rb
@@ -26,10 +26,13 @@ module Pkg::Nuget
         projname, version = File.basename(pkg).match(/^(.*)-([\d+\.]+)\.nupkg$/).captures
         package_form_data = ["--upload-file #{pkg}"]
         package_path = "#{projname}/#{version}/#{File.basename(pkg)}"
+        stdout = ''
+        retval = ''
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          Pkg::Util::Net.curl_form_data("#{uri}/#{package_path}", form_data + package_form_data)
+          stdout, retval = Pkg::Util::Net.curl_form_data("#{uri}/#{package_path}", form_data + package_form_data)
         end
-        fail "The Package upload (curl) failed with error #{$?.exitstatus}" unless $?.success?
+        fail "The Package upload (curl) failed with error #{retval}" unless Pkg::Util::Execution.success?(retval)
+        stdout
       end
     end
   end

--- a/lib/packaging/util/execution.rb
+++ b/lib/packaging/util/execution.rb
@@ -36,6 +36,25 @@ module Pkg::Util::Execution
       ret
     end
 
+    # Turns out trying to change ex to use Open3 is SUPER DANGEROUS and destructive
+    # in ways I hadn't imagined. I'm going to add a new method here instead and start
+    # converting code to use that so I don't break more than I plan to.
+    def capture3(command, debug = false)
+      require 'open3'
+      puts "Executing '#{command}'..." if debug
+      stdout, stderr, ret = Open3.capture3(command)
+      unless Pkg::Util::Execution.success?(ret)
+        raise "#{stdout}#{stderr}"
+      end
+
+      if debug
+        puts "Command '#{command}' returned:"
+        puts stdout
+      end
+
+      return stdout, stderr, ret
+    end
+
     # Loop a block up to the number of attempts given, exiting when we receive success
     # or max attempts is reached. Raise an exception unless we've succeeded.
     def retry_on_fail(args, &blk)

--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -15,7 +15,8 @@ module Pkg::Util::File
 
     def mktemp
       mktemp = Pkg::Util::Tool.find_tool('mktemp', :required => true)
-      Pkg::Util::Execution.ex("#{mktemp} -d -t pkgXXXXXX").strip
+      stdout, _, _ = Pkg::Util::Execution.capture3("#{mktemp} -d -t pkgXXXXXX")
+      stdout.strip
     end
 
     def empty_dir?(dir)
@@ -78,7 +79,8 @@ module Pkg::Util::File
         target_opts = "-C #{target}"
       end
       if file_exists?(source, :required => true)
-        Pkg::Util::Execution.ex(%Q(#{tar} #{options} #{target_opts} -xf #{source}))
+        stdout, _, _ = Pkg::Util::Execution.capture3(%Q(#{tar} #{options} #{target_opts} -xf #{source}))
+        stdout
       end
     end
 

--- a/lib/packaging/util/git.rb
+++ b/lib/packaging/util/git.rb
@@ -7,21 +7,23 @@ module Pkg::Util::Git
       fail unless Pkg::Util::Version.is_git_repo?
       puts "Commiting changes:"
       puts
-      diff = Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
+      diff, _, _ = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
       puts diff
-      Pkg::Util::Execution.ex(%Q(#{Pkg::Util::Tool::GIT} commit #{file} -m "Commit #{message} in #{file}" &> #{Pkg::Util::OS::DEVNULL}))
+      stdout, _, _ = Pkg::Util::Execution.capture3(%Q(#{Pkg::Util::Tool::GIT} commit #{file} -m "Commit #{message} in #{file}" &> #{Pkg::Util::OS::DEVNULL}))
+      stdout
     end
 
     def git_tag(version)
       fail unless Pkg::Util::Version.is_git_repo?
-      Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} tag -s -u #{Pkg::Config.gpg_key} -m '#{version}' #{version}")
+      stdout, _, _ = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} tag -s -u #{Pkg::Config.gpg_key} -m '#{version}' #{version}")
+      stdout
     end
 
     def git_bundle(treeish, appendix = Pkg::Util.rand_string, temp = Pkg::Util::File.mktemp)
       fail unless Pkg::Util::Version.is_git_repo?
-      Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix} #{treeish} --tags")
+      Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix} #{treeish} --tags")
       Dir.chdir(temp) do
-        Pkg::Util::Execution.ex("#{Pkg::Util::Tool.find_tool('tar')} -czf #{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}.tar.gz #{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}")
+        Pkg::Util::Execution.capture3("#{Pkg::Util::Tool.find_tool('tar')} -czf #{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}.tar.gz #{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}")
         FileUtils.rm_rf("#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}")
       end
       "#{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix}.tar.gz"
@@ -29,7 +31,8 @@ module Pkg::Util::Git
 
     def git_pull(remote, branch)
       fail unless Pkg::Util::Version.is_git_repo?
-      Pkg::Util::Execution.ex("#{Pkg::Util::Tool::GIT} pull #{remote} #{branch}")
+      stdout, _, _ = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} pull #{remote} #{branch}")
+      stdout
     end
 
   end

--- a/lib/packaging/util/git_tags.rb
+++ b/lib/packaging/util/git_tags.rb
@@ -43,9 +43,10 @@ module Pkg::Util
     # Fetch the full ref using ls-remote, this should raise an error if it returns non-zero
     # because that means this ref doesn't exist in the repo
     def fetch_full_ref
-      Pkg::Util::Execution.ex("#{GIT} ls-remote --tags --heads --exit-code #{address} #{ref}").split.last
-    rescue RuntimeError
-      raise "ERROR : Not a ref or sha!"
+      stdout, _, _ = Pkg::Util::Execution.capture3("#{GIT} ls-remote --tags --heads --exit-code #{address} #{ref}")
+      stdout.split.last
+    rescue RuntimeError => e
+      raise "ERROR : Not a ref or sha!\n#{e}"
     end
 
     def branch_name

--- a/lib/packaging/util/gpg.rb
+++ b/lib/packaging/util/gpg.rb
@@ -21,13 +21,15 @@ module Pkg::Util::Gpg
 
     def kill_keychain
       if keychain
-        Pkg::Util::Execution.ex("#{keychain} -k mine")
+        stdout, _, _ = Pkg::Util::Execution.capture3("#{keychain} -k mine")
+        stdout
       end
     end
 
     def start_keychain
       if keychain
-        keychain_output = Pkg::Util::Execution.ex("#{keychain} -q --agents gpg --eval #{Pkg::Config.gpg_key}").chomp
+        keychain_output, _, _ = Pkg::Util::Execution.capture3("#{keychain} -q --agents gpg --eval #{Pkg::Config.gpg_key}")
+        keychain_output.chomp!
         new_env = keychain_output.match(/GPG_AGENT_INFO=([^;]*)/)
         ENV["GPG_AGENT_INFO"] = new_env[1]
       else
@@ -40,7 +42,8 @@ module Pkg::Util::Gpg
 
       if gpg
         use_tty = "--no-tty --use-agent" if ENV['RPM_GPG_AGENT']
-        Pkg::Util::Execution.ex("#{gpg} #{use_tty} --armor --detach-sign -u #{Pkg::Config.gpg_key} #{file}")
+        stdout, _, _ = Pkg::Util::Execution.capture3("#{gpg} #{use_tty} --armor --detach-sign -u #{Pkg::Config.gpg_key} #{file}")
+        stdout
       else
         fail "No gpg available. Cannot sign #{file}."
       end

--- a/lib/packaging/util/jenkins.rb
+++ b/lib/packaging/util/jenkins.rb
@@ -23,7 +23,8 @@ module Pkg::Util::Jenkins
     def jenkins_job_exists?(name)
       job_url = "http://#{Pkg::Config.jenkins_build_host}/job/#{name}/config.xml"
       form_args = ["--silent", "--fail"]
-      _, retval = Pkg::Util::Net.curl_form_data(job_url, form_args, :quiet => true)
+      output, retval = Pkg::Util::Net.curl_form_data(job_url, form_args, :quiet => true)
+      return output if retval.nil?
       return Pkg::Util::Execution.success?(retval)
     end
 

--- a/lib/packaging/util/jenkins.rb
+++ b/lib/packaging/util/jenkins.rb
@@ -23,7 +23,8 @@ module Pkg::Util::Jenkins
     def jenkins_job_exists?(name)
       job_url = "http://#{Pkg::Config.jenkins_build_host}/job/#{name}/config.xml"
       form_args = ["--silent", "--fail"]
-      Pkg::Util::Net.curl_form_data(job_url, form_args, :quiet => true)
+      _, retval = Pkg::Util::Net.curl_form_data(job_url, form_args, :quiet => true)
+      return Pkg::Util::Execution.success?(retval)
     end
 
     # Wait for last build of job to finish.

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -86,8 +86,7 @@ module Pkg::Util::Net
 
       puts "Executing '#{command}' on #{target}"
       if capture_output
-        require 'open3'
-        stdout, stderr, exitstatus = Open3.capture3(cmd)
+        stdout, stderr, exitstatus = Pkg::Util::Execution.capture3(cmd)
         Pkg::Util::Execution.success?(exitstatus) or raise "Remote ssh command failed."
         return stdout, stderr
       else

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -237,7 +237,8 @@ module Pkg::Util::Net
       end
       begin
         Pkg::Util::Execution.ex("#{curl} #{post_string}")
-      rescue RuntimeError
+      rescue RuntimeError => e
+        puts e
         return false
       end
     end

--- a/lib/packaging/util/serialization.rb
+++ b/lib/packaging/util/serialization.rb
@@ -9,8 +9,8 @@ module Pkg::Util::Serialization
       file = File.expand_path(file)
       begin
         input_data = YAML.load_file(file) || {}
-      rescue
-        fail "There was an error loading data from #{file}."
+      rescue => e
+        fail "There was an error loading data from #{file}.\n#{e}"
       end
       input_data
     end

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -37,14 +37,14 @@ describe "Pkg::Deb::Repo" do
 
     it "warns if there are no deb repos available for the build" do
       Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:ex).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_raise(RuntimeError)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_raise(RuntimeError)
       Pkg::Deb::Repo.should_receive(:warn).with("No debian repos available for #{project} at #{ref}.")
       Pkg::Deb::Repo.generate_repo_configs
     end
 
     it "writes the expected repo configs to disk" do
       Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:ex).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_return(wget_results + wget_garbage)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_return(wget_results + wget_garbage)
       FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs/deb")
       config = []
       repo_configs.each_with_index do |repo_config, i|
@@ -65,7 +65,7 @@ describe "Pkg::Deb::Repo" do
     it "warns if there are no deb repos available for the build" do
       Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
       FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs").and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/deb/").and_raise(RuntimeError)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/deb/").and_raise(RuntimeError)
       expect {Pkg::Deb::Repo.retrieve_repo_configs}.to raise_error(RuntimeError, /Couldn't retrieve deb apt repo configs/)
     end
   end
@@ -130,7 +130,7 @@ describe "Pkg::Deb::Repo" do
       reprepro = "/bin/reprepro"
       Pkg::Util::File.should_receive(:directories).with("repos/apt").and_return(dists)
       Pkg::Util::Tool.should_receive(:check_tool).with("reprepro").and_return(reprepro)
-      Pkg::Util::Execution.should_receive(:ex).exactly(4).times.with("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
+      Pkg::Util::Execution.should_receive(:capture3).exactly(4).times.with("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
 
       dists.each do |dist|
         distfiles[dist] = double

--- a/spec/lib/packaging/rpm/repo_spec.rb
+++ b/spec/lib/packaging/rpm/repo_spec.rb
@@ -42,17 +42,17 @@ describe "Pkg::Rpm::Repo" do
 
     it "warns if there are no rpm repos available for the build" do
       Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:ex).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return("")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return("")
       Pkg::Rpm::Repo.should_receive(:warn).with("No rpm repos were found to generate configs from!")
       Pkg::Rpm::Repo.generate_repo_configs
     end
 
     it "writes the expected repo configs to disk" do
       Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:ex).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return(wget_results + wget_garbage)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return(wget_results + wget_garbage)
       wget_results.split.each do |result|
         cur_result = result.chomp('repodata/')
-        Pkg::Util::Execution.should_receive(:ex).with("#{wget} --spider -r -l 1 --no-parent #{cur_result} 2>&1").and_return("#{cur_result}/thing.rpm")
+        Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{cur_result} 2>&1").and_return("#{cur_result}/thing.rpm")
       end
       FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs/rpm")
       config = []
@@ -74,7 +74,7 @@ describe "Pkg::Rpm::Repo" do
     it "fails if there are no deb repos available for the build" do
       Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
       FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs").and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/rpm/").and_raise(RuntimeError)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/rpm/").and_raise(RuntimeError)
       expect {Pkg::Rpm::Repo.retrieve_repo_configs}.to raise_error(RuntimeError, /Couldn't retrieve rpm yum repo configs/)
     end
   end
@@ -93,7 +93,7 @@ describe "Pkg::Rpm::Repo" do
       Dir.should_receive(:chdir).with(target_directory).and_yield
       Pkg::Util::Tool.should_receive(:find_tool).with('createrepo', :required => true).and_return(command)
       Pkg::Rpm::Repo.should_receive(:repo_creation_command).with(command).and_return("run this thing")
-      Pkg::Util::Execution.should_receive(:ex).with("bash -c 'run this thing'")
+      Pkg::Util::Execution.should_receive(:capture3).with("bash -c 'run this thing'")
       Pkg::Rpm::Repo.create_repos(target_directory)
     end
   end

--- a/spec/lib/packaging/util/execution_spec.rb
+++ b/spec/lib/packaging/util/execution_spec.rb
@@ -39,4 +39,18 @@ describe "Pkg::Util::Execution" do
       Pkg::Util::Execution.ex(command).should == output
     end
   end
+
+  describe "#capture3" do
+    it "should raise an error if the command fails" do
+      Open3.should_receive(:capture3).with(command).and_return([output, '', 1])
+      Pkg::Util::Execution.should_receive(:success?).with(1).and_return(false)
+      expect{ Pkg::Util::Execution.capture3(command) }.to raise_error(RuntimeError, /#{output}/)
+    end
+
+    it "should return the output of the command for success" do
+      Open3.should_receive(:capture3).with(command).and_return([output, '', 0])
+      Pkg::Util::Execution.should_receive(:success?).with(0).and_return(true)
+      Pkg::Util::Execution.capture3(command).should == [output, '', 0]
+    end
+  end
 end

--- a/spec/lib/packaging/util/file_spec.rb
+++ b/spec/lib/packaging/util/file_spec.rb
@@ -18,35 +18,35 @@ describe "Pkg::Util::File" do
 
     it "raises an exception if the source doesn't exist" do
       Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}).and_raise(RuntimeError)
-      Pkg::Util::Execution.should_not_receive(:ex)
+      Pkg::Util::Execution.should_not_receive(:capture3)
       expect { Pkg::Util::File.untar_into(source) }.to raise_error(RuntimeError)
     end
 
     it "unpacks the tarball to the current directory if no target is passed" do
       Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::Execution.should_receive(:ex).with("#{tar}   -xf #{source}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{tar}   -xf #{source}")
       Pkg::Util::File.untar_into(source)
     end
 
     it "unpacks the tarball to the current directory with options if no target is passed" do
       Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::Execution.should_receive(:ex).with("#{tar} #{options}  -xf #{source}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{tar} #{options}  -xf #{source}")
       Pkg::Util::File.untar_into(source, nil, options)
     end
 
     it "unpacks the tarball into the target" do
-      File.stub(:exist?).with(source) { true }
+      File.stub(:capture3ist?).with(source) { true }
       Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
       Pkg::Util::File.should_receive(:file_writable?).with(target) { true }
-      Pkg::Util::Execution.should_receive(:ex).with("#{tar}  -C #{target} -xf #{source}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{tar}  -C #{target} -xf #{source}")
       Pkg::Util::File.untar_into(source, target)
     end
 
     it "unpacks the tarball into the target with options passed" do
-      File.stub(:exist?).with(source) { true }
+      File.stub(:capture3ist?).with(source) { true }
       Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
       Pkg::Util::File.should_receive(:file_writable?).with(target) { true }
-      Pkg::Util::Execution.should_receive(:ex).with("#{tar} #{options} -C #{target} -xf #{source}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{tar} #{options} -C #{target} -xf #{source}")
       Pkg::Util::File.untar_into(source, target, options)
     end
   end

--- a/spec/lib/packaging/util/git_spec.rb
+++ b/spec/lib/packaging/util/git_spec.rb
@@ -8,15 +8,15 @@ describe "Pkg::Util::Git" do
 
     it "should commit a file with no message, giving changes as the message instead" do
       Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} commit #{file} -m \"Commit changes in #{file}\" &> /dev/null")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} commit #{file} -m \"Commit changes in #{file}\" &> /dev/null")
       Pkg::Util::Git.git_commit_file(file)
     end
 
     it "should commit a file with foo as message" do
       Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} commit #{file} -m \"Commit #{message} in #{file}\" &> /dev/null")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} commit #{file} -m \"Commit #{message} in #{file}\" &> /dev/null")
       Pkg::Util::Git.git_commit_file(file, message)
     end
   end
@@ -33,7 +33,7 @@ describe "Pkg::Util::Git" do
 
     it "should not fail" do
       Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} tag -s -u #{gpg_key} -m '#{version}' #{version}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} tag -s -u #{gpg_key} -m '#{version}' #{version}")
       Pkg::Util::Git.should_not raise_error
       Pkg::Util::Git.git_tag(version)
     end
@@ -61,7 +61,7 @@ describe "Pkg::Util::Git" do
       Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
       Pkg::Util::File.should_receive(:mktemp).and_return(temp)
       Pkg::Util.should_receive(:rand_string).and_return(string)
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{project}-#{version}-#{string} #{treeish} --tags")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{project}-#{version}-#{string} #{treeish} --tags")
       Dir.should_receive(:chdir).with(temp)
       Pkg::Util::Git.git_bundle(treeish)
     end
@@ -69,14 +69,14 @@ describe "Pkg::Util::Git" do
     it "should create a git bundle with random output directory" do
       Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
       Pkg::Util::File.should_receive(:mktemp).and_return(temp)
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{project}-#{version}-#{appendix} #{treeish} --tags")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{project}-#{version}-#{appendix} #{treeish} --tags")
       Dir.should_receive(:chdir).with(temp)
       Pkg::Util::Git.git_bundle(treeish, appendix)
     end
 
     it "should create a git bundle" do
       Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} bundle create #{output_dir}/#{project}-#{version}-#{appendix} #{treeish} --tags")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} bundle create #{output_dir}/#{project}-#{version}-#{appendix} #{treeish} --tags")
       Dir.should_receive(:chdir).with(output_dir)
       Pkg::Util::Git.git_bundle(treeish, appendix, output_dir)
     end
@@ -88,7 +88,7 @@ describe "Pkg::Util::Git" do
 
     it "should pull the branch" do
       Pkg::Util::Version.should_receive(:is_git_repo?).and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} pull #{remote} #{branch}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} pull #{remote} #{branch}")
       Pkg::Util::Git.git_pull(remote, branch)
     end
   end

--- a/spec/lib/packaging/util/git_tag_spec.rb
+++ b/spec/lib/packaging/util/git_tag_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe "Pkg::Util::Git_tag" do
   context "parse_ref!" do
     it "fails for a ref that doesn't exist'" do
-      expect { Pkg::Util::Git_tag.new("git://github.com/puppetlabs/leatherman.git", "garbagegarbage") }.to raise_error(RuntimeError, "ERROR : Not a ref or sha!")
+      expect { Pkg::Util::Git_tag.new("git://github.com/puppetlabs/leatherman.git", "garbagegarbage") }.to raise_error(RuntimeError, /ERROR : Not a ref or sha!/)
     end
   end
 

--- a/spec/lib/packaging/util/gpg_spec.rb
+++ b/spec/lib/packaging/util/gpg_spec.rb
@@ -40,13 +40,13 @@ describe "Pkg::Util::Gpg" do
       ENV['RPM_GPG_AGENT'] = 'blerg'
       additional_flags = "--no-tty --use-agent"
       Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
-      Pkg::Util::Execution.should_receive(:ex).with("#{gpg}\s#{additional_flags}\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{gpg}\s#{additional_flags}\s--armor --detach-sign -u #{gpg_key} #{target_file}")
       Pkg::Util::Gpg.sign_file(target_file)
     end
 
     it 'signs without extra flags when RPM_GPG_AGENT is not set' do
       Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
-      Pkg::Util::Execution.should_receive(:ex).with("#{gpg}\s\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{gpg}\s\s--armor --detach-sign -u #{gpg_key} #{target_file}")
       Pkg::Util::Gpg.sign_file(target_file)
     end
   end

--- a/spec/lib/packaging/util/jenkins_spec.rb
+++ b/spec/lib/packaging/util/jenkins_spec.rb
@@ -24,16 +24,19 @@ describe Pkg::Util::Jenkins do
 
     it "should call curl_form_data with correct arguments" do
       Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true)
+      Pkg::Util::Execution.should_receive(:success?).and_return(true)
       Pkg::Util::Jenkins.jenkins_job_exists?(name)
     end
 
     it "should return false on job not existing" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(false)
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true)
+      Pkg::Util::Execution.should_receive(:success?).and_return(false)
       Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
     end
 
     it "should return true when job exists" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(true)
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true)
+      Pkg::Util::Execution.should_receive(:success?).and_return(true)
       Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_true
     end
   end

--- a/spec/lib/packaging/util/jenkins_spec.rb
+++ b/spec/lib/packaging/util/jenkins_spec.rb
@@ -23,19 +23,24 @@ describe Pkg::Util::Jenkins do
   describe "#jenkins_job_exists?" do
 
     it "should call curl_form_data with correct arguments" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true)
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
       Pkg::Util::Execution.should_receive(:success?).and_return(true)
       Pkg::Util::Jenkins.jenkins_job_exists?(name)
     end
 
     it "should return false on job not existing" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true)
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 1])
       Pkg::Util::Execution.should_receive(:success?).and_return(false)
       Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
     end
 
+    it "should return false if curl_form_data raised a runtime error" do
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(false)
+      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
+    end
+
     it "should return true when job exists" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true)
+      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
       Pkg::Util::Execution.should_receive(:success?).and_return(true)
       Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_true
     end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -124,19 +124,19 @@ describe "Pkg::Util::Net" do
 
     it "should rsync 'thing' to 'foo@bar:/home/foo' with flags '#{defaults} --ignore-existing'" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} #{defaults} --ignore-existing thing foo@bar:/home/foo", true)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --ignore-existing thing foo@bar:/home/foo", true)
       Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo")
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include --ignore-existing" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} #{defaults} thing foo@bar:/home/foo", true)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} thing foo@bar:/home/foo", true)
       Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", extra_flags: [])
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} #{defaults} --foo-bar --and-another-flag thing foo@bar:/home/foo", true)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag thing foo@bar:/home/foo", true)
       Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", extra_flags: ["--foo-bar", "--and-another-flag"])
     end
   end
@@ -144,7 +144,7 @@ describe "Pkg::Util::Net" do
   describe "#s3sync_to" do
     it "should fail if s3cmd is not present" do
       Pkg::Util::Tool.should_receive(:find_tool).with('s3cmd', :required => true).and_raise(RuntimeError)
-      Pkg::Util::Execution.should_not_receive(:ex).with("#{s3cmd} sync  'foo' s3://bar/boo/")
+      Pkg::Util::Execution.should_not_receive(:capture3).with("#{s3cmd} sync  'foo' s3://bar/boo/")
       expect{ Pkg::Util::Net.s3sync_to("foo", "bar", "boo") }.to raise_error(RuntimeError)
     end
 
@@ -157,14 +157,14 @@ describe "Pkg::Util::Net" do
     it "should s3 sync 'thing' to 's3://foo@bar/home/foo/' with no flags" do
       Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
       Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{s3cmd} sync  'thing' s3://foo@bar/home/foo/")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{s3cmd} sync  'thing' s3://foo@bar/home/foo/")
       Pkg::Util::Net.s3sync_to("thing", "foo@bar", "home/foo")
     end
 
     it "should s3 sync 'thing' to 's3://foo@bar/home/foo/' with --delete-removed and --acl-public" do
       Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
       Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
-      Pkg::Util::Execution.should_receive(:ex).with("#{s3cmd} sync --delete-removed --acl-public 'thing' s3://foo@bar/home/foo/")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{s3cmd} sync --delete-removed --acl-public 'thing' s3://foo@bar/home/foo/")
       Pkg::Util::Net.s3sync_to("thing", "foo@bar", "home/foo", ["--delete-removed", "--acl-public"])
     end
   end
@@ -179,19 +179,19 @@ describe "Pkg::Util::Net" do
 
     it "should not include the flags '--ignore-existing' by default" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
       Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
     end
 
     it "should rsync 'thing' from 'foo@bar' to '/home/foo' with flags '#{defaults}'" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
       Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
     end
 
     it "rsyncs 'thing' from 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
       Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:ex).with("#{rsync} #{defaults} --foo-bar --and-another-flag foo@bar:thing /home/foo", true)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag foo@bar:thing /home/foo", true)
       Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo", extra_flags: ["--foo-bar", "--and-another-flag"])
     end
   end
@@ -203,26 +203,26 @@ describe "Pkg::Util::Net" do
 
     it "should return false on failure" do
       Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{target_uri}").and_return(false)
-      Pkg::Util::Net.curl_form_data(target_uri).should be_false
+      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{target_uri}").and_return(['stdout', 'stderr', 1])
+      Pkg::Util::Net.curl_form_data(target_uri).should eq(['stdout', 1])
     end
 
 
     it "should curl with just the uri" do
       Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{target_uri}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{target_uri}")
       Pkg::Util::Net.curl_form_data(target_uri)
     end
 
     it "should curl with the form data and uri" do
       Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{form_data[0]} #{target_uri}")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} #{target_uri}")
       Pkg::Util::Net.curl_form_data(target_uri, form_data)
     end
 
     it "should curl with form data, uri, and be quiet" do
       Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:ex).with("#{curl} -i #{form_data[0]} #{target_uri} >/dev/null 2>&1")
+      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} #{target_uri} >/dev/null 2>&1")
       Pkg::Util::Net.curl_form_data(target_uri, form_data, options)
     end
 

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -91,23 +91,23 @@ describe "Pkg::Util::Net" do
     end
 
     context "with output captured" do
-      it "should execute a command :foo on a host :bar using Open3" do
+      it "should execute a command :foo on a host :bar using Pkg::Util::Execution.capture3" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
+        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true)
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
+        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar", true)
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
+        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true) }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end

--- a/spec/lib/packaging/util/version_spec.rb
+++ b/spec/lib/packaging/util/version_spec.rb
@@ -50,19 +50,19 @@ describe "Pkg::Util::Version" do
 
     it "returns a sha if the repo is not tagged" do
       Pkg::Util::Version.should_receive(:git_ref_type).and_return("sha")
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} rev-parse --short=40 HEAD").and_return(sha)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} rev-parse --short=40 HEAD").and_return(sha)
       Pkg::Util::Version.git_sha_or_tag
     end
 
     it "returns a short sha if the repo is not tagged and short is specified" do
       Pkg::Util::Version.should_receive(:git_ref_type).and_return("sha")
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} rev-parse --short=7 HEAD").and_return(short_sha)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} rev-parse --short=7 HEAD").and_return(short_sha)
       Pkg::Util::Version.git_sha_or_tag(7)
     end
 
     it "returns a tag if the repo is tagged" do
       Pkg::Util::Version.should_receive(:git_ref_type).and_return("tag")
-      Pkg::Util::Execution.should_receive(:ex).with("#{Pkg::Util::Tool::GIT} describe").and_return(tag)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{Pkg::Util::Tool::GIT} describe").and_return(tag)
       Pkg::Util::Version.git_sha_or_tag
     end
   end

--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -19,8 +19,8 @@ task :setup do
   # Read the Apple file-mappings
   begin
     @source_files        = Pkg::Util::Serialization.load_yaml('ext/osx/file_mapping.yaml')
-  rescue
-    fail "Could not load Apple file mappings from 'ext/osx/file_mapping.yaml'"
+  rescue => e
+    fail "Could not load Apple file mappings from 'ext/osx/file_mapping.yaml'\n#{e}"
   end
   @package_name          = Pkg::Config.project
   @title                 = "#{Pkg::Config.project}-#{Pkg::Config.version}"

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -24,8 +24,8 @@ def debuild(args)
   results_dir = args[:work_dir]
   begin
     sh "debuild --no-lintian -uc -us"
-  rescue
-    fail "Something went wrong. Hopefully the backscroll or #{results_dir}/#{Pkg::Config.project}_#{Pkg::Config.debversion}.build file has a clue."
+  rescue => e
+    fail "Something went wrong. Hopefully the backscroll or #{results_dir}/#{Pkg::Config.project}_#{Pkg::Config.debversion}.build file has a clue.\n#{e}"
   end
 end
 

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -193,7 +193,8 @@ namespace :pl do
       # Call out to the curl_form_data utility method in 00_utils.rake
       #
       begin
-        if Pkg::Util::Net.curl_form_data(trigger_url, args)
+        _, retval = Pkg::Util::Net.curl_form_data(trigger_url, args)
+        if Pkg::Util::Execution.success?(retval)
           puts "Build submitted. To view your build results, go to #{job_url}"
           puts "Your packages will be available at http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
         else
@@ -428,7 +429,8 @@ namespace :pl do
       "-FSubmit=Build"
       ]
 
-      if Pkg::Util::Net.curl_form_data(uri, args)
+      _, retval = Pkg::Util::Net.curl_form_data(uri, args)
+      if Pkg::Util::Execution.success?(retval)
         puts "Job triggered at #{uri}."
       else
         fail "An error occurred attempting to trigger the job at #{uri}. Please see the preceding http response for more info."

--- a/tasks/jenkins_dynamic.rake
+++ b/tasks/jenkins_dynamic.rake
@@ -175,7 +175,8 @@ namespace :pl do
       # Contstruct the job url
       trigger_url = "#{Pkg::Config.jenkins_build_host}/job/#{name}/build"
 
-      if Pkg::Util::Net.curl_form_data(trigger_url, curl_args)
+      _, retval = Pkg::Util::Net.curl_form_data(trigger_url, curl_args)
+      if Pkg::Util::Execution.success?(retval)
         Pkg::Util::Net.print_url_info("http://#{Pkg::Config.jenkins_build_host}/job/#{name}")
         puts "Your packages will be available at http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       else

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -76,8 +76,8 @@ namespace :pl do
         warn "Could not find `wget` tool. Falling back to rsyncing from #{Pkg::Config.distribution_server}"
         begin
           Pkg::Util::Net.rsync_from("#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}/", Pkg::Config.distribution_server, "#{local_target}/")
-        rescue
-          fail "Couldn't download packages from distribution server. Try installing wget!"
+        rescue => e
+          fail "Couldn't download packages from distribution server.\n#{e}"
         end
       end
       puts "Packages staged in pkg"


### PR DESCRIPTION
This is a reimplementation from #604. Rather than modifying the existing `ex()` method, I'm adding a new capture3 method so as not to interfere and change behavior with code using this method in enterprise-dist. I also converted all instances of `ex()` in the packaging repo to use `capture3`.