### PR TITLE
(RE-8978) Make regexes more specific

### DIFF
--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -11,7 +11,7 @@ module Pkg::Paths
   # Given a path to an artifact, divine the appropriate platform tag associated
   # with the artifact and path
   def tag_from_artifact_path(path)
-    platform = Pkg::Platforms.supported_platforms.find { |p| path.include?(p) }
+    platform = Pkg::Platforms.supported_platforms.find { |p| path =~ /(\/|\.)#{p}/ }
     if platform == 'windows'
       version = '2012'
       arch = Pkg::Platforms.arches_for_platform_version(platform, version).find { |a| path.include?(a) }
@@ -19,7 +19,7 @@ module Pkg::Paths
         arch = Pkg::Platforms.arches_for_platform_version(platform, version)[0]
       end
     elsif !platform.nil?
-      version = Pkg::Platforms.versions_for_platform(platform).find { |v|  path =~ /#{platform}(\/|-)?#{v}/ }
+      version = Pkg::Platforms.versions_for_platform(platform).find { |v| path =~ /#{platform}(\/|-)?#{v}/ }
       unless version.nil?
         arch = Pkg::Platforms.arches_for_platform_version(platform, version).find { |a| path.include?(a) }
         if arch.nil?
@@ -29,7 +29,7 @@ module Pkg::Paths
     end
     # if we didn't find a platform or a version, probably a codename
     if platform.nil? || version.nil?
-      codename = Pkg::Platforms.codenames('deb').find { |c| path.include?(c) }
+      codename = Pkg::Platforms.codenames('deb').find { |c| path =~ /\/#{c}\// }
       fail "I can't find a codename or platform in #{path}, teach me?" if codename.nil?
       platform, version = Pkg::Platforms.codename_to_platform_version(codename)
       fail "I can't find a platform and version from #{codename}, teach me?" if platform.nil? || version.nil?

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -28,16 +28,6 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
       '9' => { codename: 'stretch', architectures: ['i386', 'amd64'], repo: true, package_format: 'deb' }
     },
 
-    'fedora' => {
-      '24' => { architectures: ['i386', 'x86_64'], repo: true, package_format: 'rpm', signature_format: 'v4' },
-      '25' => { architectures: ['i386', 'x86_64'], repo: true, package_format: 'rpm', signature_format: 'v4' }
-    },
-
-    'sles' => {
-      '11' => { architectures: ['i386', 'x86_64', 's390x'], repo: true, package_format: 'rpm', signature_format: 'v3' },
-      '12' => { architectures: ['x86_64', 's390x'], repo: true, package_format: 'rpm', signature_format: 'v4' }
-    },
-
     'el' => {
       '5' => { architectures: ['i386', 'x86_64'], repo: true, package_format: 'rpm', signature_format: 'v3' },
       '6' => { architectures: ['i386', 'x86_64', 's390x'], repo: true, package_format: 'rpm', signature_format: 'v4' },
@@ -48,6 +38,11 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
       '4' => { architectures: ['i386'], repo: false, package_format: 'swix' }
     },
 
+    'fedora' => {
+      '24' => { architectures: ['i386', 'x86_64'], repo: true, package_format: 'rpm', signature_format: 'v4' },
+      '25' => { architectures: ['i386', 'x86_64'], repo: true, package_format: 'rpm', signature_format: 'v4' }
+    },
+
     'huaweios' => {
       '6' => { codename: 'huaweios', architectures: ['powerpc'], repo: true, package_format: 'deb' }
     },
@@ -56,6 +51,11 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
       '10.10' => { architectures: ['x86_64'], repo: false, package_format: 'dmg' },
       '10.11' => { architectures: ['x86_64'], repo: false, package_format: 'dmg' },
       '10.12' => { architectures: ['x86_64'], repo: false, package_format: 'dmg' }
+    },
+
+    'sles' => {
+      '11' => { architectures: ['i386', 'x86_64', 's390x'], repo: true, package_format: 'rpm', signature_format: 'v3' },
+      '12' => { architectures: ['x86_64', 's390x'], repo: true, package_format: 'rpm', signature_format: 'v4' }
     },
 
     'solaris' => {

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -10,9 +10,12 @@ describe 'Pkg::Paths' do
       'pkg/deb/trusty/pe-r10k_2.5.4.3-1trusty_amd64.deb' => 'ubuntu-14.04-amd64',
       'pkg/pe/rpm/el-6-i386/pe-puppetserver-2017.3.0.3-1.el6.noarch.rpm' => 'el-6-i386',
       'pkg/pe/deb/xenial/pe-puppetserver_2017.3.0.3-1puppet1_all.deb' => 'ubuntu-16.04-i386',
+      'pkg/pe/deb/xenial/super-trusty-package_1.0.0-1puppet1_all.deb' => 'ubuntu-16.04-i386',
+      'artifacts/fedora/24/puppet/x86_64/puppet-release-1.0.0-1.fc24.noarch.rpm' => 'fedora-24-x86_64',
       'artifacts/deb/wheezy/PC1/puppetdb_4.3.1-1puppetlabs1_all.deb' => 'debian-7-i386',
       'pkg/el/7/PC1/x86_64/puppetdb-4.3.1-1.el7.noarch.rpm' => 'el-7-x86_64',
       'pkg/apple/10.11/PC1/x86_64/puppet-agent-1.9.0-1.osx10.11.dmg' => 'osx-10.11-x86_64',
+      'artifacts/mac/10.11/PC1/x86_64/puppet-agent-1.9.0-1.osx10.11.dmg' => 'osx-10.11-x86_64',
       'artifacts/eos/4/PC1/i386/puppet-agent-1.9.0-1.eos4.i386.swix' => 'eos-4-i386',
       'pkg/deb/cumulus/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1cumulus_amd64.deb' => 'cumulus-2.2-amd64',
       'pkg/windows/puppet-agent-1.9.0-x86.msi' => 'windows-2012-x86'


### PR DESCRIPTION
Our initial regexes for determining platform were pretty open ended.
This lead to issues for instance with packages that matched 'el' (such
as puppet-release. woops), and could have easily been encountered with
codenames. This makes the regexes more anchored and adds some more test
cases.