### PR TITLE
(RE-8615) Skip platforms without repos when creating repo archives

### DIFF
--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -29,7 +29,7 @@ module Pkg::Repo
       platforms = Pkg::Config.platform_repos
       platforms.each do |platform|
         archive_name = "#{project}-#{platform['name']}"
-        create_signed_repo_archive(platform['repo_location'], archive_name, versioning)
+        create_signed_repo_archive(platform['repo_location'], archive_name, versioning) if platform['repo_location']
       end
     end
   end

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -5,7 +5,8 @@ describe "#Pkg::Repo" do
     [
       {"name"=>"el-4-i386", "repo_location"=>"repos/el/4/**/i386"},
       {"name"=>"el-5-i386", "repo_location"=>"repos/el/5/**/i386"},
-      {"name"=>"el-6-i386", "repo_location"=>"repos/el/6/**/i386"}
+      {"name"=>"el-6-i386", "repo_location"=>"repos/el/6/**/i386"},
+      {"name"=>"windows-2012-x86"}
     ]
   end
   describe "#create_signed_repo_archive" do
@@ -91,6 +92,7 @@ describe "#Pkg::Repo" do
       expect(Pkg::Repo).to receive(:create_signed_repo_archive).with("repos/el/4/**/i386", "project-el-4-i386", "version")
       expect(Pkg::Repo).to receive(:create_signed_repo_archive).with("repos/el/5/**/i386", "project-el-5-i386", "version")
       expect(Pkg::Repo).to receive(:create_signed_repo_archive).with("repos/el/6/**/i386", "project-el-6-i386", "version")
+      expect(Pkg::Repo).not_to receive(:create_signed_repo_archive).with(anything, "project-windows-2012-x86", "version")
       Pkg::Repo.create_all_repo_archives("project", "version")
     end
   end


### PR DESCRIPTION
This commit handles the case where a platform in `platform_repos` does not have a `repo_location` specified. These platforms are now skipped when looping through to create all repo archives.