### PR TITLE
(maint) packaging doesn't recognize source platform tags

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -291,7 +291,7 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
 
 
     # For platform names with a dash in them, because everything is special
-    supported_arches = arches_for_platform_version(platform, version)
+    supported_arches = arches_for_platform_version(platform, version, true)
     architecture = platform_tag.sub(/^(#{platform}-#{version}|#{codename})-?/, '')
 
     fail unless supported_arches.include?(architecture) || architecture.empty?
@@ -389,9 +389,9 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
   end
 
   # Given a debian codename, return the arches that we build for that codename
-  def arches_for_codename(codename)
+  def arches_for_codename(codename, include_source = false)
     platform, version = codename_to_platform_version(codename)
-    arches_for_platform_version(platform, version)
+    arches_for_platform_version(platform, version, include_source)
   end
 
   # Given a codename, return an array of associated tags
@@ -406,15 +406,17 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
 
   # Given a platform and version, return the arches that we build for that
   # platform
-  def arches_for_platform_version(platform, version)
+  def arches_for_platform_version(platform, version, include_source = false)
     platform_architectures = get_attribute_for_platform_version(platform, version, :architectures)
     # get_attribute_for_platform_version will raise an exception if the attribute
     # isn't found. We don't want this to be a fatal error, we just want to append
     # the source architecture if it's found
-    begin
-      source_architecture = Array(get_attribute_for_platform_version(platform, version, :source_architecture))
-    rescue
-      source_architecture = []
+    source_architecture = []
+    if include_source
+      begin
+        source_architecture = Array(get_attribute_for_platform_version(platform, version, :source_architecture))
+      rescue
+      end
     end
     return (platform_architectures + source_architecture).flatten
   end

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -407,7 +407,16 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
   # Given a platform and version, return the arches that we build for that
   # platform
   def arches_for_platform_version(platform, version)
-    get_attribute_for_platform_version(platform, version, :architectures)
+    platform_architectures = get_attribute_for_platform_version(platform, version, :architectures)
+    # get_attribute_for_platform_version will raise an exception if the attribute
+    # isn't found. We don't want this to be a fatal error, we just want to append
+    # the source architecture if it's found
+    begin
+      source_architecture = Array(get_attribute_for_platform_version(platform, version, :source_architecture))
+    rescue
+      source_architecture = []
+    end
+    return (platform_architectures + source_architecture).flatten
   end
 
   # Returns an array of all currently valid platform tags

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -59,19 +59,27 @@ describe 'Pkg::Platforms' do
 
   describe '#arches_for_codename' do
     it 'should return an array of arches corresponding to a given codename' do
-      expect(Pkg::Platforms.arches_for_codename('trusty')).to match_array(['i386', 'amd64', 'source'])
+      expect(Pkg::Platforms.arches_for_codename('trusty')).to match_array(['i386', 'amd64'])
+    end
+
+    it 'should be able to include source archietectures' do
+      expect(Pkg::Platforms.arches_for_codename('trusty', true)).to match_array(['i386', 'amd64', 'source'])
     end
   end
 
   describe '#codename_to_tags' do
     it 'should return an array of platform tags corresponding to a given codename' do
-      expect(Pkg::Platforms.codename_to_tags('trusty')).to match_array(['ubuntu-14.04-i386', 'ubuntu-14.04-amd64', 'ubuntu-14.04-source'])
+      expect(Pkg::Platforms.codename_to_tags('trusty')).to match_array(['ubuntu-14.04-i386', 'ubuntu-14.04-amd64'])
     end
   end
 
   describe '#arches_for_platform_version' do
     it 'should return an array of arches for a given platform and version' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '11')).to match_array(['i386', 'x86_64', 's390x', 'SRPMS'])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '11')).to match_array(['i386', 'x86_64', 's390x'])
+    end
+
+    it 'should be able to include source architectures' do
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '11', true)).to match_array(['i386', 'x86_64', 's390x', 'SRPMS'])
     end
   end
 

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -59,19 +59,19 @@ describe 'Pkg::Platforms' do
 
   describe '#arches_for_codename' do
     it 'should return an array of arches corresponding to a given codename' do
-      expect(Pkg::Platforms.arches_for_codename('trusty')).to match_array(['i386', 'amd64'])
+      expect(Pkg::Platforms.arches_for_codename('trusty')).to match_array(['i386', 'amd64', 'source'])
     end
   end
 
   describe '#codename_to_tags' do
     it 'should return an array of platform tags corresponding to a given codename' do
-      expect(Pkg::Platforms.codename_to_tags('trusty')).to match_array(['ubuntu-14.04-i386', 'ubuntu-14.04-amd64'])
+      expect(Pkg::Platforms.codename_to_tags('trusty')).to match_array(['ubuntu-14.04-i386', 'ubuntu-14.04-amd64', 'ubuntu-14.04-source'])
     end
   end
 
   describe '#arches_for_platform_version' do
     it 'should return an array of arches for a given platform and version' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '11')).to match_array(['i386', 'x86_64', 's390x'])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '11')).to match_array(['i386', 'x86_64', 's390x', 'SRPMS'])
     end
   end
 
@@ -127,6 +127,8 @@ describe 'Pkg::Platforms' do
       'xenial' => ['ubuntu', '16.04', ''],
       'windows-2012' => ['windows', '2012', ''],
       'redhat-fips-7-x86_64' => ['redhat-fips', '7', 'x86_64'],
+      'el-7-SRPMS' => ['el', '7', 'SRPMS'],
+      'ubuntu-14.04-source' => ['ubuntu', '14.04', 'source'],
     }
 
     fail_cases = [
@@ -136,6 +138,8 @@ describe 'Pkg::Platforms' do
       'windows-x86',
       'el-7-notarch',
       'debian-7-x86_64',
+      'el-7-source',
+      'debian-7-SRPMS',
     ]
 
     test_cases.each do |platform_tag, results|


### PR DESCRIPTION
When compiling the list of valid architectures to validate a platform
tag, it doesn't include source architectures. This means that things
like `el-7-SRPMS` and `ubuntu-14.04-source` are not recognized as valid
platform tags.