### PR TITLE
(RE-9874) remote_set_permissions doesn't work on directories

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -266,12 +266,12 @@ module Pkg::Util::Net
     end
 
     def remote_set_ownership(host, owner, group, files)
-      remote_cmd = "for file in #{files.join(" ")}; do if ! `lsattr $file | grep -q '\\-i\\-'`; then sudo chown #{owner}:#{group} $file; else echo \"$file is immutable\"; fi; done"
+      remote_cmd = "for file in #{files.join(" ")}; do if [[ -d $file ]] || ! `lsattr $file | grep -q '\\-i\\-'`; then sudo chown #{owner}:#{group} $file; else echo \"$file is immutable\"; fi; done"
       Pkg::Util::Net.remote_ssh_cmd(host, remote_cmd)
     end
 
     def remote_set_permissions(host, permissions, files)
-      remote_cmd = "for file in #{files.join(" ")}; do if ! `lsattr $file | grep -q '\\-i\\-'`; then sudo chmod #{permissions} $file; else echo \"$file is immutable\"; fi; done"
+      remote_cmd = "for file in #{files.join(" ")}; do if [[ -d $file ]] || ! `lsattr $file | grep -q '\\-i\\-'`; then sudo chmod #{permissions} $file; else echo \"$file is immutable\"; fi; done"
       Pkg::Util::Net.remote_ssh_cmd(host, remote_cmd)
     end
 


### PR DESCRIPTION
This commit adds checks for whether a file is directory when attempting to set ownership or permissions. Since we check for immutability by piping `lsattr` to `grep`, directories that contain immutable files were being read as immutable themselves. This fixes that by ignoring the `lsattr` result for directories.