### PR TITLE
(maint) Do not report unversioned msis

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -84,6 +84,13 @@ module Pkg
             platform, _, arch = Pkg::Util::Platform.parse_platform_tag(tag)
             arch = 'ppc' if platform == 'aix'
             package_format = Pkg::Platforms.get_attribute(tag, :package_format)
+
+            # Skip this if it's an unversioned MSI. We create these to help
+            # beaker install the msi without having to know any version
+            # information, but we should report the versioned artifact in
+            # platform_data
+            next if platform == 'windows' && artifact == "#{self.project}-#{arch}.#{package_format}"
+
             case package_format
             when 'deb'
               repo_config = "../repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Platforms.get_attribute(tag, :codename)}.list"


### PR DESCRIPTION
Prior to this commit, we had been reporting unversioned msis in the
platform_data hash. This was fine for testing, as the unversioned msi is
simply a link to the versioned one. But this is bad when we go to ship
the packages. If we are fetching packages with FOSS_ONLY=true, it will
query the yaml data looking for foss only platform targets and fetch the
corresponding artifact. This is bad, since it means that for windows, we
were fetching the unversioned artifact for the final ship. This
changes ensures we don't set the unversioned msi when we are initially
writing out the platform_data hash.