### PR TITLE
(RE-9886) Update windows keys in platform_data to include `r2`

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -113,6 +113,9 @@ module Pkg
             # Remove the f-prefix from the fedora platform tag keys so that
             # beaker can rely on consistent keys once we rip out the f for good
             tag = tag.sub(/fedora-f/, 'fedora-')
+            # Add `r2` to windows versions so that beaker can find artifacts
+            # based on the same platform tag used in puppet-agent configs
+            tag = tag.sub(/windows-2012/, 'windows-2012r2')
             data[tag] = { :artifact => artifact.sub('artifacts/', ''),
                           :repo_config => repo_config,
                         }

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -283,8 +283,8 @@ describe "Pkg::Config" do
     it "should collect versioned msis" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(windows_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data['windows-2012-x86']).to include(:artifact => './windows/puppet-agent-5.3.2-x86.msi')
-      expect(data['windows-2012-x64']).to include(:artifact => './windows/puppet-agent-5.3.2-x64.msi')
+      expect(data['windows-2012r2-x86']).to include(:artifact => './windows/puppet-agent-5.3.2-x86.msi')
+      expect(data['windows-2012r2-x64']).to include(:artifact => './windows/puppet-agent-5.3.2-x64.msi')
     end
 
     it "should not collect debug packages" do


### PR DESCRIPTION
This commit adds `r2` to windows versions in platform_data so that beaker can find artifacts based on the same platform tag used in puppet-agent configs.

Related to https://github.com/puppetlabs/beaker-hostgenerator/pull/103