### PR TITLE
(RE-8864) When determining the ref type we need a clean describe

### DIFF
--- a/lib/packaging/util/git.rb
+++ b/lib/packaging/util/git.rb
@@ -65,9 +65,9 @@ module Pkg::Util::Git
 
     # Returns the value of `git describe`. If this is not a git repo or
     # `git describe` fails because there is no tag, this will return false
-    def describe
+    def describe(extra_opts = ['--tags', '--dirty'])
       Pkg::Util.in_project_root do
-        stdout, _, ret = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} describe --tags --dirty")
+        stdout, _, ret = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} describe #{Array(extra_opts).join(' ')}")
         if Pkg::Util::Execution.success?(ret)
           stdout.strip
         else
@@ -91,7 +91,7 @@ module Pkg::Util::Git
     # Return the ref type of HEAD on the current branch
     def ref_type
       Pkg::Util.in_project_root do
-        stdout, = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} cat-file -t #{describe}")
+        stdout, = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} cat-file -t #{describe('')}")
         stdout.strip
       end
     end

--- a/spec/lib/packaging/util/git_spec.rb
+++ b/spec/lib/packaging/util/git_spec.rb
@@ -94,6 +94,23 @@ describe 'Pkg::Util::Git' do
     end
   end
 
+  context '#describe' do
+    let(:describe) { '0.5.0-25-g746e755-dirty' }
+    let(:describe_no_dirty) { '0.5.0-25-g746e755' }
+
+    it 'should default to --tags --dirty' do
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{Pkg::Util::Tool::GIT} describe --tags --dirty").and_return([describe, '', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).with(0).and_return(true)
+      Pkg::Util::Git.describe
+    end
+
+    it 'should allow you to pass no arguments to describe' do
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{Pkg::Util::Tool::GIT} describe ").and_return([describe_no_dirty, '', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).with(0).and_return(true)
+      Pkg::Util::Git.describe('')
+    end
+  end
+
   context '#sha_or_tag' do
     let(:sha) { '20a338b33e2fc1cbaee27b69de5eb2d06637a7c4' }
     let(:tag) { '2.0.4' }


### PR DESCRIPTION
To determine ref-type we use `git cat-file -t`. If this is given a
describe that isn't a sha or a tag it will fail. So, add the ability to
have `describe` run just `git describe` instead of `git describe --tags
--dirty` (the default) so we can use that method for determining the ref
type.