### PR TITLE
(RE-9948) generate_repo_configs tag creates repo config for aix

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -104,8 +104,7 @@ module Pkg
             when 'deb'
               repo_config = "../repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Platforms.get_attribute(tag, :codename)}.list"
             when 'rpm'
-              repo_config = "../repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo"
-              repo_config = repo_config.sub('power', 'ppc') if tag.include? 'aix'
+              repo_config = "../repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo" unless tag.include? 'aix'
             when 'swix', 'svr4', 'ips', 'dmg', 'msi'
               # No repo_configs for these platforms, so do nothing.
             else

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -47,6 +47,7 @@ module Pkg::Rpm::Repo
       end
 
       artifact_paths.each do |path|
+        next if path.include? 'aix'
         cmd << "if [ -d #{path}  ]; then "
         cmd << "pushd #{path} && "
         cmd << '$createrepo --checksum=sha --checkts --update --delta-workers=0 --database . && '

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -297,7 +297,13 @@ describe "Pkg::Config" do
     it "should use 'ppc' instead of 'power' in aix paths" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(aix_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data['aix-6.1-power']).to eql({:artifact => './aix/6.1/PC1/ppc/puppet-agent-5.3.2-1.aix6.1.ppc.rpm', :repo_config => "../repo_configs/rpm/pl-#{project}-#{ref}-aix-6.1-ppc.repo"})
+      expect(data['aix-6.1-power']).to include(:artifact => './aix/6.1/PC1/ppc/puppet-agent-5.3.2-1.aix6.1.ppc.rpm')
+    end
+
+    it "should not record an aix repo config" do
+      allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(aix_artifacts, nil)
+      data = Pkg::Config.platform_data
+      expect(data['aix-6.1-power'][:repo_config]).to be_nil
     end
   end
 


### PR DESCRIPTION
This commit excludes aix rpms when generating repo configs.