### PR TITLE
(RE-9467) Fix how platform_data handles multiple entries for a given platform_tag

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -89,7 +89,7 @@ module Pkg
             # beaker install the msi without having to know any version
             # information, but we should report the versioned artifact in
             # platform_data
-            next if platform == 'windows' && artifact == "#{self.project}-#{arch}.#{package_format}"
+            next if platform == 'windows' && File.basename(artifact) == "#{self.project}-#{arch}.#{package_format}"
             # Sometimes we have source or debug packages. We don't want to save
             # these paths in favor of the artifact paths.
             if platform == 'solaris'

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -98,6 +98,7 @@ module Pkg
             else
               next if File.extname(artifact) != ".#{package_format}"
             end
+            next if /#{self.project}-[a-z]+/.match(File.basename(artifact))
 
             case package_format
             when 'deb'

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -81,7 +81,7 @@ module Pkg
           data = {}
           artifacts.each do |artifact|
             tag = Pkg::Paths.tag_from_artifact_path(artifact)
-            platform, _, arch = Pkg::Util::Platform.parse_platform_tag(tag)
+            platform, version, arch = Pkg::Util::Platform.parse_platform_tag(tag)
             arch = 'ppc' if platform == 'aix'
             package_format = Pkg::Platforms.get_attribute(tag, :package_format)
 
@@ -90,6 +90,14 @@ module Pkg
             # information, but we should report the versioned artifact in
             # platform_data
             next if platform == 'windows' && artifact == "#{self.project}-#{arch}.#{package_format}"
+            # Sometimes we have source or debug packages. We don't want to save
+            # these paths in favor of the artifact paths.
+            if platform == 'solaris'
+              next if version == '10' && File.extname(artifact) != '.gz'
+              next if version == '11' && File.extname(artifact) != '.p5p'
+            else
+              next if File.extname(artifact) != ".#{package_format}"
+            end
 
             case package_format
             when 'deb'

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -208,12 +208,12 @@ describe "Pkg::Config" do
     ]
     artifacts = \
       "./artifacts/eos/4/PC1/i386/puppet-agent-5.3.2-1.eos4.i386.swix\n" \
-      "./artifacts/apple/10.12/PC1/x86_64/puppet-agent-5.3.2-1.osx10.12.dmg\n" \
+      "./artifacts/apple/10.12/PC1/x86_64/puppet-agent-5.0.0.658.gc79ef9a-1.osx10.12.dmg\n" \
       "./artifacts/cisco-wrlinux/7/PC1/x86_64/puppet-agent-5.3.2-1.cisco_wrlinux7.x86_64.rpm\n" \
       "./artifacts/aix/6.1/PC1/ppc/puppet-agent-5.3.2-1.aix6.1.ppc.rpm\n" \
       "./artifacts/deb/xenial/PC1/puppet-agent_5.3.2-1xenial_i386.deb\n" \
       "./artifacts/deb/cumulus/PC1/puppet-agent_5.3.2-1cumulus_amd64.deb\n" \
-      "./artifacts/el/6/PC1/s390x/puppet-agent-5.3.2-1.el6.s390x.rpm\n" \
+      "./artifacts/el/6/PC1/s390x/puppet-agent-5.0.0.658.gc79ef9a-1.el6.s390x.rpm\n" \
       "./artifacts/el/7/PC1/ppc64le/puppet-agent-5.3.2-1.el7.ppc64le.rpm\n" \
       "./artifacts/sles/12/PC1/x86_64/puppet-agent-5.3.2-1.sles12.x86_64.rpm"
     fedora_artifacts = \
@@ -226,6 +226,11 @@ describe "Pkg::Config" do
     solaris_artifacts = \
       "./artifacts/solaris/11/PC1/puppet-agent@5.3.2,5.11-1.sparc.p5p\n" \
       "./artifacts/solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz"
+    stretch_artifacts = \
+      "./artifacts/deb/stretch/PC1/puppet-agent-dbgsym_5.3.2-1stretch_i386.deb\n" \
+      "./artifacts/deb/stretch/PC1/puppet-agent_5.3.2-1stretch_i386.deb\n" \
+      "./artifacts/deb/stretch/PC1/puppet-agent_5.0.0.658.gc79ef9a-1stretch_amd64.deb\n" \
+      "./artifacts/deb/stretch/PC1/puppet-agent-dbgsym_5.0.0.658.gc79ef9a-1stretch_amd64.deb"
 
     project = 'puppet-agent'
     ref = '5.3.2'
@@ -274,6 +279,11 @@ describe "Pkg::Config" do
     it "should not collect unversioned msis" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(windows_artifacts, nil)
       expect(Pkg::Config.platform_data).to include({'windows-2012-x64' => {:artifact => './windows/puppet-agent-5.3.2-x64.msi', :repo_config => nil}})
+    end
+
+    it "should not collect debug packages" do
+      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(stretch_artifacts, nil)
+      expect(Pkg::Config.platform_data).to include('debian-9-amd64' => {:artifact => './deb/stretch/PC1/puppet-agent_5.0.0.658.gc79ef9a-1stretch_amd64.deb', :repo_config => '../repo_configs/deb/pl-puppet-agent-5.3.2-stretch.list'})
     end
   end
 

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -206,31 +206,36 @@ describe "Pkg::Config" do
       'el-7-ppc64le',
       'sles-12-x86_64',
     ]
+
     artifacts = \
       "./artifacts/eos/4/PC1/i386/puppet-agent-5.3.2-1.eos4.i386.swix\n" \
-      "./artifacts/apple/10.12/PC1/x86_64/puppet-agent-5.0.0.658.gc79ef9a-1.osx10.12.dmg\n" \
+      "./artifacts/apple/10.12/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.osx10.12.dmg\n" \
       "./artifacts/cisco-wrlinux/7/PC1/x86_64/puppet-agent-5.3.2-1.cisco_wrlinux7.x86_64.rpm\n" \
       "./artifacts/aix/6.1/PC1/ppc/puppet-agent-5.3.2-1.aix6.1.ppc.rpm\n" \
       "./artifacts/deb/xenial/PC1/puppet-agent_5.3.2-1xenial_i386.deb\n" \
       "./artifacts/deb/cumulus/PC1/puppet-agent_5.3.2-1cumulus_amd64.deb\n" \
-      "./artifacts/el/6/PC1/s390x/puppet-agent-5.0.0.658.gc79ef9a-1.el6.s390x.rpm\n" \
+      "./artifacts/el/6/PC1/s390x/puppet-agent-5.3.2.658.gc79ef9a-1.el6.s390x.rpm\n" \
       "./artifacts/el/7/PC1/ppc64le/puppet-agent-5.3.2-1.el7.ppc64le.rpm\n" \
       "./artifacts/sles/12/PC1/x86_64/puppet-agent-5.3.2-1.sles12.x86_64.rpm"
+
     fedora_artifacts = \
       "./artifacts/fedora/f25/PC1/x86_64/puppet-agent-5.3.2-1.fedoraf25.x86_64.rpm"
+
     windows_artifacts = \
       "./artifacts/windows/puppet-agent-x64.msi\n" \
       "./artifacts/windows/puppet-agent-5.3.2-x86.wixpdb\n" \
       "./artifacts/windows/puppet-agent-5.3.2-x86.msi\n" \
       "./artifacts/windows/puppet-agent-5.3.2-x64.msi"
+
     solaris_artifacts = \
       "./artifacts/solaris/11/PC1/puppet-agent@5.3.2,5.11-1.sparc.p5p\n" \
       "./artifacts/solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz"
+
     stretch_artifacts = \
       "./artifacts/deb/stretch/PC1/puppet-agent-dbgsym_5.3.2-1stretch_i386.deb\n" \
       "./artifacts/deb/stretch/PC1/puppet-agent_5.3.2-1stretch_i386.deb\n" \
-      "./artifacts/deb/stretch/PC1/puppet-agent_5.0.0.658.gc79ef9a-1stretch_amd64.deb\n" \
-      "./artifacts/deb/stretch/PC1/puppet-agent-dbgsym_5.0.0.658.gc79ef9a-1stretch_amd64.deb"
+      "./artifacts/deb/stretch/PC1/puppet-agent_5.3.2.658.gc79ef9a-1stretch_amd64.deb\n" \
+      "./artifacts/deb/stretch/PC1/puppet-agent-dbgsym_5.3.2.658.gc79ef9a-1stretch_amd64.deb"
 
     project = 'puppet-agent'
     ref = '5.3.2'
@@ -263,27 +268,29 @@ describe "Pkg::Config" do
 
     it "should not use 'f' in fedora platform tags" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(fedora_artifacts, nil)
-      expect(Pkg::Config.platform_data).to include('fedora-25-x86_64')
+      data = Pkg::Config.platform_data
+      expect(data).to include('fedora-25-x86_64')
+      expect(data).not_to include('fedora-f25-x86_64')
     end
 
     it "should collect packages whose extname differ from package_format" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(solaris_artifacts, nil)
-      expect(Pkg::Config.platform_data).to include('solaris-10-i386' => {:artifact => './solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz', :repo_config => nil})
+      data = Pkg::Config.platform_data
+      expect(data).to include('solaris-10-i386' => {:artifact => './solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz', :repo_config => nil})
+      expect(data).to include('solaris-11-sparc' => {:artifact => './solaris/11/PC1/puppet-agent@5.3.2,5.11-1.sparc.p5p', :repo_config => nil})
     end
 
-    it "should not collect packages with unexpected formats" do
+    it "should collect versioned msis" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(windows_artifacts, nil)
-      expect(Pkg::Config.platform_data).to include('windows-2012-x86' => {:artifact => './windows/puppet-agent-5.3.2-x86.msi', :repo_config => nil})
-    end
-
-    it "should not collect unversioned msis" do
-      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(windows_artifacts, nil)
-      expect(Pkg::Config.platform_data).to include({'windows-2012-x64' => {:artifact => './windows/puppet-agent-5.3.2-x64.msi', :repo_config => nil}})
+      data = Pkg::Config.platform_data
+      expect(data['windows-2012-x86']).to include(:artifact => './windows/puppet-agent-5.3.2-x86.msi')
+      expect(data['windows-2012-x64']).to include(:artifact => './windows/puppet-agent-5.3.2-x64.msi')
     end
 
     it "should not collect debug packages" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(stretch_artifacts, nil)
-      expect(Pkg::Config.platform_data).to include('debian-9-amd64' => {:artifact => './deb/stretch/PC1/puppet-agent_5.0.0.658.gc79ef9a-1stretch_amd64.deb', :repo_config => '../repo_configs/deb/pl-puppet-agent-5.3.2-stretch.list'})
+      data = Pkg::Config.platform_data
+      expect(data['debian-9-amd64']).to include(:artifact => './deb/stretch/PC1/puppet-agent_5.3.2.658.gc79ef9a-1stretch_amd64.deb')
     end
   end
 

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -194,6 +194,89 @@ describe "Pkg::Config" do
     end
   end
 
+  describe "#platform_data" do
+    platform_tags = [
+      'eos-4-i386',
+      'osx-10.12-x86_64',
+      'cisco-wrlinux-7-x86_64',
+      'aix-6.1-power',
+      'ubuntu-16.04-i386',
+      'cumulus-2.2-amd64',
+      'el-6-s390x',
+      'el-7-ppc64le',
+      'sles-12-x86_64',
+    ]
+    artifacts = \
+      "./artifacts/eos/4/PC1/i386/puppet-agent-5.3.2-1.eos4.i386.swix\n" \
+      "./artifacts/apple/10.12/PC1/x86_64/puppet-agent-5.3.2-1.osx10.12.dmg\n" \
+      "./artifacts/cisco-wrlinux/7/PC1/x86_64/puppet-agent-5.3.2-1.cisco_wrlinux7.x86_64.rpm\n" \
+      "./artifacts/aix/6.1/PC1/ppc/puppet-agent-5.3.2-1.aix6.1.ppc.rpm\n" \
+      "./artifacts/deb/xenial/PC1/puppet-agent_5.3.2-1xenial_i386.deb\n" \
+      "./artifacts/deb/cumulus/PC1/puppet-agent_5.3.2-1cumulus_amd64.deb\n" \
+      "./artifacts/el/6/PC1/s390x/puppet-agent-5.3.2-1.el6.s390x.rpm\n" \
+      "./artifacts/el/7/PC1/ppc64le/puppet-agent-5.3.2-1.el7.ppc64le.rpm\n" \
+      "./artifacts/sles/12/PC1/x86_64/puppet-agent-5.3.2-1.sles12.x86_64.rpm"
+    fedora_artifacts = \
+      "./artifacts/fedora/f25/PC1/x86_64/puppet-agent-5.3.2-1.fedoraf25.x86_64.rpm"
+    windows_artifacts = \
+      "./artifacts/windows/puppet-agent-x64.msi\n" \
+      "./artifacts/windows/puppet-agent-5.3.2-x86.wixpdb\n" \
+      "./artifacts/windows/puppet-agent-5.3.2-x86.msi\n" \
+      "./artifacts/windows/puppet-agent-5.3.2-x64.msi"
+    solaris_artifacts = \
+      "./artifacts/solaris/11/PC1/puppet-agent@5.3.2,5.11-1.sparc.p5p\n" \
+      "./artifacts/solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz"
+
+    project = 'puppet-agent'
+    ref = '5.3.2'
+
+    before :each do
+      allow(Pkg::Config).to receive(:project).and_return(project)
+      allow(Pkg::Config).to receive(:ref).and_return(ref)
+      allow(Pkg::Util::Net).to receive(:check_host_ssh).and_return([])
+    end
+
+    it "should return a hash mapping platform tags to paths" do
+      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(artifacts, nil)
+      expect(Pkg::Config.platform_data.keys).to eql(platform_tags)
+    end
+
+    it "should return nil if project isn't set" do
+      allow(Pkg::Config).to receive(:project).and_return(nil)
+      expect(Pkg::Config.platform_data).to be_nil
+    end
+
+    it "should return nil if ref isn't set" do
+      allow(Pkg::Config).to receive(:ref).and_return(nil)
+      expect(Pkg::Config.platform_data).to be_nil
+    end
+
+    it "should return nil if can't connect to build server" do
+      allow(Pkg::Util::Net).to receive(:check_host_ssh).and_return(['something'])
+      expect(Pkg::Config.platform_data).to be_nil
+    end
+
+    it "should not use 'f' in fedora platform tags" do
+      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(fedora_artifacts, nil)
+      expect(Pkg::Config.platform_data).to include('fedora-25-x86_64')
+    end
+
+    it "should collect packages whose extname differ from package_format" do
+      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(solaris_artifacts, nil)
+      expect(Pkg::Config.platform_data).to include('solaris-10-i386' => {:artifact => './solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz', :repo_config => nil})
+    end
+
+    it "should not collect packages with unexpected formats" do
+      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(windows_artifacts, nil)
+      expect(Pkg::Config.platform_data).to include('windows-2012-x86' => {:artifact => './windows/puppet-agent-5.3.2-x86.msi', :repo_config => nil})
+    end
+
+    it "should not collect unversioned msis" do
+      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(windows_artifacts, nil)
+      expect(Pkg::Config.platform_data).to include({'windows-2012-x64' => {:artifact => './windows/puppet-agent-5.3.2-x64.msi', :repo_config => nil}})
+    end
+  end
+
   describe "#config_to_yaml" do
     it "should write a valid yaml file" do
       file = double('file')


### PR DESCRIPTION
This PR addresses several issues in gathering artifact paths. When multiple artifact paths matched a given platform tag, only the last one would be saved to <ref>.yaml. We now have additional checks to make sure we're not grabbing debug packages, source packages, unversioned msis, etc.