### PR TITLE
(maint) Missing `require 'time'` in gemspec

### DIFF
--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -1,3 +1,5 @@
+require 'time'
+
 Gem::Specification.new do |gem|
   gem.name    = 'packaging'
   gem.version = %x(git describe --tags).gsub('-', '.').chomp


### PR DESCRIPTION
That's needed to do `Date.today.to_s`.