### PR TITLE
Maint/1.0.x/revert staging changes

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -333,8 +333,6 @@ module Pkg::Params
                     { :oldvar => :yum_host,               :newvar => :swix_host },
                     { :oldvar => :yum_host,               :newvar => :dmg_host },
                     { :oldvar => :yum_host,               :newvar => :tar_host },
-                    { :oldvar => :apt_repo_name,          :newvar => :repo_name },
-                    { :oldvar => :yum_repo_name,          :newvar => :repo_name },
                  ]
 
   # These are variables that we have deprecated. If they are encountered in a
@@ -346,11 +344,5 @@ module Pkg::Params
     build_defaults.yaml or project_data.yaml" },
                   { :var => :gpg_name, :message => "
     DEPRECATED, 29-Jul-2014: 'gpg_name' has been replaced with 'gpg_key'.
-                   Please update this field in your build_defaults.yaml" },
-                  { :var => :apt_repo_name, :message => "
-    DEPRECATED, 25-May-2017: 'apt_repo_name' has been replaced with 'repo_name'.
-                   Please update this field in your builds_defaults.yaml" },
-                  { :var => :yum_repo_name, :message => "
-    DEPRECATED, 25-May-2017: 'yum_repo_name' has been replaced with 'repo_name'.
-                   Please update this field in your builds_defaults.yaml" }]
+                   Please update this field in your build_defaults.yaml" }]
 end

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -69,8 +69,7 @@ task :build_deb, :deb_command, :cow do |t, args|
     work_dir  = Pkg::Util::File.mktemp
     subdir    = 'pe/' if Pkg::Config.build_pe
     codename = /base-(.*)-(.*)\.cow/.match(cow)[1] unless cow.nil?
-    arch = /base-(.*)-(.*)\.cow/.match(cow)[2] unless cow.nil?
-    dest_dir  = File.join(Pkg::Config.project_root, "pkg", "#{Pkg::Platforms.codename_to_platform_version(codename).join('-')}-#{arch}")
+    dest_dir  = File.join(Pkg::Config.project_root, "pkg", "#{subdir}deb", codename, Pkg::Paths.repo_name.to_s)
     Pkg::Util::Tool.check_tool(deb_build)
     mkdir_p dest_dir
     deb_args  = { :work_dir => work_dir, :cow => cow }

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -29,17 +29,6 @@ def debuild(args)
   end
 end
 
-def link_noarch_debs(codename, dest_dir, arch)
-  supported_arches = Pkg::Platforms.arches_for_codename(codename)
-  supported_arches.each do |link_arch|
-    next if link_arch == arch
-    link_dir = "#{Pkg::Platforms.codename_to_platform_version(codename).join('-')}-#{link_arch}"
-    cd "#{File.dirname(dest_dir)}" do
-      FileUtils.ln_s(File.basename(dest_dir), link_dir, :verbose => true) unless Dir.exist?(link_dir)
-    end
-  end
-end
-
 task :prep_deb_tars, :work_dir do |t, args|
   work_dir = args.work_dir
   FileUtils.cp "pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz", work_dir, { :preserve => true }
@@ -110,7 +99,6 @@ task :build_deb, :deb_command, :cow do |t, args|
       rm_rf "#{work_dir}/#{Pkg::Config.project}-#{Pkg::Config.debversion}"
       rm_rf work_dir
     end
-    link_noarch_debs(codename, dest_dir, arch) unless FileList["#{dest_dir}/*_all.deb"].empty?
   end
   puts "Finished building in: #{bench}"
 end

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -63,13 +63,14 @@ task :prep_deb_tars, :work_dir do |t, args|
 end
 
 task :build_deb, :deb_command, :cow do |t, args|
+  subrepo = Pkg::Config.apt_repo_name
   bench = Benchmark.realtime do
     deb_build = args.deb_command
     cow       = args.cow
     work_dir  = Pkg::Util::File.mktemp
     subdir    = 'pe/' if Pkg::Config.build_pe
     codename = /base-(.*)-(.*)\.cow/.match(cow)[1] unless cow.nil?
-    dest_dir  = File.join(Pkg::Config.project_root, "pkg", "#{subdir}deb", codename, Pkg::Paths.repo_name.to_s)
+    dest_dir  = File.join(Pkg::Config.project_root, "pkg", "#{subdir}deb", codename.to_s, subrepo.to_s)
     Pkg::Util::Tool.check_tool(deb_build)
     mkdir_p dest_dir
     deb_args  = { :work_dir => work_dir, :cow => cow }

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -188,7 +188,11 @@ def build_rpm_with_mock(mocks)
   mocks.split(' ').each do |mock_config|
     family  = mock_el_family(mock_config)
     version = mock_el_ver(mock_config)
-    subdir  = Pkg::Paths.repo_name
+    subdir  = if Pkg::Config.yum_repo_name
+                Pkg::Config.yum_repo_name
+              else
+                Pkg::Util::Version.is_final? ? 'products' : 'devel'
+              end
     bench = Benchmark.realtime do
       # Set up the rpmbuild dir in a temp space, with our tarball and spec
       workdir = prep_rpm_build_dir

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -66,7 +66,7 @@ def mock_artifact(mock_config, cmd_args, mockfile)
     # configdir anymore either way, so we always clean it up if we're using
     # randomized mockroots.
     #
-    FileUtils.rm_r configdir if randomize
+    rm_r configdir if randomize
   end
 end
 
@@ -228,10 +228,10 @@ def build_rpm_with_mock(mocks)
         rpm.strip!
         arches = Pkg::Platforms.arches_for_platform_version(family, version)
 
-        FileUtils.mkdir_p "pkg/#{family}-#{version}-{srpms,#{arches.join(',')}})"
+        %x(mkdir -p pkg/#{family}-#{version}-{srpms,#{arches.join(',')}})
         case File.basename(rpm)
         when /debuginfo/
-          FileUtils.rm_rf(rpm)
+          rm_rf(rpm)
         when /src\.rpm/
           FileUtils.cp_r(rpm, "pkg/#{family}-#{version}-srpms", { :preserve => true })
         when /noarch/
@@ -314,7 +314,7 @@ def randomize_mock_config_dir(mock_config, mockfile)
   # Setup a mock config dir, copying in our mock config and logging.ini etc
   configdir = setup_mock_config_dir(config)
   # Clean up the directory with the temporary mock config
-  FileUtils.rm_r File.dirname(config)
+  rm_r File.dirname(config)
   return basedir, configdir
 end
 

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -134,25 +134,6 @@ def mock_el_ver(mock_config)
   version
 end
 
-# Determine the architecture of the target distribution based on the mock config name,
-# e.g. pupent-3.0-el5-i386 = "i386"
-# and "pl-fedora-17-x86_64" = "x86_64"
-#
-def mock_el_arch(mock_config)
-  if Pkg::Config.build_pe
-    # This uses a regex capture instead of splitting to allow the now defunct PE version component to be optional
-    arch = mock_config.match(/^pupent-(\d\.\d-)?([a-z]+)([0-9]+)-(.*)$/)[4]
-  else
-    components = mock_config.split('-')
-    if (components[0] == 'el' || components[0] == 'fedora') || (components[0] == 'pl' && components[1].match(/^\d+$/))
-      arch = components[2]
-    else
-      arch = components[3]
-    end
-  end
-  arch
-end
-
 # Return the RPM family and version for a Vanagon or Packaging repo built project.
 def rpm_family_and_version
   if Pkg::Config.vanagon_project
@@ -207,7 +188,6 @@ def build_rpm_with_mock(mocks)
   mocks.split(' ').each do |mock_config|
     family  = mock_el_family(mock_config)
     version = mock_el_ver(mock_config)
-    mock_arch = mock_el_arch(mock_config)
     subdir  = Pkg::Paths.repo_name
     bench = Benchmark.realtime do
       # Set up the rpmbuild dir in a temp space, with our tarball and spec
@@ -226,22 +206,52 @@ def build_rpm_with_mock(mocks)
 
       rpms.each do |rpm|
         rpm.strip!
-        arches = Pkg::Platforms.arches_for_platform_version(family, version)
 
-        %x(mkdir -p pkg/#{family}-#{version}-{srpms,#{arches.join(',')}})
-        case File.basename(rpm)
-        when /debuginfo/
-          rm_rf(rpm)
-        when /src\.rpm/
-          FileUtils.cp_r(rpm, "pkg/#{family}-#{version}-srpms", { :preserve => true })
-        when /noarch/
-          FileUtils.cp_r(rpm, "pkg/#{family}-#{version}-#{arches[0]}", { :preserve => true })
-          arches.each do |arch|
-            next if arch == arches[0]
-            FileUtils.ln("pkg/#{family}-#{version}-#{arches[0]}/#{File.basename(rpm)}", "pkg/#{family}-#{version}-#{arch}/", :force => false, :verbose => true)
+        if Pkg::Config.build_pe
+          %x(mkdir -p pkg/pe/rpm/#{family}-#{version}-{srpms,i386,x86_64})
+          case File.basename(rpm)
+            when /debuginfo/
+              rm_rf(rpm)
+            when /src\.rpm/
+              FileUtils.cp_r(rpm, "pkg/pe/rpm/#{family}-#{version}-srpms", { :preserve => true })
+            when /i.?86/
+              FileUtils.cp_r(rpm, "pkg/pe/rpm/#{family}-#{version}-i386", { :preserve => true })
+            when /x86_64/
+              FileUtils.cp_r(rpm, "pkg/pe/rpm/#{family}-#{version}-x86_64", { :preserve => true })
+            when /noarch/
+              FileUtils.cp_r(rpm, "pkg/pe/rpm/#{family}-#{version}-i386", { :preserve => true })
+              FileUtils.ln("pkg/pe/rpm/#{family}-#{version}-i386/#{File.basename(rpm)}", "pkg/pe/rpm/#{family}-#{version}-x86_64/", :force => true, :verbose => true)
+          end
+        elsif subdir == 'PC1' || !Pkg::Config.yum_repo_name
+          %x(mkdir -p pkg/#{family}/#{version}/#{subdir}/{SRPMS,i386,x86_64})
+          case File.basename(rpm)
+            when /debuginfo/
+              rm_rf(rpm)
+            when /src\.rpm/
+              FileUtils.cp_r(rpm, "pkg/#{family}/#{version}/#{subdir}/SRPMS", { :preserve => true })
+            when /i.?86/
+              FileUtils.cp_r(rpm, "pkg/#{family}/#{version}/#{subdir}/i386", { :preserve => true })
+            when /x86_64/
+              FileUtils.cp_r(rpm, "pkg/#{family}/#{version}/#{subdir}/x86_64", { :preserve => true })
+            when /noarch/
+              FileUtils.cp_r(rpm, "pkg/#{family}/#{version}/#{subdir}/i386", { :preserve => true })
+              FileUtils.ln("pkg/#{family}/#{version}/#{subdir}/i386/#{File.basename(rpm)}", "pkg/#{family}/#{version}/#{subdir}/x86_64/", :force => true, :verbose => true)
           end
         else
-          FileUtils.cp_r(rpm, "pkg/#{family}-#{version}-#{mock_arch}", { :preserve => true })
+          %x(mkdir -p pkg/#{subdir}/#{family}/#{version}/{SRPMS,i386,x86_64})
+          case File.basename(rpm)
+            when /debuginfo/
+              rm_rf(rpm)
+            when /src\.rpm/
+              FileUtils.cp_r(rpm, "pkg/#{subdir}/#{family}/#{version}/SRPMS", { :preserve => true })
+            when /i.?86/
+              FileUtils.cp_r(rpm, "pkg/#{subdir}/#{family}/#{version}/i386", { :preserve => true })
+            when /x86_64/
+              FileUtils.cp_r(rpm, "pkg/#{subdir}/#{family}/#{version}/x86_64", { :preserve => true })
+            when /noarch/
+              FileUtils.cp_r(rpm, "pkg/#{subdir}/#{family}/#{version}/i386", { :preserve => true })
+              FileUtils.ln("pkg/#{subdir}/#{family}/#{version}/i386/#{File.basename(rpm)}", "pkg/#{subdir}/#{family}/#{version}/x86_64/", :force => true, :verbose => true)
+          end
         end
       end
       # To avoid filling up the system with our random mockroots, we should


### PR DESCRIPTION
This PR is meant to revert all changes to how packages are built and staged. This only impacts packages build with the packaging repo or with ezbake. It allows us to build and stage packages on builds.delivery.puppetlabs.net in exactly the same way we always have. This minimizes the amount of tooling changes we need to do now and lets us move forward with getting puppet5 ships less manual. This will also let us move forward on actually getting automatic nightly pipelines up.