### PR TITLE
(maint) Remove project config from synced path

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -323,7 +323,7 @@ namespace :pl do
       version = ENV['VERSION'] || Pkg::Util::Version.get_dot_version
 
       tempdir = Pkg::Util::File.mktemp
-      latest_filepath = File.join(tempdir, "pkg", "#{Pkg::Config.project}")
+      latest_filepath = File.join(tempdir, "pkg")
       FileUtils.mkdir_p(latest_filepath)
 
       latest_filename = File.join(latest_filepath, "LATEST")


### PR DESCRIPTION
This commit removes the project name from the final synced path as it
when the S3 sync happens we get an extra directory too deep when syncing
files.