### PR TITLE
(maint) Restore backwards compatibility for create_repos

### DIFF
--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -189,7 +189,15 @@ module Pkg::Rpm::Repo
       puts "Wrote yum configuration files for #{Pkg::Config.project} at #{Pkg::Config.ref} to pkg/#{target}/rpm"
     end
 
-    def create_repos(directory = 'repos')
+    def create_local_repos(directory = "repos")
+      Dir.chdir(directory) do
+        createrepo = Pkg::Util::Tool.check_tool('createrepo')
+        stdout, _, _ = Pkg::Util::Execution.capture3("bash -c '#{repo_creation_command(createrepo)}'")
+        stdout
+      end
+    end
+
+    def create_remote_repos(directory = 'repos')
       artifact_directory = File.join(Pkg::Config.jenkins_repo_path, Pkg::Config.project, Pkg::Config.ref)
       artifact_paths = Pkg::Repo.directories_that_contain_packages(File.join(artifact_directory, 'artifacts'), 'rpm')
       Pkg::Repo.populate_repo_directory(artifact_directory)
@@ -209,9 +217,14 @@ module Pkg::Rpm::Repo
       end
     end
 
-    def create_repos_from_artifacts
-      Pkg::Util.deprecate('Pkg::Rpm::Repo.create_repos_from_artifacts', 'Pkg::Rpm::Repo.create_repos')
-      create_repos
+    def create_repos_from_artifacts(directory = "repos")
+      Pkg::Util.deprecate('Pkg::Rpm::Repo.create_repos_from_artifacts', 'Pkg::Rpm::Repo.create_remote_repos')
+      create_remote_repos(directory)
+    end
+
+    def create_repos(directory = "repos")
+      Pkg::Util.deprecate('Pkg::Rpm::Repo.create_repos', 'Pkg::Rpm::Repo.create_local_repos')
+      create_local_repos(directory)
     end
 
     # @deprecated this command is exactly as awful as you think it is.

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -31,7 +31,7 @@ namespace :pl do
 
     task :sign_repos => "pl:fetch" do
       Pkg::Util::RakeUtils.invoke_task("pl:sign_rpms", "repos")
-      Pkg::Rpm::Repo.create_repos('repos')
+      Pkg::Rpm::Repo.create_local_repos('repos')
       Pkg::Rpm::Repo.sign_repos('repos')
       Pkg::Deb::Repo.sign_repos('repos', 'Apt repository for signed builds')
       Pkg::OSX.sign('repos') unless Dir['repos/apple/**/*.dmg'].empty?

--- a/tasks/rpm_repos.rake
+++ b/tasks/rpm_repos.rake
@@ -13,7 +13,7 @@ namespace :pl do
   namespace :jenkins do
     desc "Create yum repositories of built RPM packages for this SHA on the distribution server"
     task :rpm_repos => "pl:fetch" do
-      Pkg::Rpm::Repo.create_repos_from_artifacts
+      Pkg::Rpm::Repo.create_remote_repos
     end
 
     desc "Create yum repository configs for package repos for this sha/tag on the distribution server"


### PR DESCRIPTION
In
https://github.com/puppetlabs/packaging/pull/693/commits/d036eba3666198b7e6f792a44aee60bcbc984f5c
the functionality for create_repos was modified from something that runs
repo creation locally to something that runs repo creation on a remote
host. To restore backwards compatibility we added create_local_repos and
create_remote_repos. The original create_repos method has been
deprecated in favor of create_local_repos and
create_repos_from_artifacts has been deprecated in favor of
create_remote_repos.