### PR TITLE
(maint) Add ppc64el to the list of packaging architectures

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -95,7 +95,7 @@ module Pkg::Deb::Repo
 Origin: Puppet Labs
 Label: Puppet Labs
 Codename: $dist
-Architectures: i386 amd64 arm64 armel armhf powerpc sparc mips mipsel
+Architectures: i386 amd64 arm64 armel armhf powerpc ppc64el sparc mips mipsel
 Components: #{subrepo}
 Description: Apt repository for acceptance testing" >> conf/distributions ; )
 
@@ -159,7 +159,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; )
               f.puts "Origin: Puppet Labs
 Label: Puppet Labs
 Codename: #{dist}
-Architectures: i386 amd64 arm64 armel armhf powerpc sparc mips mipsel
+Architectures: i386 amd64 arm64 armel armhf powerpc ppc64el sparc mips mipsel
 Components: #{subrepo}
 Description: #{message} for #{dist}
 SignWith: #{Pkg::Config.gpg_key}"


### PR DESCRIPTION
This is needed for the IBM Power8 platform.