### PR TITLE
Fix Bundler's `fetch` not found error

### DIFF
--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -100,7 +100,7 @@ if Pkg::Config.pre_tar_task
       # Cache the gems
       definition.specs.each do |spec|
         # Fetch Rubygem specs
-        Bundler::Fetcher.fetch(spec) if spec.source.is_a?(Bundler::Source::Rubygems)
+        Bundler::Fetcher.fetch_spec(spec) if spec.source.is_a?(Bundler::Source::Rubygems)
         # Cache everything but bundler itself...
         spec.source.cache(spec) unless spec.name == "bundler"
       end


### PR DESCRIPTION
We were calling the internal `fetch` method inside Bundler::Fetcher. Upstream
has started calling this an internal method, and moved it around, so now we
should be using the public version of this functionality.