### PR TITLE
(maint) Prepare for shipping packaging as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem 'artifactory'
 
 group :development, :test do
-  gem "rake", "~> 0.9.6"
+  gem "rake"
   gem "rspec", "~> 2.14.1"
   gem "pry"
   gem "win32console", platforms: [:mingw_18, :mingw_19]

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -172,25 +172,15 @@ module Pkg
       end
 
       def default_project_root
-        # It is really quite unsafe to assume github.com/puppetlabs/packaging has been
-        # cloned into $project_root/ext/packaging even if it has _always_ been the
-        # default location. We really don't have much choice as of this moment but to
-        # assume this directory, or assume the user has passed in the correct one via
-        # ENV['PROJECT_ROOT']. It is critical we have the correct $project_root, because
-        # we get all of the package versioning from the `git-describe` of $project. If we
-        # assume $project/ext/packaging, it means packaging/lib/packaging.rb is
-        # three subdirectories below $project_root, e.g.,
-        # $project_root/ext/packaging/lib/packaging.rb.
+        # Assume that either PROJECT_ROOT has been set, or we're running from the
+        # project root
         #
         ENV['PROJECT_ROOT'] || Dir.pwd
       end
 
       def default_packaging_root
-        # It is really quite unsafe to assume github.com/puppetlabs/packaging has been
-        # cloned into $project_root/ext/packaging even if it has _always_ been the
-        # default location. Here we use the PACKAGING_ROOT constant defined in
-        # packaging.rake if it is available, or use the parent directory of the
-        # current file as the packaging_root.
+        # Assume that PACKAGING_ROOT has been set, or set the PACKAGING_ROOT to
+        # one directory above the LIBDIR
         #
         defined?(PACKAGING_ROOT) ? File.expand_path(PACKAGING_ROOT) : File.expand_path(File.join(LIBDIR, ".."))
       end

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -182,7 +182,7 @@ module Pkg
         # three subdirectories below $project_root, e.g.,
         # $project_root/ext/packaging/lib/packaging.rb.
         #
-        ENV['PROJECT_ROOT'] || File.expand_path(File.join(LIBDIR, "..", "..", ".."))
+        ENV['PROJECT_ROOT'] || Dir.pwd
       end
 
       def default_packaging_root

--- a/lib/packaging/util/rake_utils.rb
+++ b/lib/packaging/util/rake_utils.rb
@@ -61,7 +61,7 @@ module Pkg::Util::RakeUtils
       end
     end
 
-    def load_packaging_tasks(packaging_root = Pkg::Config.packaging_root)
+    def load_packaging_tasks(packaging_root = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..')))
       packaging_task_dir = File.join(packaging_root, 'tasks')
       tasks = [
         '00_utils.rake',

--- a/lib/packaging/util/rake_utils.rb
+++ b/lib/packaging/util/rake_utils.rb
@@ -61,7 +61,7 @@ module Pkg::Util::RakeUtils
       end
     end
 
-    def load_packaging_tasks(packaging_root = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..')))
+    def load_packaging_tasks(packaging_root = Pkg::Config.packaging_root)
       packaging_task_dir = File.join(packaging_root, 'tasks')
       tasks = [
         '00_utils.rake',

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -11,8 +11,9 @@ Gem::Specification.new do |gem|
   gem.homepage = 'http://github.com/puppetlabs/packaging'
 
   gem.add_development_dependency('rspec', ['~> 2.14.1'])
-  gem.add_development_dependency('rake', ['~> 0.9.6'])
   gem.add_development_dependency('rubocop', ['~> 0.24.1'])
+  gem.add_runtime_dependency('rake')
+  gem.add_runtime_dependency('artifactory')
   gem.require_path = 'lib'
 
   # Ensure the gem is built out of versioned files


### PR DESCRIPTION
This makes the needed changes to enable packaging to ship as a gem. In
my testing this also works for projects that are still using packaging
as a github repo, so it will allow projects to start moving to a gem
over time.