### PR TITLE
Initial support for PE release branches

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -371,17 +371,27 @@ module Pkg
       end
 
       def yum_target_path(feature_branch = false)
+        target_path = "#{Pkg::Config.yum_repo_path}/#{Pkg::Config.pe_version}"
+        # Target path is different for feature (PEZ) or release branches
         if feature_branch || Pkg::Config.pe_feature_branch
-          return "#{Pkg::Config.yum_repo_path}/#{Pkg::Config.pe_version}/feature/repos/"
+          return "#{target_path}/feature/repos/"
+        elsif Pkg::Config.pe_release_branch
+          return "#{target_path}/release/repos/"
+        else
+          return "#{target_path}/repos/"
         end
-        "#{Pkg::Config.yum_repo_path}/#{Pkg::Config.pe_version}/repos/"
       end
 
       def apt_target_path(feature_branch = false)
+        target_path = "#{Pkg::Config.apt_repo_path}/#{Pkg::Config.pe_version}"
+        # Target path is different for feature (PEZ) or release branches
         if feature_branch || Pkg::Config.pe_feature_branch
-          return "#{Pkg::Config.apt_repo_path}/#{Pkg::Config.pe_version}/feature/repos/"
+          return "#{target_path}/feature/repos/"
+        elsif Pkg::Config.pe_release_branch
+          return "#{target_path}/release/repos/"
+        else
+          return "#{target_path}/repos/"
         end
-        "#{Pkg::Config.apt_repo_path}/#{Pkg::Config.pe_version}/repos/"
       end
     end
   end

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -121,6 +121,7 @@ module Pkg::Params
                   :packaging_url,
                   :pbuild_conf,
                   :pe_feature_branch,
+                  :pe_release_branch,
                   :pe_name,
                   :pe_platforms,
                   :pe_version,
@@ -286,6 +287,7 @@ module Pkg::Params
               { :var => :msi_signing_cert,        :val => '$MSI_SIGNING_CERT' },
               { :var => :msi_signing_cert_pw,     :val => '$MSI_SIGNING_CERT_PW' },
               { :var => :pe_feature_branch,       :val => false },
+              { :var => :pe_release_branch,       :val => false },
               { :var => :s3_ship,                 :val => false },
               { :var => :apt_releases,            :val => Pkg::Platforms.codenames("deb") }]
 


### PR DESCRIPTION
This adds a new config variable for PE release branches,
and updates the ship tasks to ship to the correct locations
depending on release branch (vs feature or mainline)