### PR TITLE
(RE-8843) Don't fail if ext/project_data.yaml doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ rescue LoadError
 end
 ```
 
-Also in ext should be two files, build_defaults.yaml and project_data.yaml.
+Also in ext should be two files, build_defaults.yaml and project_data.yaml (optional).
 
 This is the sample build_defaults.yaml file from Hiera:
 ```yaml

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -181,23 +181,26 @@ module Pkg
       end
 
       def load_default_configs
-        default_project_data = File.join(@project_root, "ext", "project_data.yaml")
-        default_build_defaults = File.join(@project_root, "ext", "build_defaults.yaml")
+        got_config = false
+        default_project_data = { :path => File.join(@project_root, "ext", "project_data.yaml"), :required => false }
+        default_build_defaults = { :path => File.join(@project_root, "ext", "build_defaults.yaml"), :required => true }
 
         [default_project_data, default_build_defaults].each do |config|
-          if File.readable? config
-            self.config_from_yaml(config)
+          if File.readable? config[:path]
+            self.config_from_yaml(config[:path])
+            got_config = true if config[:required]
           else
-            puts "Skipping load of expected default config #{config}, cannot read file."
-            #   Since the default configuration files are not readable, most
-            #   likely not present, at this point we assume the project_root
-            #   isn't what we hoped it would be, and unset it.
-            @project_root = nil
+            puts "Skipping load of expected default config #{config[:path]}, cannot read file."
           end
         end
 
-        if @project_root
+        if got_config
           self.config
+        else
+          # Since the default configuration files are not readable, most
+          # likely not present, at this point we assume the project_root
+          # isn't what we hoped it would be, and unset it.
+          @project_root = nil
         end
       end
 

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -325,8 +325,8 @@ module Pkg::Params
   DEPRECATIONS = [{ :var => :gem_devel_dependencies, :message => "
     DEPRECATED, 9-Nov-2013: 'gem_devel_dependencies' has been replaced with
     'gem_development_dependencies.' Please update this field in your
-    project_data.yaml" },
+    build_defaults.yaml or project_data.yaml" },
                   { :var => :gpg_name, :message => "
     DEPRECATED, 29-Jul-2014: 'gpg_name' has been replaced with 'gpg_key'.
-                   Please update this field in your project_data.yaml" }]
+                   Please update this field in your build_defaults.yaml" }]
 end

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -2,7 +2,7 @@
 # This task is intended to retrieve packages from the distribution server that
 # have been built by jenkins and placed in a specific location,
 # /opt/jenkins-builds/$PROJECT/$SHA where $PROJECT is the build project as
-# established in project_data.yaml and $SHA is the git sha/tag of the project that
+# established in build_defaults.yaml and $SHA is the git sha/tag of the project that
 # was built into packages. The current day is assumed, but an environment
 # variable override exists to retrieve packages from another day. The sha/tag is
 # assumed to be the current project's HEAD, e.g.  to retrieve packages for a

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -122,7 +122,7 @@ namespace :pl do
     end
   end
 
-  desc "Sign ips package, uses PL certificates by default, update privatekey_pem, certificate_pem, and ips_inter_cert in project_data.yaml to override."
+  desc "Sign ips package, uses PL certificates by default, update privatekey_pem, certificate_pem, and ips_inter_cert in build_defaults.yaml to override."
   task :sign_ips do
     Pkg::IPS.sign unless Dir['pkg/solaris/11/**/*.p5p'].empty?
   end


### PR DESCRIPTION
This commit adjusts the loading of default configs to move on if
project_data.yaml isn't found. Load will only fail if both project_data.yaml
and build_defaults.yaml cannot be found.