### PR TITLE
(RE-8943) Update shipping automation to deal with 'latest' symlinks

### DIFF
--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -70,4 +70,23 @@ module Pkg::Util::Ship
       end
     end
   end
+
+  def create_latest_symlink(package_name, dir, platform_ext, excludes = [], arch = nil)
+    cmd = "if [ -d '#{dir}' ] ; then "
+    cmd << "pushd #{dir} ; "
+    cmd << "ln -sf `\ls -1 *.#{platform_ext} | grep -v latest | grep -v rc | grep #{package_name} "
+    if arch
+      cmd << "| grep #{arch} "
+      package_name << "-#{arch}"
+    end
+    excludes.each do |excl|
+      cmd << "| grep -v #{excl} "
+    end
+    cmd << "| sort --version-sort | tail -1` #{package_name}-latest.#{platform_ext} ; "
+    cmd << "popd ; "
+    cmd << "fi"
+
+    _, err = Pkg::Util::Net.remote_ssh_command(Pkg::Config.staging_server, cmd, true)
+    $stderr.puts err
+  end
 end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -269,6 +269,10 @@ namespace :pl do
   desc "ship apple dmg to #{Pkg::Config.dmg_staging_server}"
   task ship_dmg: 'pl:fetch' do
     Pkg::Util::Ship.ship_pkgs(['pkg/**/*.dmg'], Pkg::Config.dmg_staging_server, Pkg::Config.dmg_path, addtl_path_to_sub: '/mac')
+    Pkg::Util::Ship.create_latest_symlink('puppet', '/opt/downloads/mac', 'dmg', ['agent', 'hiera'])
+    Pkg::Util::Ship.create_latest_symlink('hiera', '/opt/downloads/mac', 'dmg', ['puppet'])
+    Pkg::Util::Ship.create_latest_symlink('facter', '/opt/downloads/mac', 'dmg')
+    Pkg::Util::Ship.create_latest_symlink('puppet-agent', '/opt/downloads/mac', 'dmg')
   end
 
   desc "ship Arista EOS swix packages and signatures to #{Pkg::Config.swix_staging_server}"
@@ -296,6 +300,10 @@ namespace :pl do
   desc "Ship MSI packages to #{Pkg::Config.msi_staging_server}"
   task ship_msi: 'pl:fetch' do
     Pkg::Util::Ship.ship_pkgs(['pkg/**/*.msi'], Pkg::Config.msi_staging_server, Pkg::Config.msi_path, addtl_path_to_sub: '/windows', excludes: ["#{Pkg::Config.project}-x(86|64).msi"])
+    Pkg::Util::Ship.create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', ['agent', 'x64'])
+    Pkg::Util::Ship.create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', ['agent'], 'x64')
+    Pkg::Util::Ship.create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', [], 'x64')
+    Pkg::Util::Ship.create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', [], 'x86')
   end
 
   desc 'UBER ship: ship all the things in pkg'


### PR DESCRIPTION
This commit adds a function for finding the latest version of something and creating a 'latest' symlink to it. We do this for puppet-agent (and its components) for mac and windows. We now do this whenever we ship a dmg or msi.