### PR TITLE
(maint) Only fail repo updates if *required* params are missing

### DIFF
--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -57,7 +57,9 @@ module Pkg::Repo
     end
 
     def update_yum_repo(repo_name, repo_path, repo_host, command)
-      fail "At least one of your arguments is nil, update your build_defaults?" unless repo_name && repo_path && repo_host && command
+      method(__method__).parameters.each do |_, param|
+        fail "Missing required argument #{param}, update your build_defaults?" if argument_required?(param.to_s, command) && binding.local_variable_get(param).to_s.empty?
+      end
       yum_whitelist = {
         __REPO_NAME__: repo_name,
         __REPO_PATH__: repo_path,
@@ -68,7 +70,9 @@ module Pkg::Repo
     end
 
     def update_apt_repo(repo_name, repo_path, repo_host, repo_url, command)
-      fail "At least one of your arguments is nil, update your build_defaults?" unless repo_name && repo_path && repo_host && repo_url && command
+      method(__method__).parameters.each do |_, param|
+        fail "Missing required argument #{param}, update your build_defaults?" if argument_required?(param.to_s, command) && binding.local_variable_get(param).to_s.empty?
+      end
       apt_whitelist = {
         __REPO_NAME__: repo_name,
         __REPO_PATH__: repo_path,

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -52,6 +52,10 @@ module Pkg::Repo
       fail "Could not populate repos directory in #{Pkg::Config.distribution_server}:#{artifact_parent_directory}"
     end
 
+    def argument_required?(argument_name, repo_command)
+      repo_command.include?("__#{argument_name.upcase}__")
+    end
+
     def update_yum_repo(repo_name, repo_path, repo_host, command)
       fail "At least one of your arguments is nil, update your build_defaults?" unless repo_name && repo_path && repo_host && command
       yum_whitelist = {

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -58,10 +58,9 @@ module Pkg::Repo
 
     def update_repo(remote_host, command, options = {})
       fail_message = "Missing required argument '%s', update your build_defaults?"
-      fail fail_message % 'repo_name' if argument_required?('repo_name', command) && !options[:repo_name]
-      fail fail_message % 'repo_path' if argument_required?('repo_path', command) && !options[:repo_path]
-      fail fail_message % 'repo_host' if argument_required?('repo_host', command) && !options[:repo_host]
-      fail fail_message % 'repo_url' if argument_required?('repo_url', command) && !options[:repo_url]
+      [:repo_name, :repo_path, :repo_host, :repo_url].each do |option|
+        fail fail_message % option.to_s if argument_required?(option.to_s, command) && !options[option]
+      end
 
       whitelist = {
         __REPO_NAME__: options[:repo_name],

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -109,32 +109,11 @@ describe "#Pkg::Repo" do
     end
   end
 
-  describe "#update_yum_repo" do
-    let(:yum_repo_command) { "some command with __REPO_NAME__ and __REPO_PATH__ and stuff" }
-    let(:repo_name) { 'puppet5' }
-    let(:repo_path) { '/opt/repository/yum' }
-    let(:repo_host) { 'weth.delivery.puppetlabs.net' }
-
-    before(:each) do
-      allow(Pkg::Util::Gpg).to receive(:key)
-    end
-
-    it 'should fail if required params are nil' do
-      expect{ Pkg::Repo.update_yum_repo(repo_name, nil, repo_host, yum_repo_command) }.to raise_error(RuntimeError, /Missing required argument/)
-    end
-
-    it 'should execute remote_ssh_cmd' do
-      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(repo_host, "some command with #{repo_name} and #{repo_path} and stuff")
-      Pkg::Repo.update_yum_repo(repo_name, repo_path, repo_host, yum_repo_command)
-    end
-  end
-
-  describe "#update_apt_repo" do
-    let(:apt_repo_command) { "some command with __APT_PLATFORMS__ and __REPO_URL__ and stuff" }
+  describe "#update_repo" do
+    let(:remote_host) { 'weth.delivery.puppetlabs.net' }
+    let(:repo_command) { "some command with __REPO_NAME__ and __REPO_PATH__ and stuff" }
     let(:repo_name) { 'puppet5' }
     let(:repo_path) { '/opt/repository/apt' }
-    let(:repo_host) { 'weth.delivery.puppetlabs.net' }
-    let(:repo_url)  { 'http://apt.puppetlabs.com' }
     let(:apt_releases) { ['stretch', 'trusty', 'xenial'] }
 
     before(:each) do
@@ -142,14 +121,13 @@ describe "#Pkg::Repo" do
       allow(Pkg::Config).to receive(:apt_releases).and_return(apt_releases)
     end
 
-    it 'should execute command if optional params are nil' do
-      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(repo_host, "some command with #{apt_releases.join(' ')} and #{repo_url} and stuff")
-      Pkg::Repo.update_apt_repo(repo_name, nil, repo_host, repo_url, apt_repo_command)
+    it 'should fail if required params are nil' do
+      expect{ Pkg::Repo.update_repo(remote_host, repo_command, { :repo_path => repo_path }) }.to raise_error(RuntimeError, /Missing required argument 'repo_name'/)
     end
 
-    it 'should execute remote_ssh_cmd' do
-      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(repo_host, "some command with #{apt_releases.join(' ')} and #{repo_url} and stuff")
-      Pkg::Repo.update_apt_repo(repo_name, repo_path, repo_host, repo_url, apt_repo_command)
+    it 'should execute command if optional params are nil' do
+      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(remote_host, "some command with #{repo_name} and #{repo_path} and stuff")
+      Pkg::Repo.update_repo(remote_host, repo_command, { :repo_name => repo_name, :repo_path => repo_path })
     end
   end
 end

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -119,8 +119,8 @@ describe "#Pkg::Repo" do
       allow(Pkg::Util::Gpg).to receive(:key)
     end
 
-    it 'should fail if any params are nil' do
-      expect{ Pkg::Repo.update_yum_repo(repo_name, nil, repo_host, yum_repo_command) }.to raise_error(RuntimeError, /one of your arguments is nil/)
+    it 'should fail if required params are nil' do
+      expect{ Pkg::Repo.update_yum_repo(repo_name, nil, repo_host, yum_repo_command) }.to raise_error(RuntimeError, /Missing required argument/)
     end
 
     it 'should execute remote_ssh_cmd' do
@@ -142,8 +142,9 @@ describe "#Pkg::Repo" do
       allow(Pkg::Config).to receive(:apt_releases).and_return(apt_releases)
     end
 
-    it 'should fail if any params are nil' do
-      expect{ Pkg::Repo.update_apt_repo(nil, repo_path, repo_host, nil, apt_repo_command) }.to raise_error(RuntimeError, /one of your arguments is nil/)
+    it 'should execute command if optional params are nil' do
+      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(repo_host, "some command with #{apt_releases.join(' ')} and #{repo_url} and stuff")
+      Pkg::Repo.update_apt_repo(repo_name, nil, repo_host, repo_url, apt_repo_command)
     end
 
     it 'should execute remote_ssh_cmd' do

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -95,6 +95,20 @@ describe "#Pkg::Repo" do
     end
   end
 
+  describe "#argument_required?" do
+    let(:repo_command) { "some command with __REPO_PATH__ but not repo name or anything" }
+    let(:required_arg) { 'repo_path' }
+    let(:optional_arg) { 'repo_name' }
+
+    it 'should return true if command requires arg' do
+      expect(Pkg::Repo.argument_required?(required_arg, repo_command)).to be_true
+    end
+
+    it 'should return false if command does not need arg' do
+      expect(Pkg::Repo.argument_required?(optional_arg, repo_command)).to be_false
+    end
+  end
+
   describe "#update_yum_repo" do
     let(:yum_repo_command) { "some command with __REPO_NAME__ and __REPO_PATH__ and stuff" }
     let(:repo_name) { 'puppet5' }

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -10,16 +10,16 @@ namespace :pl do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_yum_repo(Pkg::Config.repo_name, Pkg::Config.yum_repo_path, Pkg::Config.yum_staging_server, command)
+        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => Pkg::Config.repo_name, :repo_path => Pkg::Config.yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
       end
     end
 
     desc "Update nightlies yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_nightlies_yum_repo: 'pl:fetch' do
-      command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
+      command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository-nightlies/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_yum_repo(Pkg::Config.nonfinal_repo_name, Pkg::Config.nonfinal_yum_repo_path, Pkg::Config.yum_staging_server, command)
+        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => Pkg::Config.nonfinal_repo_name, :repo_path => Pkg::Config.nonfinal_yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
       end
     end
 
@@ -29,7 +29,7 @@ namespace :pl do
     task update_apt_repo: 'pl:fetch' do
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_apt_repo(Pkg::Config.repo_name, Pkg::Config.apt_repo_path, Pkg::Config.apt_host, Pkg::Config.apt_repo_url, Pkg::Config.apt_repo_command)
+        Pkg::Repo.update_repo(Pkg::Config.apt_staging_server, Pkg::Config.apt_repo_command, { :repo_name => Pkg::Config.repo_name, :repo_path => Pkg::Config.apt_repo_path, :repo_host => Pkg::Config.apt_repo_host, :repo_url => Pkg::Config.apt_repo_url })
       end
     end
 
@@ -37,7 +37,7 @@ namespace :pl do
     task update_nightlies_apt_repo: 'pl:fetch' do
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_apt_repo(Pkg::Config.nonfinal_repo_name, Pkg::Config.nonfinal_apt_repo_path, Pkg::Config.apt_host, Pkg::Config.apt_repo_url, Pkg::Config.nonfinal_apt_repo_command)
+        Pkg::Repo.update_repo(Pkg::Config.apt_staging_server, Pkg::Config.nonfinal_apt_repo_command, { :repo_name => Pkg::Config.nonfinal_repo_name, :repo_path => Pkg::Config.nonfinal_apt_repo_path, :repo_host => Pkg::Config.apt_repo_host, :repo_url => Pkg::Config.apt_repo_url })
       end
     end
 


### PR DESCRIPTION
This PR updates the update_repo methods to not fail if nil arguments are not required by the repo command.