### PR TITLE
(maint) Do not shallow clone git repo

### DIFF
--- a/tasks/fetch.rake
+++ b/tasks/fetch.rake
@@ -35,7 +35,7 @@ namespace :pl do
 
     begin
       temp_build_data_dir = Pkg::Util::File.mktemp
-      %x(git clone --depth 1 #{data_repo} #{temp_build_data_dir})
+      %x(git clone #{data_repo} #{temp_build_data_dir})
       if $?.success?
         Dir.chdir(temp_build_data_dir) do
           [team_data_branch, project_data_branch].each do |branch|


### PR DESCRIPTION
Setting `--depth 1` when cloning the build-data repo doesn't serve us
well. It prevents us from checking out the different branches we need to
check out. We need to be able to check out both the team specific and
project specific branch in order to load any extra data from them. We
can't do that with a shallow clone. This fixes that issue.