### PR TITLE
(RE-9889) Nightly repo ship only generates repo configs, ships no artifacts

### DIFF
--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -176,7 +176,7 @@ module Pkg::Paths
     end
   end
 
-  def repo_path(platform_tag, legacy = false)
+  def repo_path(platform_tag, legacy: false)
     repo_target = repo_name
     repo_target = Pkg::Config.repo_name if legacy
     platform, version, arch = Pkg::Platforms.parse_platform_tag(platform_tag)

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -176,21 +176,27 @@ module Pkg::Paths
     end
   end
 
-  def repo_path(platform_tag)
+  def repo_path(platform_tag, legacy = false)
+    repo_target = repo_name
+    repo_target = Pkg::Config.repo_name if legacy
     platform, version, arch = Pkg::Platforms.parse_platform_tag(platform_tag)
     package_format = Pkg::Platforms.package_format_for_tag(platform_tag)
 
     case package_format
     when 'rpm', 'swix'
-      File.join('repos', repo_name, platform, version, arch)
+      if legacy
+        File.join('repos', platform, version, repo_target, arch)
+      else
+        File.join('repos', repo_target, platform, version, arch)
+      end
     when 'deb'
-      File.join('repos', 'apt', Pkg::Platforms.get_attribute(platform_tag, :codename), 'pool', repo_name)
+      File.join('repos', 'apt', Pkg::Platforms.get_attribute(platform_tag, :codename), 'pool', repo_target)
     when 'svr4', 'ips'
-      File.join('repos', 'solaris', repo_name, version)
+      File.join('repos', 'solaris', repo_target, version)
     when 'dmg'
-      File.join('repos', 'mac', repo_name, version, arch)
+      File.join('repos', 'mac', repo_target, version, arch)
     when 'msi'
-      File.join('repos', 'windows', repo_name)
+      File.join('repos', 'windows', repo_target)
     else
       raise "Not sure what to do with a package format of '#{package_format}'"
     end

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -196,7 +196,7 @@ namespace :pl do
 
       if args.foss_only && Pkg::Config.foss_platforms && !Pkg::Config.foss_platforms.empty?
         Pkg::Config.foss_platforms.each do |platform|
-          include_paths << Pkg::Paths.repo_path(platform, true)
+          include_paths << Pkg::Paths.repo_path(platform, legacy: true)
           if Pkg::Paths.repo_config_path(platform)
             include_paths << Pkg::Paths.repo_config_path(platform)
           end

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -196,7 +196,7 @@ namespace :pl do
 
       if args.foss_only && Pkg::Config.foss_platforms && !Pkg::Config.foss_platforms.empty?
         Pkg::Config.foss_platforms.each do |platform|
-          include_paths << Pkg::Paths.repo_path(platform)
+          include_paths << Pkg::Paths.repo_path(platform, true)
           if Pkg::Paths.repo_config_path(platform)
             include_paths << Pkg::Paths.repo_config_path(platform)
           end


### PR DESCRIPTION
This commit adds an optional parameter `repo_target` to Pkg::Paths.repo_path. Previously, the value of Pkg::Paths.repo_name was used instead. This allows the nightly ship task to find builds using the (final) repo name, rather than the nonfinal repo name, when shipping to ravi. Ideally, this should be reverted once the old nightlies process is obsoleted.