### PR TITLE
(maint) Updates requested by beaker team

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -94,6 +94,9 @@ module Pkg
             else
               fail "Not sure what to do with packages with a package format of '#{package_format}' - maybe update PLATFORM_INFO?"
             end
+            # Remove the f-prefix from the fedora platform tag keys so that
+            # beaker can rely on consistent keys once we rip out the f for good
+            tag = tag.sub(/fedora-f/, 'fedora-')
             data[tag] = { :artifact => artifact.sub('artifacts/', ''),
                           :repo_config => repo_config,
                         } if artifact

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -85,16 +85,16 @@ module Pkg
             case package_format
             when 'deb'
               artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and (e.include?("all") || e.include?("#{arch}.deb")) }
-              repo_config = "./repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Util::Platform.get_attribute(tag, :codename)}.list" if artifact
+              repo_config = "../repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Util::Platform.get_attribute(tag, :codename)}.list" if artifact
             when 'rpm'
               artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
-              repo_config = "./repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo" if artifact
+              repo_config = "../repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo" if artifact
             when 'swix', 'svr4', 'ips', 'dmg', 'msi'
               artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
             else
               fail "Not sure what to do with packages with a package format of '#{package_format}' - maybe update PLATFORM_INFO?"
             end
-            data[tag] = { :artifact => artifact,
+            data[tag] = { :artifact => artifact.sub('artifacts/', ''),
                           :repo_config => repo_config,
                         } if artifact
           end

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -38,6 +38,8 @@ module Pkg
       'fedora' => {
         'f24' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
         'f25' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '24' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '25' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
       },
 
       'huaweios' => {


### PR DESCRIPTION
This PR updates the `platform_data` hash that beaker will consume. I have changed the artifact and repo_config paths to be relative to the location of the <ref>.yaml file (i.e. the artifacts directory) and removed the f prefix from the fedora keys (in this hash only). 

I also added back the non-f-prefixed versions to the `PLATFORM_INFO` map. This will allow us to locate paths with and without f prefixes. The breakage in the puppet-agent pipeline last week was due to packages on builds not having the f-prefix, but beaker looking for packages *with* the f prefix. I believe this was due to the removal of the f prefix in the puppet-agent vanagon configs, rather than anything packaging-related.