### PR TITLE
(maint) Only require artifactory gem if we are using artifactory

### DIFF
--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -5,7 +5,6 @@ module Pkg
   # by the Release Engineering team at Puppet. It has the ability to both push
   # artifacts to the repos, and to retrieve them back from the repos.
   class ManageArtifactory
-    require 'artifactory'
 
     DEFAULT_REPO_TYPE = 'generic'
     DEFAULT_REPO_BASE = 'development'
@@ -21,6 +20,8 @@ module Pkg
     # @option :repo_base [String] The base of all repos, set for consistency.
     #   This currently defaults to 'development'
     def initialize(project, project_version, opts = {})
+      require 'artifactory'
+
       @artifactory_uri = opts[:artifactory_uri] || 'https://artifactory.delivery.puppetlabs.net/artifactory'
       @repo_base = opts[:repo_base] || DEFAULT_REPO_BASE
 


### PR DESCRIPTION
Previously, the fact that we had been requiring the artifactory gem at
the top of this file meant that calling any rake tasks would fail if the
artifactory gem was not installed. This commit moves the requires inside
the init for artifactory, so that we only require that library when we
are actually using it.