### PR TITLE
(CPR-407) Enable shipping fedora packages to repos not prepended with f

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -36,8 +36,8 @@ module Pkg
       },
 
       'fedora' => {
-        'f24' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        'f25' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '24' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '25' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
       },
 
       'huaweios' => {


### PR DESCRIPTION
This commit removes the f prefixed to fedora package version numbers.