### PR TITLE
(RE-8980) Drop sources into the correct directory

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -199,6 +199,10 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
     PLATFORM_INFO[platform][version][:signature_format]
   end
 
+  def signature_format_for_platform_version(platform, version)
+    PLATFORM_INFO[platform][version][:signature_format]
+  end
+
   # Return an array of platform tags associated with a given package format
   def platform_tags_for_package_format(format)
     platform_tags = []

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -176,11 +176,6 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
   # rubocop:disable Style/GuardClause
   def parse_platform_tag(platform_tag)
     platform, version, arch = platform_tag.match(/^(.*)-(.*)-(.*)$/).captures
-    if PLATFORM_INFO.key?(platform) && PLATFORM_INFO[platform].key?(version) && PLATFORM_INFO[platform][version][:architectures].include?(arch)
-      [platform, version, arch]
-    else
-      raise "#{platform_tag} isn't a valid platform tag. Perhaps it hasn't been defined yet?"
-    end
   end
 
   def get_attribute(platform_tag, attribute_name)

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe 'Pkg::Paths' do
+  describe '#arch_from_artifact_path' do
+    arch_transformations = {
+      ['pkg/el-7-x86_64/puppet-agent-4.99.0-1.el7.x86_64.rpm', 'el', '7'] => 'x86_64',
+      ['artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz', 'ubuntu', '16.04'] => 'source',
+      ['http://saturn.puppetlabs.net/deb_repos/1234abcd/repos/apt/xenial', 'ubuntu', '16.04'] => 'i386',
+      ['pkg/ubuntu-16.04-amd64/puppet-agent_4.99.0-1xenial_amd64.deb', 'ubuntu', '16.04'] => 'amd64',
+      ['artifacts/deb/jessie/PC1/puppetserver_5.0.1.master.orig.tar.gz', 'debian', '8'] => 'source',
+      ['artifacts/el/6/PC1/SRPMS/puppetserver-5.0.1.master-0.1SNAPSHOT.2017.08.18T0951.el6.src.rpm', 'el', '6'] => 'SRPMS'
+    }
+    arch_transformations.each do |path_array, arch|
+      it "should correctly return #{arch} for #{path_array[0]}" do
+        expect(Pkg::Paths.arch_from_artifact_path(path_array[1], path_array[2], path_array[0])).to eq(arch)
+      end
+    end
+  end
+
   describe '#tag_from_artifact_path' do
     path_tranformations = {
       'pkg/el-7-x86_64/puppet-agent-4.99.0-1.el7.x86_64.rpm' => 'el-7-x86_64',
@@ -19,10 +35,12 @@ describe 'Pkg::Paths' do
       'artifacts/eos/4/PC1/i386/puppet-agent-1.9.0-1.eos4.i386.swix' => 'eos-4-i386',
       'pkg/deb/cumulus/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1cumulus_amd64.deb' => 'cumulus-2.2-amd64',
       'pkg/windows/puppet-agent-1.9.0-x86.msi' => 'windows-2012-x86',
-      'artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz' => 'ubuntu-16.04-i386',
+      'artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz' => 'ubuntu-16.04-source',
       'http://saturn.puppetlabs.net/deb_repos/1234abcd/repos/apt/xenial' => 'ubuntu-16.04-i386',
       'http://builds.puppetlabs.lan/puppet-agent/0ce4e6a0448366e01537323bbab77f834d7035c7/repos/el/6/PC1/x86_64/' => 'el-6-x86_64',
-      'http://builds.puppetlabs.lan/puppet-agent/0ce4e6a0448366e01537323bbab77f834d7035c7/repos/el/6/PC1/x86_64/' => 'el-6-x86_64'
+      'http://builds.puppetlabs.lan/puppet-agent/0ce4e6a0448366e01537323bbab77f834d7035c7/repos/el/6/PC1/x86_64/' => 'el-6-x86_64',
+      'pkg/pe/rpm/el-6-i386/pe-puppetserver-2017.3.0.3-1.el6.src.rpm' => 'el-6-SRPMS',
+      'pkg/pe/deb/xenial/pe-puppetserver_2017.3.0.3-1puppet1.orig.tar.gz' => 'ubuntu-16.04-source'
     }
     path_tranformations.each do |pre, post|
       it "should correctly parse path #{pre} to tag #{post}" do

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -91,12 +91,6 @@ describe 'Pkg::Platforms' do
     end
   end
 
-  describe '#parse_platform_tag' do
-    it 'fails with a reasonable error on invalid platform' do
-      expect { Pkg::Platforms.parse_platform_tag('abcd-15-ia64') }.to raise_error(/valid platform tag/)
-    end
-  end
-
   describe '#get_attribute' do
     it 'returns info about a given platform' do
       expect(Pkg::Platforms.get_attribute('el-6-x86_64', :signature_format)).to eq('v4')

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -85,11 +85,12 @@ namespace :pl do
     v4_rpms = []
     all_rpms.each do |rpm|
       platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
+      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
 
       # We don't sign AIX rpms
       next if platform_tag.include?('aix')
 
-      sig_type = Pkg::Platforms.signature_format_for_tag(platform_tag)
+      sig_type = Pkg::Platforms.signature_format_for_platform_version(platform, version)
       case sig_type
       when 'v3'
         v3_rpms << rpm
@@ -113,7 +114,7 @@ namespace :pl do
     # Now we hardlink them back in
     Dir["#{rpm_dir}/**/*.noarch.rpm"].each do |rpm|
       platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
-      platform, version, architecture = Pkg::Platforms.parse_platform_tag(platform_tag)
+      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
       supported_arches = Pkg::Platforms.arches_for_platform_version(platform, version)
       cd File.dirname(rpm) do
         noarch_rpm = File.basename(rpm)


### PR DESCRIPTION
This commit updates the packaging repo to handle source packages
correctly. Previously, sources would just be dropped into the first
supported architecture for whatever platform-version we're dealing with.
This will let us send them to the proper directories when we ship.

This also adds a new method to allow us to get the package format
without needing to worry about architecture.