### PR TITLE
(RE-9525) Simultaneously ship nightlies to weth and old nightlies server

### DIFF
--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -138,4 +138,28 @@ module Pkg::Util::Ship
   rescue => e
     fail "Failed to create rolling repo link for '#{platform_tag}'.\n#{e}"
   end
+
+  def test_ship(vm, ship_task)
+    command = 'getent group release || groupadd release'
+    Pkg::Util::Net.remote_ssh_cmd(vm, command)
+    ENV['APT_HOST'] = vm
+    ENV['DMG_HOST'] = vm
+    ENV['GEM_HOST'] = vm
+    ENV['IPS_HOST'] = vm
+    ENV['MSI_HOST'] = vm
+    ENV['P5P_HOST'] = vm
+    ENV['SVR4_HOST'] = vm
+    ENV['SWIX_HOST'] = vm
+    ENV['TAR_HOST'] = vm
+    ENV['YUM_HOST'] = vm
+    ENV['APT_SIGNING_SERVER'] = vm
+    ENV['APT_STAGING_SERVER'] = vm
+    ENV['DMG_STAGING_SERVER'] = vm
+    ENV['MSI_STAGING_SERVER'] = vm
+    ENV['SWIX_STAGING_SERVER'] = vm
+    ENV['TAR_STAGING_SERVER'] = vm
+    ENV['YUM_STAGING_SERVER'] = vm
+    ENV['STAGING_SERVER'] = vm
+    Rake::Task[ship_task].invoke
+  end
 end

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -142,24 +142,29 @@ module Pkg::Util::Ship
   def test_ship(vm, ship_task)
     command = 'getent group release || groupadd release'
     Pkg::Util::Net.remote_ssh_cmd(vm, command)
-    ENV['APT_HOST'] = vm
-    ENV['DMG_HOST'] = vm
-    ENV['GEM_HOST'] = vm
-    ENV['IPS_HOST'] = vm
-    ENV['MSI_HOST'] = vm
-    ENV['P5P_HOST'] = vm
-    ENV['SVR4_HOST'] = vm
-    ENV['SWIX_HOST'] = vm
-    ENV['TAR_HOST'] = vm
-    ENV['YUM_HOST'] = vm
-    ENV['APT_SIGNING_SERVER'] = vm
-    ENV['APT_STAGING_SERVER'] = vm
-    ENV['DMG_STAGING_SERVER'] = vm
-    ENV['MSI_STAGING_SERVER'] = vm
-    ENV['SWIX_STAGING_SERVER'] = vm
-    ENV['TAR_STAGING_SERVER'] = vm
-    ENV['YUM_STAGING_SERVER'] = vm
-    ENV['STAGING_SERVER'] = vm
+    hosts_to_override = %w(
+      APT_HOST
+      DMG_HOST
+      GEM_HOST
+      IPS_HOST
+      MSI_HOST
+      P5P_HOST
+      SVR4_HOST
+      SWIX_HOST
+      TAR_HOST
+      YUM_HOST
+      APT_SIGNING_SERVER
+      APT_STAGING_SERVER
+      DMG_STAGING_SERVER
+      MSI_STAGING_SERVER
+      SWIX_STAGING_SERVER
+      TAR_STAGING_SERVER
+      YUM_STAGING_SERVER
+      STAGING_SERVER
+    )
+    hosts_to_override.each do |host|
+      ENV[host] = vm
+    end
     Rake::Task[ship_task].invoke
   end
 end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -249,6 +249,21 @@ namespace :pl do
       end
     end
 
+    task :uber_ship_lite => "pl:fetch" do
+      tasks = %w(
+        jenkins:retrieve
+        ship_rpms
+        ship_debs
+        ship_dmg
+        ship_swix
+        ship_msi
+      )
+      tasks.map { |t| "pl:#{t}" }.each do |t|
+        puts "Running #{t} . . ."
+        Rake::Task[t].invoke
+      end
+    end
+
     desc "Retrieve packages built by jenkins, sign, and ship all!"
     task :uber_ship => "pl:fetch" do
       uber_tasks = %w(

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -352,6 +352,13 @@ namespace :pl do
       puts "Do you want to mark this release as successfully shipped?"
       Rake::Task["pl:jenkins:ship"].invoke("shipped") if Pkg::Util.ask_yes_or_no
     end
+
+    desc "Test shipping by replacing hosts with a VM"
+    task :test_ship, [:vm, :ship_task] do |t, args|
+      vm = args.vm or fail "`vm` is a required argument for #{t}"
+      ship_task = args.ship_task or fail "`ship_task` is a required argument for #{t}"
+      Pkg::Util::Ship.test_ship(vm, ship_task)
+    end
   end
 end
 
@@ -456,4 +463,3 @@ namespace :pl do
     end
   end
 end
-

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -7,9 +7,14 @@ namespace :pl do
 
     desc "Update remote yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_yum_repo: 'pl:fetch' do
+      if Pkg::Util::Version.final?
+        path = Pkg::Config.yum_repo_path
+      else
+        path = Pkg::Config.nonfinal_yum_repo_path || Pkg::Config.yum_repo_path
+      end
       yum_whitelist = {
         __REPO_NAME__: Pkg::Paths.repo_name,
-        __REPO_PATH__: Pkg::Config.yum_repo_path,
+        __REPO_PATH__: path,
         __REPO_HOST__: Pkg::Config.yum_staging_server,
         __GPG_KEY__: Pkg::Util::Gpg.key
       }


### PR DESCRIPTION
This PR adds automation for shipping nightlies the same way we ship final builds.
See individual commit messages for more details.