### PR TITLE
Revert "(maint) Go back to using `Pkg::Util::Tool.check_tool`"

### DIFF
--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -23,13 +23,13 @@ module Pkg::Rpm::Repo
     end
 
     def repo_creation_command(repo_directory, artifact_paths = nil)
-      createrepo = Pkg::Util::Tool.check_tool('createrepo')
       cmd = "[ -d #{repo_directory} ] || exit 1 ; "
       cmd << "pushd #{repo_directory} > /dev/null && "
       cmd << 'echo "Checking for running repo creation. Will wait if detected." && '
       cmd << 'while [ -f .lock ] ; do sleep 1 ; echo -n "." ; done && '
       cmd << 'echo "Setting lock" && '
       cmd << 'touch .lock && '
+      cmd << 'createrepo=$(which createrepo) ; '
 
       # Added for compatibility.
       # The nightly repo ships operate differently and do not want to be calculating
@@ -40,7 +40,7 @@ module Pkg::Rpm::Repo
       artifact_paths.each do |path|
         cmd << "if [ -d #{path}  ]; then "
         cmd << "pushd #{path} && "
-        cmd << "#{createrepo} --checksum=sha --checkts --update --delta-workers=0 --database . && "
+        cmd << '$createrepo --checksum=sha --checkts --update --delta-workers=0 --database . && '
         cmd << 'popd ; '
         cmd << 'fi ;'
       end

--- a/spec/lib/packaging/rpm/repo_spec.rb
+++ b/spec/lib/packaging/rpm/repo_spec.rb
@@ -85,11 +85,6 @@ describe "Pkg::Rpm::Repo" do
     let(:command) { "/usr/bin/make some repos" }
     let(:target_directory) { "/tmp/dir/thing" }
 
-    it "fails without createrepo" do
-      Pkg::Util::Tool.should_receive(:find_tool).with('createrepo', :required => true).and_raise(RuntimeError)
-      expect { Pkg::Rpm::Repo.create_local_repos(target_directory) }.to raise_error(RuntimeError)
-    end
-
     it "makes a repo in the target directory" do
       Pkg::Rpm::Repo.should_receive(:repo_creation_command).with(target_directory).and_return("run this thing")
       Pkg::Util::Execution.should_receive(:capture3).with("bash -c 'run this thing'")


### PR DESCRIPTION
This reverts commit e2db10e343382df5a5695f42d18917f6c254aa41.

Since repo_creation_command is generating a command to be used later we
don't care if createrepo is available where we're generating the
command, but rather on the system it's run on.