### PR TITLE
(RE-9948) generate_repo_configs tag creates repo config for aix

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -89,10 +89,7 @@ module Pkg
               repo_config = "../repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Util::Platform.get_attribute(tag, :codename)}.list" if artifact
             when 'rpm'
               artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
-              if artifact
-                repo_config = "../repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo"
-                repo_config = repo_config.sub('power', 'ppc') if tag.include? 'aix'
-              end
+              repo_config = "../repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo" if artifact && !tag.include?('aix')
             when 'swix', 'svr4', 'ips', 'dmg', 'msi'
               artifact = artifacts.find { |e| e.include? Pkg::Util::Platform.artifacts_path(tag) and e.include?(arch) }
             else

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -23,7 +23,7 @@ module Pkg::Rpm::Repo
     end
 
     def repo_creation_command(createrepo)
-      cmd = 'for repodir in $(find ./ -name "*.rpm" | xargs -I {} dirname {}) ; do '
+      cmd = 'for repodir in $(find ./ -name "*.rpm" ! -name "*aix*" | xargs -I {} dirname {}) ; do '
       cmd << "[ -d ${repodir} ] || continue; "
       cmd << "pushd ${repodir} && #{createrepo} --checksum=sha --checkts --update --delta-workers=0 --database . ; popd ; "
       cmd << "done "
@@ -208,7 +208,7 @@ module Pkg::Rpm::Repo
       cmd << "touch .lock ; "
       cmd << "rsync -avxl artifacts/ repos/ ; pushd repos ; "
       cmd << "createrepo=$(which createrepo) ; "
-      cmd << 'for repodir in $(find ./ -name "*.rpm" | xargs -I {} dirname {}) ; do '
+      cmd << 'for repodir in $(find ./ -name "*.rpm" ! -name "*aix*" | xargs -I {} dirname {}) ; do '
       cmd << "[ -d ${repodir} ] || continue; "
       cmd << "pushd ${repodir} && ${createrepo} --checksum=sha --checkts --update --delta-workers=0 --database . ; popd ; "
       cmd << "done ; popd "


### PR DESCRIPTION
This commit excludes aix rpms when generating repo configs.