### PR TITLE
(BUILD-69) Enable ppc64le package builds for el-7

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -28,7 +28,7 @@ module Pkg
       'el' => {
         '5' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v3', },
         '6' => { :architectures => ['i386', 'x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        '7' => { :architectures => ['x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '7' => { :architectures => ['x86_64', 's390x', 'ppc64le'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
       },
 
       'eos' => {


### PR DESCRIPTION
This is the final thing needed so I can ship these packages to our build-tools repo.