### PR TITLE
(maint) Specify path for remote bundle installs

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -351,7 +351,7 @@ module Pkg::Util::Net
       tarball_name = File.basename(tarball).gsub('.tar.gz', '')
       Pkg::Util::Net.rsync_to(tarball, host, '/tmp')
       appendix = Pkg::Util.rand_string
-      Pkg::Util::Net.remote_ssh_cmd(host, "#{tar} -zxvf /tmp/#{tarball_name}.tar.gz -C /tmp/ ; git clone --recursive /tmp/#{tarball_name} /tmp/#{Pkg::Config.project}-#{appendix} ; cd /tmp/#{Pkg::Config.project}-#{appendix} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install; bundle exec rake package:bootstrap")
+      Pkg::Util::Net.remote_ssh_cmd(host, "#{tar} -zxvf /tmp/#{tarball_name}.tar.gz -C /tmp/ ; git clone --recursive /tmp/#{tarball_name} /tmp/#{Pkg::Config.project}-#{appendix} ; cd /tmp/#{Pkg::Config.project}-#{appendix} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle exec rake package:bootstrap")
       "/tmp/#{Pkg::Config.project}-#{appendix}"
     end
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -21,7 +21,7 @@ namespace :pl do
       remote_repo   = Pkg::Util::Net.remote_bootstrap(signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(signing_server, Pkg::Config)
       Pkg::Util::Net.rsync_to('repos', signing_server, remote_repo)
-      Pkg::Util::Net.remote_ssh_cmd(signing_server, "cd #{remote_repo} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install; bundle exec rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}")
+      Pkg::Util::Net.remote_ssh_cmd(signing_server, "cd #{remote_repo} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle exec rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}")
       Pkg::Util::Net.rsync_from("#{remote_repo}/repos/", signing_server, target)
       Pkg::Util::Net.remote_ssh_cmd(signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(signing_server, "rm #{build_params}")

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -216,7 +216,7 @@ namespace :pl do
       remote_repo   = Pkg::Util::Net.remote_bootstrap(Pkg::Config.signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(Pkg::Config.signing_server, Pkg::Config)
       Pkg::Util::Net.rsync_to('pkg', Pkg::Config.signing_server, remote_repo)
-      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "cd #{remote_repo} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install; bundle exec rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}")
+      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "cd #{remote_repo} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle exec rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}")
       Pkg::Util::Net.rsync_from("#{remote_repo}/pkg/", Pkg::Config.signing_server, "pkg/")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm #{build_params}")


### PR DESCRIPTION
This commit adds `.bundle/gems` as the path to install gems when executing remote rake tasks. Previously, `bundle install` could fail because the user did not have write permission to the default path.