### PR TITLE
(RE-8186) Using pipes in Open3.capture3 with JRuby is special

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -233,11 +233,11 @@ module Pkg::Util::Net
       post_string << "#{uri}"
 
       # If this is quiet, we're going to silence all output
-      if options[:quiet]
-        post_string << " >#{Pkg::Util::OS::DEVNULL} 2>&1"
-      end
       begin
         stdout, _, retval = Pkg::Util::Execution.capture3("#{curl} #{post_string}")
+        if options[:quiet]
+          stdout = ''
+        end
         return stdout, retval
       rescue RuntimeError => e
         puts e

--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -5,7 +5,6 @@ module Pkg::Util::Version
   class << self
 
     GIT = Pkg::Util::Tool::GIT
-    DEVNULL = Pkg::Util::OS::DEVNULL
 
     def git_co(ref)
       Pkg::Util.in_project_root do
@@ -16,7 +15,7 @@ module Pkg::Util::Version
 
     def git_tagged?
       Pkg::Util.in_project_root do
-        _, _, ret = Pkg::Util::Execution.capture3("#{GIT} describe >#{DEVNULL} 2>&1")
+        _, _, ret = Pkg::Util::Execution.capture3("#{GIT} describe")
         Pkg::Util::Execution.success?(ret)
       end
     end
@@ -60,7 +59,7 @@ module Pkg::Util::Version
     # Return true if we're in a git repo, otherwise false
     def is_git_repo?
       Pkg::Util.in_project_root do
-        _, _, ret = Pkg::Util::Execution.capture3("#{GIT} rev-parse --git-dir > #{DEVNULL} 2>&1")
+        _, _, ret = Pkg::Util::Execution.capture3("#{GIT} rev-parse --git-dir")
         Pkg::Util::Execution.success?(ret)
       end
     end
@@ -105,7 +104,7 @@ module Pkg::Util::Version
     # This is a stub to ease testing...
     def run_git_describe_internal
       Pkg::Util.in_project_root do
-        raw, _, ret = Pkg::Util::Execution.capture3("#{GIT} describe --tags --dirty 2>#{DEVNULL}")
+        raw, _, ret = Pkg::Util::Execution.capture3("#{GIT} describe --tags --dirty")
         Pkg::Util::Execution.success?(ret) ? raw : nil
       end
     end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -222,8 +222,8 @@ describe "Pkg::Util::Net" do
 
     it "should curl with form data, uri, and be quiet" do
       Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} #{target_uri} >/dev/null 2>&1")
-      Pkg::Util::Net.curl_form_data(target_uri, form_data, options)
+      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} #{target_uri}").and_return(['stdout', 'stderr', 0])
+      Pkg::Util::Net.curl_form_data(target_uri, form_data, options).should eq(['', 0])
     end
 
   end


### PR DESCRIPTION
After the initial work for this was merged in, failures became apparent
with razor packaging. Razor builds using JRuby 1.7.19. Whereas with ruby
2.1.8, we see
```
irb(main):004:0> Open3.capture3("echo 'hi' >/dev/null")
=> ["", "", #<Process::Status: pid 95032 exit 0>]
```
with JRuby 1.7.9 the same command results in
```
irb(main):005:0> Open3.capture3("echo 'hi' >/dev/null")
=> ["hi >/dev/null\n", "", #<Process::Status: pid=95178,exited(0)>]
```

This commit updates unnecessary piping in the code that checks
versioning and updates the method for curling to discard stdout when
curling quietly rather than dealing with pipes.

There are still pipes elsewhere in the code but this removes them from
enough places to allow razor to build successfully, and as that is the
only project that builds using jruby this should be sufficient.