### PR TITLE
(RE-8943) Update shipping automation to deal with 'latest' symlinks

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -280,16 +280,18 @@ module Pkg::Util::Net
       Pkg::Util::Net.remote_ssh_cmd(host, "sudo chattr +i #{files.join(" ")}")
     end
 
-    def remote_create_latest_symlink(package_name, dir, platform_ext, excludes = [], arch = nil)
+    def remote_create_latest_symlink(package_name, dir, platform_ext, options = {})
       cmd = "if [ -d '#{dir}' ] ; then "
       cmd << "pushd #{dir} ; "
       cmd << "ln -sf `\ls -1 *.#{platform_ext} | grep -v latest | grep -v rc | grep #{package_name} "
-      if arch
-        cmd << "| grep #{arch} "
-        package_name << "-#{arch}"
+      if options[:arch]
+        cmd << "| grep #{options[:arch]} "
+        package_name << "-#{options[:arch]}"
       end
-      excludes.each do |excl|
-        cmd << "| grep -v #{excl} "
+      if options[:excludes]
+        options[:excludes].each do |excl|
+          cmd << "| grep -v #{excl} "
+        end
       end
       cmd << "| sort --version-sort | tail -1` #{package_name}-latest.#{platform_ext} ; "
       cmd << "popd ; "

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -280,6 +280,18 @@ module Pkg::Util::Net
       Pkg::Util::Net.remote_ssh_cmd(host, "sudo chattr +i #{files.join(" ")}")
     end
 
+    # Create a symlink indicating the latest version of a package
+    #
+    # @param package_name [String] The name of the package you want to symlink
+    #   to, e.g. 'puppet-agent', 'facter', etc.
+    # @param dir [String] The directory you want to find the latest package and
+    #   create the symlink in.
+    # @param platform_ext [String] The type of files you want to consider, e.g.
+    #   'dmg', 'msi', etc.
+    # @param options [Hash] Additional optional params:
+    #   @option :arch [String] Architecture you want to narrow your search by.
+    #   @option :excludes [Array] Strings you want to exclude from your search,
+    #     e.g. 'agent' if only searching for 'puppet'.
     def remote_create_latest_symlink(package_name, dir, platform_ext, options = {})
       cmd = "if [ -d '#{dir}' ] ; then "
       cmd << "pushd #{dir} ; "

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -367,6 +367,10 @@ namespace :pl do
         end
       end
     end
+    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/mac', 'dmg', ['agent', 'hiera'])
+    Pkg::Util::Net.remote_create_latest_symlink('hiera', '/opt/downloads/mac', 'dmg', ['puppet'])
+    Pkg::Util::Net.remote_create_latest_symlink('facter', '/opt/downloads/mac', 'dmg')
+    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/mac', 'dmg')
   end
 
   desc "ship Arista EOS swix packages and signatures to #{Pkg::Config.swix_staging_server}"
@@ -427,6 +431,10 @@ namespace :pl do
         end
       end
     end
+    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', ['agent', 'x64'])
+    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', ['agent'], 'x64')
+    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', [], 'x64')
+    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', [], 'x86')
   end
 
   desc "UBER ship: ship all the things in pkg"

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -370,7 +370,9 @@ namespace :pl do
     Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/mac', 'dmg', ['agent', 'hiera'])
     Pkg::Util::Net.remote_create_latest_symlink('hiera', '/opt/downloads/mac', 'dmg', ['puppet'])
     Pkg::Util::Net.remote_create_latest_symlink('facter', '/opt/downloads/mac', 'dmg')
-    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/mac', 'dmg')
+    Pkg::Platforms.PLATFORM_INFO['osx'].keys.each do |version|
+      Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', "/opt/downloads/mac/#{version}/#{Pkg::Config.yum_repo_name}/x86_64", 'dmg')
+    end
   end
 
   desc "ship Arista EOS swix packages and signatures to #{Pkg::Config.swix_staging_server}"

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -367,8 +367,8 @@ namespace :pl do
         end
       end
     end
-    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/mac', 'dmg', ['agent', 'hiera'])
-    Pkg::Util::Net.remote_create_latest_symlink('hiera', '/opt/downloads/mac', 'dmg', ['puppet'])
+    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/mac', 'dmg', excludes: ['agent', 'hiera'])
+    Pkg::Util::Net.remote_create_latest_symlink('hiera', '/opt/downloads/mac', 'dmg', excludes: ['puppet'])
     Pkg::Util::Net.remote_create_latest_symlink('facter', '/opt/downloads/mac', 'dmg')
     Pkg::Platforms.PLATFORM_INFO['osx'].keys.each do |version|
       Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', "/opt/downloads/mac/#{version}/#{Pkg::Config.yum_repo_name}/x86_64", 'dmg')
@@ -433,10 +433,10 @@ namespace :pl do
         end
       end
     end
-    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', ['agent', 'x64'])
-    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', ['agent'], 'x64')
-    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', [], 'x64')
-    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', [], 'x86')
+    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', excludes: ['agent', 'x64'])
+    Pkg::Util::Net.remote_create_latest_symlink('puppet', '/opt/downloads/windows', 'msi', excludes: ['agent'], arch: 'x64')
+    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', arch: 'x64')
+    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', '/opt/downloads/windows', 'msi', arch: 'x86')
   end
 
   desc "UBER ship: ship all the things in pkg"


### PR DESCRIPTION
This commit adds a function for finding the latest version of something and creating a 'latest' symlink to it. We do this for puppet-agent (and its components) for mac and windows. We now do this whenever we ship a dmg or msi.