### PR TITLE
(maint) Separate nightly repo updates

### DIFF
--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -51,5 +51,29 @@ module Pkg::Repo
     rescue => e
       fail "Could not populate repos directory in #{Pkg::Config.distribution_server}:#{artifact_parent_directory}"
     end
+
+    def update_yum_repo(repo_name, repo_path, repo_host, command)
+      fail "At least one of your arguments is nil, update your build_defaults?" unless repo_name && repo_path && repo_host && command
+      yum_whitelist = {
+        __REPO_NAME__: repo_name,
+        __REPO_PATH__: repo_path,
+        __REPO_HOST__: repo_host,
+        __GPG_KEY__: Pkg::Util::Gpg.key
+      }
+      Pkg::Util::Net.remote_ssh_cmd(repo_host, Pkg::Util::Misc.search_and_replace(command, yum_whitelist))
+    end
+
+    def update_apt_repo(repo_name, repo_path, repo_host, repo_url, command)
+      fail "At least one of your arguments is nil, update your build_defaults?" unless repo_name && repo_path && repo_host && repo_url && command
+      apt_whitelist = {
+        __REPO_NAME__: repo_name,
+        __REPO_PATH__: repo_path,
+        __REPO_HOST__: repo_host,
+        __REPO_URL__: repo_url,
+        __APT_PLATFORMS__: Pkg::Config.apt_releases.join(' '),
+        __GPG_KEY__: Pkg::Util::Gpg.key
+      }
+      Pkg::Util::Net.remote_ssh_cmd(repo_host, Pkg::Util::Misc.search_and_replace(command, apt_whitelist))
+    end
   end
 end

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -94,4 +94,47 @@ describe "#Pkg::Repo" do
       Pkg::Repo.create_all_repo_archives("project", "version")
     end
   end
+
+  describe "#update_yum_repo" do
+    let(:yum_repo_command) { "some command with __REPO_NAME__ and __REPO_PATH__ and stuff" }
+    let(:repo_name) { 'puppet5' }
+    let(:repo_path) { '/opt/repository/yum' }
+    let(:repo_host) { 'weth.delivery.puppetlabs.net' }
+
+    before(:each) do
+      allow(Pkg::Util::Gpg).to receive(:key)
+    end
+
+    it 'should fail if any params are nil' do
+      expect{ Pkg::Repo.update_yum_repo(repo_name, nil, repo_host, yum_repo_command) }.to raise_error(RuntimeError, /one of your arguments is nil/)
+    end
+
+    it 'should execute remote_ssh_cmd' do
+      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(repo_host, "some command with #{repo_name} and #{repo_path} and stuff")
+      Pkg::Repo.update_yum_repo(repo_name, repo_path, repo_host, yum_repo_command)
+    end
+  end
+
+  describe "#update_apt_repo" do
+    let(:apt_repo_command) { "some command with __APT_PLATFORMS__ and __REPO_URL__ and stuff" }
+    let(:repo_name) { 'puppet5' }
+    let(:repo_path) { '/opt/repository/apt' }
+    let(:repo_host) { 'weth.delivery.puppetlabs.net' }
+    let(:repo_url)  { 'http://apt.puppetlabs.com' }
+    let(:apt_releases) { ['stretch', 'trusty', 'xenial'] }
+
+    before(:each) do
+      allow(Pkg::Util::Gpg).to receive(:key)
+      allow(Pkg::Config).to receive(:apt_releases).and_return(apt_releases)
+    end
+
+    it 'should fail if any params are nil' do
+      expect{ Pkg::Repo.update_apt_repo(nil, repo_path, repo_host, nil, apt_repo_command) }.to raise_error(RuntimeError, /one of your arguments is nil/)
+    end
+
+    it 'should execute remote_ssh_cmd' do
+      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(repo_host, "some command with #{apt_releases.join(' ')} and #{repo_url} and stuff")
+      Pkg::Repo.update_apt_repo(repo_name, repo_path, repo_host, repo_url, apt_repo_command)
+    end
+  end
 end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -267,7 +267,7 @@ namespace :pl do
 
     task :ship_nightlies => "pl:fetch" do
       Rake::Task['pl:jenkins:uber_ship_lite'].invoke
-      Rake::Task['pl:remote:update_foss_repos'].invoke
+      Rake::Task['pl:remote:update_nightly_repos'].invoke
       Rake::Task['pl:remote:deploy_nightlies_to_s3'].invoke
     end
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -12,20 +12,11 @@ namespace :pl do
       else
         path = Pkg::Config.nonfinal_yum_repo_path || Pkg::Config.yum_repo_path
       end
-      yum_whitelist = {
-        __REPO_NAME__: Pkg::Paths.repo_name,
-        __REPO_PATH__: path,
-        __REPO_HOST__: Pkg::Config.yum_staging_server,
-        __GPG_KEY__: Pkg::Util::Gpg.key
-      }
+      command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
 
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        if Pkg::Config.yum_repo_command
-          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_staging_server, Pkg::Util::Misc.search_and_replace(Pkg::Config.yum_repo_command, yum_whitelist))
-        else
-          Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_staging_server, 'rake -f /opt/repository/Rakefile mk_repo')
-        end
+        Pkg::Repo.update_yum_repo(Pkg::Paths.repo_name, path, Pkg::Config.yum_staging_server, command)
       end
     end
 
@@ -40,28 +31,10 @@ namespace :pl do
         path = Pkg::Config.nonfinal_apt_repo_path || Pkg::Config.apt_repo_path
         cmd = Pkg::Config.nonfinal_apt_repo_command || Pkg::Config.apt_repo_command
       end
-      apt_whitelist = {
-        __REPO_NAME__: Pkg::Paths.repo_name,
-        __REPO_PATH__: path,
-        __REPO_URL__: Pkg::Config.apt_repo_url,
-        __REPO_HOST__: Pkg::Config.apt_host,
-        __APT_PLATFORMS__: Pkg::Config.apt_releases.join(' '),
-        __GPG_KEY__: Pkg::Util::Gpg.key
-      }
 
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        if cmd
-          Pkg::Util::Net.remote_ssh_cmd(
-            Pkg::Config.apt_signing_server,
-            Pkg::Util::Misc.search_and_replace(
-              cmd,
-              apt_whitelist
-            )
-          )
-        else
-          warn %(Pkg::Config#apt_repo_command returned something unexpected, so no attempt will be made to update remote repos)
-        end
+        Pkg::Repo.update_apt_repo(Pkg::Paths.repo_name, path, Pkg::Config.apt_host, Pkg::Config.apt_repo_url, cmd)
       end
     end
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -7,16 +7,19 @@ namespace :pl do
 
     desc "Update remote yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_yum_repo: 'pl:fetch' do
-      if Pkg::Util::Version.final?
-        path = Pkg::Config.yum_repo_path
-      else
-        path = Pkg::Config.nonfinal_yum_repo_path || Pkg::Config.yum_repo_path
-      end
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
-
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_yum_repo(Pkg::Paths.repo_name, path, Pkg::Config.yum_staging_server, command)
+        Pkg::Repo.update_yum_repo(Pkg::Config.repo_name, Pkg::Config.yum_repo_path, Pkg::Config.yum_staging_server, command)
+      end
+    end
+
+    desc "Update nightlies yum repository on '#{Pkg::Config.yum_staging_server}'"
+    task update_nightlies_yum_repo: 'pl:fetch' do
+      command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
+      $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
+      if Pkg::Util.ask_yes_or_no
+        Pkg::Repo.update_yum_repo(Pkg::Config.nonfinal_repo_name, Pkg::Config.nonfinal_yum_repo_path, Pkg::Config.yum_staging_server, command)
       end
     end
 
@@ -24,17 +27,17 @@ namespace :pl do
 
     desc "Update remote apt repository on '#{Pkg::Config.apt_signing_server}'"
     task update_apt_repo: 'pl:fetch' do
-      if Pkg::Util::Version.final?
-        path = Pkg::Config.apt_repo_path
-        cmd = Pkg::Config.apt_repo_command
-      else
-        path = Pkg::Config.nonfinal_apt_repo_path || Pkg::Config.apt_repo_path
-        cmd = Pkg::Config.nonfinal_apt_repo_command || Pkg::Config.apt_repo_command
-      end
-
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_apt_repo(Pkg::Paths.repo_name, path, Pkg::Config.apt_host, Pkg::Config.apt_repo_url, cmd)
+        Pkg::Repo.update_apt_repo(Pkg::Config.repo_name, Pkg::Config.apt_repo_path, Pkg::Config.apt_host, Pkg::Config.apt_repo_url, Pkg::Config.apt_repo_command)
+      end
+    end
+
+    desc "Update nightlies apt repository on '#{Pkg::Config.apt_signing_server}'"
+    task update_nightlies_apt_repo: 'pl:fetch' do
+      $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
+      if Pkg::Util.ask_yes_or_no
+        Pkg::Repo.update_apt_repo(Pkg::Config.nonfinal_repo_name, Pkg::Config.nonfinal_apt_repo_path, Pkg::Config.apt_host, Pkg::Config.apt_repo_url, Pkg::Config.nonfinal_apt_repo_command)
       end
     end
 
@@ -42,6 +45,12 @@ namespace :pl do
     task :update_foss_repos => "pl:fetch" do
       Rake::Task['pl:remote:update_apt_repo'].invoke
       Rake::Task['pl:remote:update_yum_repo'].invoke
+    end
+
+    desc "Update nightlies apt and yum repos"
+    task :update_nightly_repos => "pl:fetch" do
+      Rake::Task['pl:remote:update_nightlies_apt_repo'].invoke
+      Rake::Task['pl:remote:update_nightlies_yum_repo'].invoke
     end
 
     desc "Update remote ips repository on #{Pkg::Config.ips_host}"


### PR DESCRIPTION
This PR modifies how we update apt and yum repos to be intentional about whether we are updating final or nonfinal repos, instead of relying on version magic.
See individual commit messages for details.