### PR TITLE
(maint) uber_ship fixups

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -140,6 +140,7 @@ module Pkg::Params
                   :rpm_targets,
                   :rpmrelease,
                   :rpmversion,
+                  :s3_ship,
                   :short_ref,
                   :sign_tar,
                   :signing_server,
@@ -239,6 +240,7 @@ module Pkg::Params
               { :var => :random_mockroot,         :envvar => :RANDOM_MOCKROOT, :type => :bool },
               { :var => :rc_mocks,                :envvar => :MOCK },
               { :var => :release,                 :envvar => :RELEASE },
+              { :var => :s3_ship,                 :envvar => :S3_SHIP,         :type => :bool },
               { :var => :sign_tar,                :envvar => :SIGN_TAR,        :type => :bool },
               { :var => :signing_server,          :envvar => :SIGNING_SERVER },
               { :var => :staging_server,          :envvar => :STAGING_SERVER },
@@ -283,6 +285,7 @@ module Pkg::Params
               { :var => :msi_signing_cert,        :val => '$MSI_SIGNING_CERT' },
               { :var => :msi_signing_cert_pw,     :val => '$MSI_SIGNING_CERT_PW' },
               { :var => :pe_feature_branch,       :val => false },
+              { :var => :s3_ship,                 :val => false },
               { :var => :apt_releases,            :val => Pkg::Platforms.codenames("deb") }]
 
   # These are variables which, over time, we decided to rename or replace. For

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -275,13 +275,6 @@ namespace :pl do
         fail "Using ANSWER_OVERRIDE without FOSS_ONLY=true is dangerous!"
       end
 
-      puts '**************'
-      puts 'WARNING: Shipping software currently requires manual CDN Updates'
-      puts 'Don\'t continue unless you or someone else around knows how to do this'
-      puts '**************'
-      puts 'Continue?'
-      exit unless Pkg::Util.ask_yes_or_no
-
       # Some projects such as pl-build-tools do not stage to a separate server - so we do to deploy
       uber_tasks.delete("remote:deploy_apt_repo") if Pkg::Config.apt_host == Pkg::Config.apt_signing_server
       uber_tasks.delete("remote:deploy_yum_repo") if Pkg::Config.yum_host == Pkg::Config.yum_staging_server

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -282,6 +282,20 @@ namespace :pl do
       uber_tasks.delete("remote:deploy_swix_repo") if Pkg::Config.swix_host == Pkg::Config.swix_staging_server
       uber_tasks.delete("remote:deploy_tar_repo") if Pkg::Config.tar_host == Pkg::Config.tar_staging_server
 
+      if Pkg::Config.s3_ship
+        uber_tasks.delete("remote:deploy_apt_repo")
+        uber_tasks.delete("remote:deploy_yum_repo")
+        uber_tasks.delete("remote:deploy_dmg_repo")
+        uber_tasks.delete("remote:deploy_swix_repo")
+        uber_tasks.delete("remote:deploy_msi_repo")
+        uber_tasks.delete("remote:deploy_tar_repo")
+      else
+        uber_tasks.delete("remote:deploy_apt_repo_to_s3")
+        uber_tasks.delete("remote:deploy_yum_repo_to_s3")
+        uber_tasks.delete("remote:deploy_downloads_repo_to_s3")
+        uber_tasks.delete("remote:update_rsync_from_s3")
+      end
+
       # Delete the ship_gem task if we aren't building gems
       uber_tasks.delete("ship_gem") unless Pkg::Config.build_gem
 

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -279,7 +279,7 @@ namespace :pl do
       uber_tasks.delete("remote:deploy_apt_repo") if Pkg::Config.apt_host == Pkg::Config.apt_signing_server
       uber_tasks.delete("remote:deploy_yum_repo") if Pkg::Config.yum_host == Pkg::Config.yum_staging_server
       uber_tasks.delete("remote:deploy_dmg_repo") if Pkg::Config.dmg_host == Pkg::Config.dmg_staging_server
-      uber_tasks.delete("remote:deploy_swix_rep") if Pkg::Config.swix_host == Pkg::Config.swix_staging_server
+      uber_tasks.delete("remote:deploy_swix_repo") if Pkg::Config.swix_host == Pkg::Config.swix_staging_server
       uber_tasks.delete("remote:deploy_tar_repo") if Pkg::Config.tar_host == Pkg::Config.tar_staging_server
 
       # Delete the ship_gem task if we aren't building gems


### PR DESCRIPTION
I bundled a few fixups for uber_ship into this PR as I was looking into needed changes for s3 shipping.

* Not all projects will ship to s3, so add the s3_ship parameter to ship to s3 when needed
* If we're shipping to s3 we don't need to do any of the deployment steps since we'll go right from staging -> s3
* The s3 shipping automates CDN invalidations, so we can remove the CDN warning
* There was a typo for swix tasks.