### PR TITLE
(maint) Double the timeouts, double the fun

### DIFF
--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -326,7 +326,7 @@ try {
   </publishers>
   <buildWrappers>
     <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.11">
-      <timeoutMinutes>45</timeoutMinutes>
+      <timeoutMinutes>90</timeoutMinutes>
       <failBuild>false</failBuild>
       <writingDescription>false</writingDescription>
       <timeoutPercentage>0</timeoutPercentage>


### PR DESCRIPTION
We're having a bunch of packaging timeouts on the deb builders possibly
due to hardware oversubscription. There is more hardware planned for
these boxes, but in the interim let's increase the timeout so fewer
things fail.