### PR TITLE
(maint) Add override to make tagged but dirty trees final

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -3,7 +3,8 @@ require "packaging/platforms"
 # These are all of the parameters known to our packaging system.
 # They are ingested by the config class as class instance variables
 module Pkg::Params
-  BUILD_PARAMS = [:answer_override,
+  BUILD_PARAMS = [:allow_dirty_tree,
+                  :answer_override,
                   :apt_host,
                   :apt_releases,
                   :apt_repo_command,
@@ -178,6 +179,7 @@ module Pkg::Params
   #           Note: :type is assumed :string if not present
   #
   ENV_VARS = [
+              { :var => :allow_dirty_tree,        :envvar => :ALLOW_DIRTY_TREE, :type => :bool },
               { :var => :answer_override,         :envvar => :ANSWER_OVERRIDE },
               { :var => :apt_host,                :envvar => :APT_HOST },
               { :var => :apt_releases,            :envvar => :APT_RELEASES,    :type => :array },
@@ -269,7 +271,8 @@ module Pkg::Params
   #
   # usage is the same as above
   #
-  DEFAULTS = [{ :var => :builder_data_file,       :val => 'builder_data.yaml' },
+  DEFAULTS = [{ :var => :allow_dirty_tree,        :val => false },
+              { :var => :builder_data_file,       :val => 'builder_data.yaml' },
               { :var => :team,                    :val => 'dev' },
               { :var => :random_mockroot,         :val => true },
               { :var => :keychain_loaded,         :val => false },

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -55,7 +55,7 @@ module Pkg::Paths
       if Pkg::Config.nonfinal_repo_name
         Pkg::Config.nonfinal_repo_name
       else
-        fail "You are attempting to ship a non-final build without specifying a non-final repo destination. Either make sure you are shipping a final version or define `nonfinal_repo_name` in your build_defaults."
+        fail "You are attempting to ship a non-final build without specifying a non-final repo destination. Either make sure you are shipping a final version or define `nonfinal_repo_name` in your build_defaults.\nIf this is a test build and you want to allow tagged versions with dirty trees to be final builds, set ALLOW_DIRTY_TREE=true."
       end
     end
   end

--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -98,12 +98,12 @@ module Pkg::Util::Version
         false
       when /SNAPSHOT/
         false
+      when /g[a-f0-9]{7}/
+        false
+      when /^(\d+\.)+\d+-\d+/
+        false
       when /-dirty/
-        false
-      when /g[a-f0-9]{7}$/
-        false
-      when /^(\d+\.)+\d+-\d+$/
-        false
+        Pkg::Config.allow_dirty_tree
       else
         true
       end

--- a/spec/lib/packaging/util/version_spec.rb
+++ b/spec/lib/packaging/util/version_spec.rb
@@ -89,5 +89,17 @@ describe 'Pkg::Util::Version' do
       allow(Pkg::Config).to receive(:version) { '4.99.0-56-dirty' }
       expect(Pkg::Util::Version.final?).to be false
     end
+
+    it 'classifies dirty versions as final when allow_dirty_tree is set' do
+      allow(Pkg::Config).to receive(:allow_dirty_tree).and_return true
+      allow(Pkg::Config).to receive(:version) { '1.0.0-dirty' }
+      expect(Pkg::Util::Version.final?).to be true
+    end
+
+    it 'classifies dirty nonfinal versions as not final even when allow_dirty_tree is set' do
+      allow(Pkg::Config).to receive(:allow_dirty_tree).and_return true
+      allow(Pkg::Config).to receive(:version) { '1.0.0-22-dirty' }
+      expect(Pkg::Util::Version.final?).to be false
+    end
   end
 end


### PR DESCRIPTION
When testing automation changes or fixing last-minute packaging errors,
it can be desirable to check out a tagged version of a project and
modify build_defaults to use an alternate branch of packaging. This
allows you to pass the ALLOW_DIRTY_TREE environment variable to return
cause final? to return true if you're on a tagged build with a dirty
tree.