### PR TITLE
(maint) Print errors if you fail out of retry_on_fail

### DIFF
--- a/lib/packaging/util/execution.rb
+++ b/lib/packaging/util/execution.rb
@@ -59,6 +59,7 @@ module Pkg::Util::Execution
     # or max attempts is reached. Raise an exception unless we've succeeded.
     def retry_on_fail(args, &blk)
       success = FALSE
+      exception = ''
 
       if args[:times].respond_to?(:times) and block_given?
         args[:times].times do |i|
@@ -70,14 +71,15 @@ module Pkg::Util::Execution
             blk.call
             success = TRUE
             break
-          rescue
+          rescue => err
             puts "An error was encountered evaluating block. Retrying.."
+            exception = err + "\n" + err.backtrace.join("\n")
           end
         end
       else
         fail "retry_on_fail requires and arg (:times => x) where x is an Integer/Fixnum, and a block to execute"
       end
-      fail "Block failed maximum of #{args[:times]} tries. Exiting.." unless success
+      fail "Block failed maximum of #{args[:times]} tries. Exiting..\nLast failure was: #{exception}" unless success
     end
   end
 end


### PR DESCRIPTION
Right now that method just includes a generic failure message if the
called method fails the specified version of things. This just adds the
exception and the backtrace so you can actually debug what went wrong.