### PR TITLE
(maint) Change AIX arches from 'power' to 'ppc'

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -80,7 +80,8 @@ module Pkg
           artifacts = artifacts.split("\n")
           data = {}
           Pkg::Util::Platform.platform_tags.each do |tag|
-            _, _, arch = Pkg::Util::Platform.parse_platform_tag(tag)
+            platform, _, arch = Pkg::Util::Platform.parse_platform_tag(tag)
+            arch = 'ppc' if platform == 'aix'
             package_format = Pkg::Util::Platform.get_attribute(tag, :package_format)
             case package_format
             when 'deb'


### PR DESCRIPTION
AIX artifacts have 'ppc' as the arch, so we encountered issues when mapping artifact paths to platform tags.