### PR TITLE
(maint) Reorder the ubership to do all the updates before the deploys

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -257,10 +257,10 @@ namespace :pl do
         uber_ship
         ship_gem
         remote:update_apt_repo
-        remote:deploy_apt_repo
         remote:update_yum_repo
-        remote:deploy_yum_repo
         remote:update_ips_repo
+        remote:deploy_apt_repo
+        remote:deploy_yum_repo
         remote:deploy_dmg_repo
         remote:deploy_swix_repo
         remote:deploy_msi_repo


### PR DESCRIPTION
The repo updates can take a substantial amount of time. Doing all of
those before we start deploying them will reduce the amount of time in a
partially deployed state and make it easier to time the cache
invalidation.