### PR TITLE
(QENG-4740) Call in to pkg directory in internal ship jobs

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -254,10 +254,12 @@ namespace :pl do
 
     task :generate_signed_repos, [:target_prefix] => ["pl:fetch"] do |t, args|
       target_prefix = args.target_prefix || 'nightly'
-      ["pl:jenkins:remote_sign_repos", "pl:jenkins:ship_signed_repos", "pl:jenkins:generate_signed_repo_configs", "pl:jenkins:ship_signed_repo_configs"].each do |task|
-        Pkg::Util::RakeUtils.invoke_task(task, target_prefix)
+      Dir.chdir("pkg") do
+        ["pl:jenkins:remote_sign_repos", "pl:jenkins:ship_signed_repos", "pl:jenkins:generate_signed_repo_configs", "pl:jenkins:ship_signed_repo_configs"].each do |task|
+          Pkg::Util::RakeUtils.invoke_task(task, target_prefix)
+        end
+        puts "Shipped '#{Pkg::Config.ref}' (#{Pkg::Config.version}) of '#{Pkg::Config.project}' into the puppet-agent repos."
       end
-      puts "Shipped '#{Pkg::Config.ref}' (#{Pkg::Config.version}) of '#{Pkg::Config.project}' into the puppet-agent repos."
     end
 
     # We want to keep the puppet-agent repos at a higher level and them link


### PR DESCRIPTION
The 'generate_signed_repos' task did not previously execute out of the pkg
directory. This meant that in a later step, when 'prepare_signed_repos'
attempted to clean work that was no longer required, there was nothing to
clean.

This PR remedies that, so the job's disk footprint can be drastically
decreased.