### PR TITLE
(RE-8187) fail more!

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -64,8 +64,12 @@ module Pkg::Util::Net
       return errs
     end
 
-    def remote_ssh_cmd(target, command, capture_output = false, extra_options = '')
+    def remote_ssh_cmd(target, command, capture_output = false, extra_options = '', fail_fast = true)
       ssh = Pkg::Util::Tool.check_tool('ssh')
+
+      # we pass some pretty complicated commands in via ssh. We need this to fail
+      # if any part of the remote ssh command fails.
+      command = "set -e; #{command}" if fail_fast
       cmd = "#{ssh} #{extra_options} -t #{target} '#{command.gsub("'", "'\\\\''")}'"
 
       # This is NOT a good way to support this functionality.

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -258,12 +258,12 @@ module Pkg::Util::Net
     end
 
     def remote_set_ownership(host, owner, group, files)
-      remote_cmd = "for file in #{files.join(" ")}; do lsattr $file | grep -q '\\-i\\-'; if [ $? -eq 1 ]; then sudo chown #{owner}:#{group} $file; else echo \"$file is immutable\"; fi; done"
+      remote_cmd = "for file in #{files.join(" ")}; do if ! `lsattr $file | grep -q '\\-i\\-'`; then sudo chown #{owner}:#{group} $file; else echo \"$file is immutable\"; fi; done"
       Pkg::Util::Net.remote_ssh_cmd(host, remote_cmd)
     end
 
     def remote_set_permissions(host, permissions, files)
-      remote_cmd = "for file in #{files.join(" ")}; do lsattr $file | grep -q '\\-i\\-'; if [ $? -eq 1 ]; then sudo chmod #{permissions} $file; else echo \"$file is immutable\"; fi; done"
+      remote_cmd = "for file in #{files.join(" ")}; do if ! `lsattr $file | grep -q '\\-i\\-'`; then sudo chmod #{permissions} $file; else echo \"$file is immutable\"; fi; done"
       Pkg::Util::Net.remote_ssh_cmd(host, remote_cmd)
     end
 

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -60,24 +60,31 @@ describe "Pkg::Util::Net" do
       expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError)
     end
 
+    it "should be able to not fail fast" do
+        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
+        Pkg::Util::Execution.should_receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_ssh_cmd("foo", "bar", false, '', false)
+     end
+
     context "without output captured" do
       it "should execute a command :foo on a host :bar using Kernel" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar")
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'b'\\''ar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar")
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end
@@ -86,21 +93,21 @@ describe "Pkg::Util::Net" do
     context "with output captured" do
       it "should execute a command :foo on a host :bar using Open3" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'bar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true)
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'b'\\''ar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar", true)
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'bar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true) }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end


### PR DESCRIPTION
This adds `set -e` to `remote_ssh_cmd` and also fixes the two cases I found where we were depending on a failure in a command passed to `remote_ssh_cmd`