### PR TITLE
Do not ship HTML directory indexes to rsync server

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -271,7 +271,7 @@ namespace :pl do
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
           Pkg::Config.rsync_servers.each do |rsync_server|
             ['apt', 'yum'].each do |repo|
-              command = "sudo su - rsync --command 'rsync --verbose -a /opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/ rsync@#{rsync_server}:/opt/repository/#{repo}'"
+              command = "sudo su - rsync --command 'rsync --verbose -a --exclude '*.html' /opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/ rsync@#{rsync_server}:/opt/repository/#{repo}'"
               Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.staging_server, command)
             end
           end


### PR DESCRIPTION
Exclude *.html from rsyncing to the rsync download servers.

Without this change, after we switch DNS users will download a ton of HTML files they don't care about.

