### PR TITLE
(RE-10238) FOSS_ONLY doesn't retrieve tarballs

### DIFF
--- a/lib/packaging/retrieve.rb
+++ b/lib/packaging/retrieve.rb
@@ -48,7 +48,7 @@ module Pkg::Retrieve
     unless Pkg::Config.foss_platforms
       fail "FOSS_ONLY specified, but I don't know anything about FOSS_PLATFORMS. Retrieve cancelled."
     end
-    default_wget(local_target, "#{build_url}/artifacts/#{Pkg::Config.ref}.yaml")
+    default_wget(local_target, "#{build_url}/artifacts/", { 'level' => 1 })
     yaml_path = File.join(local_target, "#{Pkg::Config.ref}.yaml")
     unless File.readable?(yaml_path)
       fail "Couldn't read #{Pkg::Config.ref}.yaml, which is necessary for FOSS_ONLY. Retrieve cancelled."

--- a/spec/lib/packaging/retrieve_spec.rb
+++ b/spec/lib/packaging/retrieve_spec.rb
@@ -28,6 +28,44 @@ describe 'Pkg::Retrieve' do
     allow(Pkg::Util::Serialization).to receive(:load_yaml).and_return(platform_data)
   end
 
+  describe '#default_wget_command' do
+    let(:options) { [
+      "--quiet",
+      "--recursive",
+      "--no-parent",
+      "--no-host-directories",
+      "--level=0",
+      "--cut-dirs=3",
+      "--directory-prefix=#{local_target}",
+      "--reject='index*",
+    ] }
+    before :each do
+      allow(Pkg::Util::Tool).to receive(:check_tool).with('wget').and_return('wget')
+    end
+    context 'when no options passed' do
+      it 'should include default options' do
+        options.each do |option|
+          expect(Pkg::Retrieve.default_wget_command(local_target, build_url)).to include(option)
+        end
+      end
+    end
+    context 'when options are passed' do
+      it 'should add to existing options' do
+        options.push('--convert-links')
+        options.each do |option|
+          expect(Pkg::Retrieve.default_wget_command(local_target, build_url, {'convert-links' => true})).to include(option)
+        end
+      end
+      it 'should replace default values' do
+        options.push('--level=1').delete('--level=0')
+        expect(Pkg::Retrieve.default_wget_command(local_target, build_url, {'level' => 1})).to_not include('--level=0')
+        options.each do |option|
+          expect(Pkg::Retrieve.default_wget_command(local_target, build_url, {'level' => 1})).to include(option)
+        end
+      end
+    end
+  end
+
   describe '#foss_only_retrieve' do
     it 'should fail without foss_platforms' do
       allow(Pkg::Config).to receive(:foss_platforms).and_return(nil)


### PR DESCRIPTION
This PR adds `'level' => 1` as an option to `foss_only_retrieve` to ensure that all top-level artifacts (including source tarballs) are retrieved before platform-specific artifacts.