### PR TITLE
(RE-10247) Clojure project signing bundles don't have Gemfiles

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -21,7 +21,16 @@ namespace :pl do
       remote_repo   = Pkg::Util::Net.remote_bootstrap(signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(signing_server, Pkg::Config)
       Pkg::Util::Net.rsync_to('repos', signing_server, remote_repo)
-      Pkg::Util::Net.remote_ssh_cmd(signing_server, "cd #{remote_repo} ; bundle_prefix= ; if [[ -r Gemfile ]]; then source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle_prefix='bundle exec'; fi ; $bundle_prefix rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}")
+      rake_command = <<-DOC
+cd #{remote_repo} ;
+bundle_prefix= ;
+if [[ -r Gemfile ]]; then
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems;
+  bundle_prefix='bundle exec';
+fi ;
+$bundle_prefix rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}
+DOC
+      Pkg::Util::Net.remote_ssh_cmd(signing_server, rake_command)
       Pkg::Util::Net.rsync_from("#{remote_repo}/repos/", signing_server, target)
       Pkg::Util::Net.remote_ssh_cmd(signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(signing_server, "rm #{build_params}")

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -21,7 +21,7 @@ namespace :pl do
       remote_repo   = Pkg::Util::Net.remote_bootstrap(signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(signing_server, Pkg::Config)
       Pkg::Util::Net.rsync_to('repos', signing_server, remote_repo)
-      Pkg::Util::Net.remote_ssh_cmd(signing_server, "cd #{remote_repo} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle exec rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}")
+      Pkg::Util::Net.remote_ssh_cmd(signing_server, "cd #{remote_repo} ; bundle_prefix= ; if [[ -r Gemfile ]]; then source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle_prefix='bundle exec'; fi ; $bundle_prefix rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}")
       Pkg::Util::Net.rsync_from("#{remote_repo}/repos/", signing_server, target)
       Pkg::Util::Net.remote_ssh_cmd(signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(signing_server, "rm #{build_params}")

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -216,7 +216,7 @@ namespace :pl do
       remote_repo   = Pkg::Util::Net.remote_bootstrap(Pkg::Config.signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(Pkg::Config.signing_server, Pkg::Config)
       Pkg::Util::Net.rsync_to('pkg', Pkg::Config.signing_server, remote_repo)
-      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "cd #{remote_repo} ; source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle exec rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}")
+      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "cd #{remote_repo} ; bundle_prefix= ; if [[ -r Gemfile ]]; then source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle_prefix='bundle exec'; fi ; $bundle_prefix rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}")
       Pkg::Util::Net.rsync_from("#{remote_repo}/pkg/", Pkg::Config.signing_server, "pkg/")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm #{build_params}")

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -216,7 +216,16 @@ namespace :pl do
       remote_repo   = Pkg::Util::Net.remote_bootstrap(Pkg::Config.signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(Pkg::Config.signing_server, Pkg::Config)
       Pkg::Util::Net.rsync_to('pkg', Pkg::Config.signing_server, remote_repo)
-      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "cd #{remote_repo} ; bundle_prefix= ; if [[ -r Gemfile ]]; then source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems; bundle_prefix='bundle exec'; fi ; $bundle_prefix rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}")
+      rake_command = <<-DOC
+cd #{remote_repo} ;
+bundle_prefix= ;
+if [[ -r Gemfile ]]; then
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems;
+  bundle_prefix='bundle exec';
+fi ;
+$bundle_prefix rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}
+DOC
+      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, rake_command)
       Pkg::Util::Net.rsync_from("#{remote_repo}/pkg/", Pkg::Config.signing_server, "pkg/")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm #{build_params}")


### PR DESCRIPTION
This commit adds a check for Gemfile to the rake tasks that are executed
remotely. Previously, these commands would attempt a `bundle install` and then
fail if no Gemfile was found. Since not all projects are ready to use packaging
as a gem, we need to support the old method of using packaging (bootstrapping).