### PR TITLE
(RE-8843) Don't fail if ext/project_data.yaml doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ rescue LoadError
 end
 ```
 
-Also in ext should be two files, build_defaults.yaml and project_data.yaml.
+Also in ext should be two files, build_defaults.yaml and project_data.yaml (optional).
 
 This is the sample build_defaults.yaml file from Hiera:
 ```yaml

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -69,40 +69,6 @@ module Pkg
       end
 
       ##
-      # For each platform we ship for, find paths to its artifact and repo_config (if applicable).
-      # This is to be consumed by beaker and later replaced with our metadata service.
-      #
-      def platform_data
-        if self.project && self.ref
-          dir = "/opt/jenkins-builds/#{self.project}/#{self.ref}"
-          cmd = "if [ -s \"#{dir}/artifacts\" ]; then cd #{dir}; find ./artifacts/ -mindepth 2 -type f; fi"
-          artifacts, _ = Pkg::Util::Net.remote_ssh_cmd(self.builds_server, cmd, true)
-          artifacts = artifacts.split("\n")
-          data = {}
-          Pkg::Util::Platform.platform_tags.each do |tag|
-            _, _, arch = Pkg::Util::Platform.parse_platform_tag(tag)
-            package_format = Pkg::Util::Platform.get_attribute(tag, :package_format)
-            case package_format
-            when 'deb'
-              artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and (e.include?("all") || e.include?("#{arch}.deb")) }
-              repo_config = "./repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Util::Platform.get_attribute(tag, :codename)}.list" if artifact
-            when 'rpm'
-              artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
-              repo_config = "./repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo" if artifact
-            when 'swix', 'svr4', 'ips', 'dmg', 'msi'
-              artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
-            else
-              fail "Not sure what to do with packages with a package format of '#{package_format}' - maybe update PLATFORM_INFO?"
-            end
-            data[tag] = { :artifact => artifact,
-                          :repo_config => repo_config,
-                        } if artifact
-          end
-          data
-        end
-      end
-
-      ##
       # Return a hash of all build parameters and their values, nil if unassigned.
       #
       def config_to_hash
@@ -110,7 +76,6 @@ module Pkg
         Pkg::Params::BUILD_PARAMS.each do |param|
           data.store(param, self.instance_variable_get("@#{param}"))
         end
-        data.store(:platform_data, platform_data)
         data
       end
 

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -139,23 +139,26 @@ module Pkg
       end
 
       def load_default_configs
-        default_project_data = File.join(@project_root, "ext", "project_data.yaml")
-        default_build_defaults = File.join(@project_root, "ext", "build_defaults.yaml")
+        got_config = false
+        default_project_data = { :path => File.join(@project_root, "ext", "project_data.yaml"), :required => false }
+        default_build_defaults = { :path => File.join(@project_root, "ext", "build_defaults.yaml"), :required => true }
 
         [default_project_data, default_build_defaults].each do |config|
-          if File.readable? config
-            self.config_from_yaml(config)
+          if File.readable? config[:path]
+            self.config_from_yaml(config[:path])
+            got_config = true if config[:required]
           else
-            puts "Skipping load of expected default config #{config}, cannot read file."
-            #   Since the default configuration files are not readable, most
-            #   likely not present, at this point we assume the project_root
-            #   isn't what we hoped it would be, and unset it.
-            @project_root = nil
+            puts "Skipping load of expected default config #{config[:path]}, cannot read file."
           end
         end
 
-        if @project_root
+        if got_config
           self.config
+        else
+          # Since the default configuration files are not readable, most
+          # likely not present, at this point we assume the project_root
+          # isn't what we hoped it would be, and unset it.
+          @project_root = nil
         end
       end
 

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -321,8 +321,8 @@ module Pkg::Params
   DEPRECATIONS = [{ :var => :gem_devel_dependencies, :message => "
     DEPRECATED, 9-Nov-2013: 'gem_devel_dependencies' has been replaced with
     'gem_development_dependencies.' Please update this field in your
-    project_data.yaml" },
+    build_defaults.yaml or project_data.yaml" },
                   { :var => :gpg_name, :message => "
     DEPRECATED, 29-Jul-2014: 'gpg_name' has been replaced with 'gpg_key'.
-                   Please update this field in your project_data.yaml" }]
+                   Please update this field in your build_defaults.yaml" }]
 end

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -2,7 +2,7 @@
 # This task is intended to retrieve packages from the distribution server that
 # have been built by jenkins and placed in a specific location,
 # /opt/jenkins-builds/$PROJECT/$SHA where $PROJECT is the build project as
-# established in project_data.yaml and $SHA is the git sha/tag of the project that
+# established in build_defaults.yaml and $SHA is the git sha/tag of the project that
 # was built into packages. The current day is assumed, but an environment
 # variable override exists to retrieve packages from another day. The sha/tag is
 # assumed to be the current project's HEAD, e.g.  to retrieve packages for a

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -505,6 +505,11 @@ namespace :pl do
       project_basedir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       artifact_dir = "#{project_basedir}/#{target}"
 
+      # In order to get a snapshot of what this build looked like at the time
+      # of shipping, we also generate and ship the params file
+      #
+      Pkg::Config.config_to_yaml(local_dir)
+
       # For EZBake builds, we also want to include the ezbake.manifest file to
       # get a snapshot of this build and all dependencies. We eventually will
       # create a yaml version of this file, but until that point we want to
@@ -580,16 +585,8 @@ namespace :pl do
         Pkg::Util::Net.rsync_to("#{local_dir}/", Pkg::Config.distribution_server, "#{artifact_dir}/", extra_flags: ["--ignore-existing", "--exclude repo_configs"])
       end
 
-      # In order to get a snapshot of what this build looked like at the time
-      # of shipping, we also generate and ship the params file
-      #
-      Pkg::Config.config_to_yaml(local_dir)
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
-        Pkg::Util::Net.rsync_to("#{local_dir}/#{Pkg::Config.ref}.yaml", Pkg::Config.distribution_server, "#{artifact_dir}/", extra_flags: ["--exclude repo_configs"])
-      end
-
       # If we just shipped a tagged version, we want to make it immutable
-      files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) and !f.include? "#{Pkg::Config.ref}.yaml" }.map do |file|
+      files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) }.map do |file|
         "#{artifact_dir}/#{file.sub(/^#{local_dir}\//, '')}"
       end
 

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -122,7 +122,7 @@ namespace :pl do
     end
   end
 
-  desc "Sign ips package, uses PL certificates by default, update privatekey_pem, certificate_pem, and ips_inter_cert in project_data.yaml to override."
+  desc "Sign ips package, uses PL certificates by default, update privatekey_pem, certificate_pem, and ips_inter_cert in build_defaults.yaml to override."
   task :sign_ips do
     Pkg::IPS.sign unless Dir['pkg/solaris/11/**/*.p5p'].empty?
   end


### PR DESCRIPTION
This commit adjusts the loading of default configs to move on if project_data.yaml isn't found. Load will only fail if both project_data.yaml and build_defaults.yaml cannot be found.