### PR TITLE
(maint) Update host for the s3 download sync

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -259,7 +259,7 @@ namespace :pl do
       puts "Really run S3 sync to sync downloads.puppetlabs.com from #{Pkg::Config.staging_server} to AWS S3? [y,n]"
       if Pkg::Util.ask_yes_or_no
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          destination_server = Pkg::Config.apt_signing_server
+          destination_server = Pkg::Config.staging_server
           command = 'sudo /usr/local/bin/s3_repo_sync.sh downloads.puppetlabs.com'
           Pkg::Util::Net.remote_ssh_cmd(destination_server, command)
         end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -247,7 +247,7 @@ namespace :pl do
       puts "Really run S3 sync to deploy RPM repos from #{Pkg::Config.yum_staging_server} to AWS S3? [y,n]"
       if Pkg::Util.ask_yes_or_no
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          destination_server = Pkg::Config.apt_signing_server
+          destination_server = Pkg::Config.yum_staging_server
           command = 'sudo /usr/local/bin/s3_repo_sync.sh yum.puppetlabs.com'
           Pkg::Util::Net.remote_ssh_cmd(destination_server, command)
         end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -220,9 +220,8 @@ namespace :pl do
       puts "Really run S3 sync to deploy Debian repos from #{Pkg::Config.apt_signing_server} to AWS S3? [y,n]"
       if Pkg::Util.ask_yes_or_no
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          destination_server = Pkg::Config.apt_signing_server
           command = 'sudo /usr/local/bin/s3_repo_sync.sh apt.puppetlabs.com'
-          Pkg::Util::Net.remote_ssh_cmd(destination_server, command)
+          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.apt_signing_server, command)
         end
       end
     end
@@ -247,9 +246,8 @@ namespace :pl do
       puts "Really run S3 sync to deploy RPM repos from #{Pkg::Config.yum_staging_server} to AWS S3? [y,n]"
       if Pkg::Util.ask_yes_or_no
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          destination_server = Pkg::Config.yum_staging_server
           command = 'sudo /usr/local/bin/s3_repo_sync.sh yum.puppetlabs.com'
-          Pkg::Util::Net.remote_ssh_cmd(destination_server, command)
+          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_staging_server, command)
         end
       end
     end
@@ -259,9 +257,8 @@ namespace :pl do
       puts "Really run S3 sync to sync downloads.puppetlabs.com from #{Pkg::Config.staging_server} to AWS S3? [y,n]"
       if Pkg::Util.ask_yes_or_no
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          destination_server = Pkg::Config.staging_server
           command = 'sudo /usr/local/bin/s3_repo_sync.sh downloads.puppetlabs.com'
-          Pkg::Util::Net.remote_ssh_cmd(destination_server, command)
+          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.staging_server, command)
         end
       end
     end


### PR DESCRIPTION
The ask_yes_or_no messages were using `staging_host` but the actual
command was running on `apt_signing_host`. While these are the same
right now, this is dangerous, so we should be consistent.
