### PR TITLE
(RE-8415) Fix Bundler's `fetch` not found error

### DIFF
--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -105,6 +105,9 @@ if Pkg::Config.pre_tar_task
         elsif Bundler::Fetcher.respond_to?(:fetch, true)
           # Retain this call in case we are dealing with an older version of bundler.
           Bundler::Fetcher.fetch(spec) if spec.source.is_a?(Bundler::Source::Rubygems)
+        else
+          # shrug
+          fail "Cannot find a way to download the gem for caching! Did the `fetch_gem` method move?"
         end
         # Cache everything but bundler itself...
         spec.source.cache(spec) unless spec.name == "bundler"

--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -100,11 +100,15 @@ if Pkg::Config.pre_tar_task
       # Cache the gems
       definition.specs.each do |spec|
         # Fetch Rubygem specs
-        Bundler::Fetcher.fetch(spec) if spec.source.is_a?(Bundler::Source::Rubygems)
+        if spec.source.respond_to?(:fetch_gem, true)
+          spec.source.send(:fetch_gem, spec) if spec.source.is_a?(Bundler::Source::Rubygems)
+        elsif Bundler::Fetcher.respond_to?(:fetch, true)
+          # Retain this call in case we are dealing with an older version of bundler.
+          Bundler::Fetcher.fetch(spec) if spec.source.is_a?(Bundler::Source::Rubygems)
+        end
         # Cache everything but bundler itself...
         spec.source.cache(spec) unless spec.name == "bundler"
       end
-
     end
   end
 end


### PR DESCRIPTION
We were calling the internal `fetch` method inside Bundler::Fetcher. Upstream
has started calling this an internal method, and moved it around, so now we
should be using the public version of this functionality.