### PR TITLE
(RE-8866) Fix FOSS_ONLY

### DIFF
--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -19,55 +19,33 @@ namespace :pl do
       mkdir_p local_target
       package_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       if wget = Pkg::Util::Tool.find_tool("wget")
-        ## The following logic has been temporarily removed as FOSS_ONLY
-        ## expects a specific path structure that we are currently changing.
-        ## This will be fixed shortly, but for now we will fail if FOSS_ONLY
-        ## is specified.
-        ##
-        if Pkg::Config.foss_only
-          fail "FOSS_ONLY is temporarily unsupported. You must fetch everything and remove PE-only platforms from pkg/."
-        ##if Pkg::Config.foss_only && !Pkg::Config.foss_platforms
-        ##  warn "FOSS_ONLY specified, but I don't know anything about FOSS_PLATFORMS. Fetch everything?"
-        ##  unless Pkg::Util.ask_yes_or_no(true)
-        ##    warn "Retrieve cancelled"
-        ##    exit
-        ##  end
-        ##elsif Pkg::Config.foss_only && remote_target != 'artifacts'
-        ##  warn "I only know how to fetch from remote_target 'artifacts' with FOSS_ONLY. Fetch everything?"
-        ##  unless Pkg::Util.ask_yes_or_no(true)
-        ##    warn "Retrieve cancelled"
-        ##    exit
-        ##  end
-        ##end
-        ##if Pkg::Config.foss_only && Pkg::Config.foss_platforms && remote_target == 'artifacts'
-        ##  Pkg::Config.foss_platforms.each do |platform|
-        ##    begin
-        ##      platform_path = Pkg::Paths.artifacts_path(platform, package_url)
-        ##      _, _, arch = Pkg::Platforms.parse_platform_tag(platform)
-        ##      url = "#{package_url}/#{platform_path}"
-        ##      puts "Fetching: Platform = #{platform}, URL = #{url}"
-        ##      #osx packages have no platform in their name
-        ##      if platform =~ /^osx/
-        ##        sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{url}/"
-        ##      else
-        ##        sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*#{arch}*' #{url}/"
-        ##      end
-        ##    rescue => e
-        ##      warn "Encountered error fetching #{platform}:"
-        ##      warn e
-        ##    end
-        ##  end
-
-        ##  # also want to fetch the yaml and the signing bundle
-        ##  sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.yaml' #{package_url}/#{remote_target}/"
-        ##  sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.tar.gz' #{package_url}/#{remote_target}/"
-
-        ##  # Recursively remove empty directories under pkg
-        ##  Dir.glob("#{local_target}/**/*").select { |f| File.directory? f }.sort.uniq.reverse.each do |path|
-        ##    if Dir["#{path}/*"].empty?
-        ##      Dir.delete "#{path}"
-        ##    end
-        ##  end
+        # Grab the <ref>.yaml file
+        sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} #{package_url}/#{remote_target}/#{Pkg::Config.ref}.yaml"
+        yaml_path = File.join(local_target, "#{Pkg::Config.ref}.yaml")
+        if Pkg::Config.foss_only && !Pkg::Config.foss_platforms
+          warn "FOSS_ONLY specified, but I don't know anything about FOSS_PLATFORMS. Fetch everything?"
+          unless Pkg::Util.ask_yes_or_no(true)
+            warn "Retrieve cancelled"
+            exit
+          end
+        elsif Pkg::Config.foss_only && remote_target != 'artifacts'
+          warn "I only know how to fetch from remote_target 'artifacts' with FOSS_ONLY. Fetch everything?"
+          unless Pkg::Util.ask_yes_or_no(true)
+            warn "Retrieve cancelled"
+            exit
+          end
+        elsif Pkg::Config.foss_only && !File.readable?(yaml_path)
+          warn "Couldn't read #{Pkg::Config.ref}.yaml, which is necessary for FOSS_ONLY. Fetch everything?"
+          unless Pkg::Util.ask_yes_or_no(true)
+            warn "Retrieve cancelled"
+            exit
+          end
+        end
+        if Pkg::Config.foss_only && Pkg::Config.foss_platforms && remote_target == 'artifacts' && File.readable?(yaml_path)
+          platform_data = Pkg::Util::Serialization.load_yaml(yaml_path)[:platform_data]
+          platform_data.each do |platform, paths|
+            sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{package_url}/#{remote_target}/#{paths[:artifact]}" if Pkg::Config.foss_platforms.include?(platform)
+          end
         else
           # For the next person who needs to look these flags up:
           # -r = recursive

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -20,7 +20,7 @@ namespace :pl do
       package_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       if wget = Pkg::Util::Tool.find_tool("wget")
         # Grab the <ref>.yaml file
-        sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} #{package_url}/#{remote_target}/#{Pkg::Config.ref}.yaml"
+        sh "#{wget} --quiet --recursive --no-parent --no-host-directories --level=0 --cut-dirs 3 --directory-prefix=#{local_target} #{package_url}/#{remote_target}/#{Pkg::Config.ref}.yaml"
         yaml_path = File.join(local_target, "#{Pkg::Config.ref}.yaml")
         if Pkg::Config.foss_only && !Pkg::Config.foss_platforms
           warn "FOSS_ONLY specified, but I don't know anything about FOSS_PLATFORMS. Fetch everything?"
@@ -44,7 +44,7 @@ namespace :pl do
         if Pkg::Config.foss_only && Pkg::Config.foss_platforms && remote_target == 'artifacts' && File.readable?(yaml_path)
           platform_data = Pkg::Util::Serialization.load_yaml(yaml_path)[:platform_data]
           platform_data.each do |platform, paths|
-            sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{package_url}/#{remote_target}/#{paths[:artifact]}" if Pkg::Config.foss_platforms.include?(platform)
+            sh "#{wget} --quiet --recursive --no-parent --no-host-directories --level=0 --cut-dirs 3 --directory-prefix=#{local_target} --reject 'index*' #{package_url}/#{remote_target}/#{paths[:artifact]}" if Pkg::Config.foss_platforms.include?(platform)
           end
         else
           # For the next person who needs to look these flags up:
@@ -55,7 +55,7 @@ namespace :pl do
           # -nH = Discard http://#{Pkg::Config.builds_server} when saving to disk
           # --reject = Reject all hits that match the supplied regex
           # -P = where to save to disk (defaults to ./)
-          sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' #{package_url}/#{remote_target}/"
+          sh "#{wget} --quiet --recursive --no-parent --no-host-directories --level=0 --cut-dirs 3 --directory-prefix=#{local_target} --reject 'index*' #{package_url}/#{remote_target}/"
         end
       else
         warn "Could not find `wget` tool. Falling back to rsyncing from #{Pkg::Config.distribution_server}"


### PR DESCRIPTION
This commit re-implements FOSS_ONLY when retrieving packages. It uses the artifact paths gathered in the <ref>.yaml file and only grabs artifacts for platforms listed as foss platforms.