### PR TITLE
(RE-8707) Add `platform_data`

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -69,6 +69,40 @@ module Pkg
       end
 
       ##
+      # For each platform we ship for, find paths to its artifact and repo_config (if applicable).
+      # This is to be consumed by beaker and later replaced with our metadata service.
+      #
+      def platform_data
+        if self.project && self.ref
+          dir = "/opt/jenkins-builds/#{self.project}/#{self.ref}"
+          cmd = "if [ -s \"#{dir}/artifacts\" ]; then cd #{dir}; find ./artifacts/ -mindepth 2 -type f; fi"
+          artifacts, _ = Pkg::Util::Net.remote_ssh_cmd(self.builds_server, cmd, true)
+          artifacts = artifacts.split("\n")
+          data = {}
+          Pkg::Util::Platform.platform_tags.each do |tag|
+            _, _, arch = Pkg::Util::Platform.parse_platform_tag(tag)
+            package_format = Pkg::Util::Platform.get_attribute(tag, :package_format)
+            case package_format
+            when 'deb'
+              artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and (e.include?("all") || e.include?("#{arch}.deb")) }
+              repo_config = "./repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Util::Platform.get_attribute(tag, :codename)}.list" if artifact
+            when 'rpm'
+              artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
+              repo_config = "./repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo" if artifact
+            when 'swix', 'svr4', 'ips', 'dmg', 'msi'
+              artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
+            else
+              fail "Not sure what to do with packages with a package format of '#{package_format}' - maybe update PLATFORM_INFO?"
+            end
+            data[tag] = { :artifact => artifact,
+                          :repo_config => repo_config,
+                        } if artifact
+          end
+          data
+        end
+      end
+
+      ##
       # Return a hash of all build parameters and their values, nil if unassigned.
       #
       def config_to_hash
@@ -76,6 +110,7 @@ module Pkg
         Pkg::Params::BUILD_PARAMS.each do |param|
           data.store(param, self.instance_variable_get("@#{param}"))
         end
+        data.store(:platform_data, platform_data)
         data
       end
 

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -20,14 +20,12 @@ module Pkg
       },
 
       'debian' => {
-        '6' => { :codename => 'squeeze', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
         '7' => { :codename => 'wheezy', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
         '8' => { :codename => 'jessie', :architectures  => ['i386', 'amd64', 'powerpc'], :repo => true, :package_format => 'deb', },
         '9' => { :codename => 'stretch', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
       },
 
       'el' => {
-        '4' => { :architectures => ['i386', 'x86_64'], :repo => false, :package_format => 'rpm', :signature_format => 'v3', },
         '5' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v3', },
         '6' => { :architectures => ['i386', 'x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
         '7' => { :architectures => ['x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
@@ -38,9 +36,6 @@ module Pkg
       },
 
       'fedora' => {
-        'f21' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        'f22' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        'f23' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
         'f24' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
         'f25' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
       },
@@ -50,14 +45,12 @@ module Pkg
       },
 
       'osx' => {
-        '10.9' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
         '10.10' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
         '10.11' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
         '10.12' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
       },
 
       'sles' => {
-        '10' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v3', },
         '11' => { :architectures => ['i386', 'x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v3', },
         '12' => { :architectures => ['x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
       },
@@ -68,11 +61,7 @@ module Pkg
       },
 
       'ubuntu' => {
-        '10.04' => { :codename => 'lucid', :architectures   => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
-        '12.04' => { :codename => 'precise', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
         '14.04' => { :codename => 'trusty', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
-        '15.04' => { :codename => 'vivid', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
-        '15.10' => { :codename => 'wily', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
         '16.04' => { :codename => 'xenial', :architectures => ['i386', 'amd64', 'ppc64el'], :repo => true, :package_format => 'deb', },
         '16.10' => { :codename => 'yakkety', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
       },

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -505,11 +505,6 @@ namespace :pl do
       project_basedir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       artifact_dir = "#{project_basedir}/#{target}"
 
-      # In order to get a snapshot of what this build looked like at the time
-      # of shipping, we also generate and ship the params file
-      #
-      Pkg::Config.config_to_yaml(local_dir)
-
       # For EZBake builds, we also want to include the ezbake.manifest file to
       # get a snapshot of this build and all dependencies. We eventually will
       # create a yaml version of this file, but until that point we want to
@@ -585,8 +580,16 @@ namespace :pl do
         Pkg::Util::Net.rsync_to("#{local_dir}/", Pkg::Config.distribution_server, "#{artifact_dir}/", extra_flags: ["--ignore-existing", "--exclude repo_configs"])
       end
 
+      # In order to get a snapshot of what this build looked like at the time
+      # of shipping, we also generate and ship the params file
+      #
+      Pkg::Config.config_to_yaml(local_dir)
+      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+        Pkg::Util::Net.rsync_to("#{local_dir}/#{Pkg::Config.ref}.yaml", Pkg::Config.distribution_server, "#{artifact_dir}/", extra_flags: ["--exclude repo_configs"])
+      end
+
       # If we just shipped a tagged version, we want to make it immutable
-      files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) }.map do |file|
+      files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) and !f.include? "#{Pkg::Config.ref}.yaml" }.map do |file|
         "#{artifact_dir}/#{file.sub(/^#{local_dir}\//, '')}"
       end
 


### PR DESCRIPTION
This PR adds a `platform_data` hash that maps each platform to where its
artifact and repo_config (if applicable) can be found. This info will get added
to the <ref>.yaml file that gets generated when a package is built, allowing
beaker to consume this info without having to figure out the mapping itself.