### PR TITLE
(maint) Using && and || can cause issues

### DIFF
--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -83,7 +83,7 @@ module Pkg::Deb::Repo
     end
 
     def repo_creation_command(repo_directory, artifact_paths)
-      cmd = "[ -d #{repo_directory} ] || exit 1 && "
+      cmd = "[ -d #{repo_directory} ] || exit 1 ; "
       cmd << "pushd #{repo_directory} > /dev/null && "
       cmd << 'echo "Checking for running repo creation. Will wait if detected." && '
       cmd << 'while [ -f .lock ] ; do sleep 1 ; echo -n "." ; done && '
@@ -100,14 +100,14 @@ module Pkg::Deb::Repo
         arches = Pkg::Platforms.arches_for_codename(codename)
 
         cmd << "mkdir -p #{codename}/conf && "
-        cmd << "pushd #{codename} && "
+        cmd << "pushd #{codename} ; "
         cmd << %Q( [ -e 'conf/distributions' ] || echo "
 Origin: Puppet Labs
 Label: Puppet Labs
 Codename: #{codename}
 Architectures: #{(DEBIAN_PACKAGING_ARCHES + arches).uniq.join(' ')}
 Components: #{reprepro_repo_name}
-Description: Apt repository for acceptance testing" >> conf/distributions && )
+Description: Apt repository for acceptance testing" >> conf/distributions ; )
 
         cmd << 'reprepro=$(which reprepro) && '
         cmd << "$reprepro includedeb #{codename} ../../#{path}/*.deb && "

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -34,7 +34,7 @@ module Pkg::Repo
     end
 
     def directories_that_contain_packages(artifact_directory, pkg_ext)
-      cmd = "[ -d #{artifact_directory} ] || exit 1 && "
+      cmd = "[ -d #{artifact_directory} ] || exit 1 ; "
       cmd << "pushd #{artifact_directory} > /dev/null && "
       cmd << "find . -name '*.#{pkg_ext}' -print0 | xargs --no-run-if-empty -0 -I {} dirname {} "
       stdout, stderr = Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, cmd, true)
@@ -44,7 +44,7 @@ module Pkg::Repo
     end
 
     def populate_repo_directory(artifact_parent_directory)
-      cmd = "[ -d #{artifact_parent_directory}/artifacts ] || exit 1 && "
+      cmd = "[ -d #{artifact_parent_directory}/artifacts ] || exit 1 ; "
       cmd << "pushd #{artifact_parent_directory} > /dev/null && "
       cmd << 'rsync --archive --verbose --one-file-system --ignore-existing artifacts/ repos/ '
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.distribution_server, cmd)

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -23,16 +23,16 @@ module Pkg::Rpm::Repo
     end
 
     def repo_creation_command(repo_directory, artifact_paths)
-      cmd = "[ -d #{repo_directory} ] || exit 1 && "
+      cmd = "[ -d #{repo_directory} ] || exit 1 ; "
       cmd << "pushd #{repo_directory} > /dev/null && "
       cmd << 'echo "Checking for running repo creation. Will wait if detected." && '
       cmd << 'while [ -f .lock ] ; do sleep 1 ; echo -n "." ; done && '
       cmd << 'echo "Setting lock" && '
       cmd << 'touch .lock && '
-      cmd << 'createrepo=$(which createrepo) && '
+      cmd << 'createrepo=$(which createrepo) ; '
 
       artifact_paths.each do |path|
-        cmd << "[ -d #{path} ] || continue && "
+        cmd << "[ -d #{path} ] || continue ; "
         cmd << "pushd #{path} && "
         cmd << '$createrepo --checksum=sha --checkts --update --delta-workers=0 --database . && '
         cmd << 'popd ; '


### PR DESCRIPTION
Care needs to be taken when combining && and || in a long command to
avoid running into operator precedence issues.