### PR TITLE
(RE-9133) Add task to packaging for syncing latest file to s3

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -317,5 +317,19 @@ namespace :pl do
       Pkg::Util::RakeUtils.invoke_task("pl:jenkins:prepare_signed_repos", target_host, 'signed', 'version')
       Pkg::Util::RakeUtils.invoke_task("pl:jenkins:deploy_signed_repos_to_s3", target_bucket)
     end
+
+    task :update_release_versions, [:target_bucket] do |t, args|
+      target_bucket = args.target_bucket or fail ":target_bucket is a required argument to #{t}"
+
+      tempdir = Pkg::Util::File.mktemp
+      latest_filepath = File.join(tempdir, "pkg", "#{Pkg::Config.project}")
+      FileUtils.mkdir_p(latest_filepath)
+
+      version = Pkg::Util::Version.get_dot_version
+      latest_filename = File.join(latest_filepath, "LATEST")
+      File.open(latest_filename, 'w') { |file| file.write(version) }
+      Pkg::Util::Net.s3sync_to(latest_filepath, target_bucket, Pkg::Config.project, ["--acl-public", "--follow-symlinks"])
+      FileUtils.rm_rf latest_filepath
+    end
   end
 end


### PR DESCRIPTION
Because it is useful to have a file which has the latest version of a
released package on s3 for cgi-bin scripts to correctly resolve 'latest'
this commit creates automation around this task.