### PR TITLE
Revert "(RE-8187) fail more!"

### DIFF
--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -60,31 +60,24 @@ describe "Pkg::Util::Net" do
       expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError)
     end
 
-    it "should be able to not fail fast" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_ssh_cmd("foo", "bar", false, '', false)
-     end
-
     context "without output captured" do
       it "should execute a command :foo on a host :bar using Kernel" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar")
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar")
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end
@@ -93,21 +86,21 @@ describe "Pkg::Util::Net" do
     context "with output captured" do
       it "should execute a command :foo on a host :bar using Open3" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true)
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar", true)
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
+        Open3.should_receive(:capture3).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true) }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end


### PR DESCRIPTION
Reverts puppetlabs/packaging#615

Found some more issues, in particular puppet-agent/vanagon promotions that have platforms in the build_data.yaml that don't exist in PE