### PR TITLE
(RE-10318) Stop shipping noarch packages to unsupported arches

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -82,25 +82,24 @@ namespace :pl do
     # Create a hash mapping full paths to basenames.
     # This will allow us to keep track of the different paths that may be
     # associated with a single basename, e.g. noarch packages.
-    hash = {}
-    all_rpms = Dir["#{rpm_dir}/**/*.rpm"]
-    all_rpms.each do |fullpath|
-      hash[fullpath] = File.basename(fullpath)
+    all_rpms = {}
+    rpms_to_sign = Dir["#{rpm_dir}/**/*.rpm"]
+    rpms_to_sign.each do |rpm_path|
+      all_rpms[rpm_path] = File.basename(rpm_path)
     end
-    # Delete a package, both from the signing server and from the hash, if
+    # Delete a package, both from the signing server and from the rpm array, if
     # there are other packages with the same basename so that we only sign the
     # package once.
-    all_rpms.each do |rpm|
-      if hash.values.count(File.basename(rpm)) > 1
-        FileUtils.rm_rf(rpm)
-        hash.delete(rpm)
+    all_rpms.each do |rpm_path, rpm_filename|
+      if rpms_to_sign.map { |rpm| File.basename(rpm) }.count(rpm_filename) > 1
+        FileUtils.rm(rpm_path)
+        rpms_to_sign.delete(rpm_path)
       end
     end
-    unique_rpms = hash.keys
 
     v3_rpms = []
     v4_rpms = []
-    unique_rpms.each do |rpm|
+    rpms_to_sign.each do |rpm|
       platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
       platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
 
@@ -128,20 +127,15 @@ namespace :pl do
       sign_rpm(v4_rpms.join(' '))
     end
 
-    # Now we hardlink them back in
-    Dir["#{rpm_dir}/**/*.noarch.rpm"].each do |rpm|
-      platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
-      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
-      supported_arches = Pkg::Platforms.arches_for_platform_version(platform, version)
-      cd File.dirname(rpm) do
-        noarch_rpm = File.basename(rpm)
-        supported_arches.each do |arch|
-          arch_dir = File.join('..', arch)
-          FileUtils.mkdir_p(arch_dir)
-          unless File.exist?(File.join(arch_dir, noarch_rpm))
-            FileUtils.ln(noarch_rpm, arch_dir, :force => true, :verbose => true)
-          end
-        end
+    # Using the map of paths to basenames, we re-hardlink the rpms we deleted.
+    all_rpms.each do |link_path, rpm_filename|
+      next if File.exist? link_path
+      FileUtils.mkdir_p(File.dirname(link_path))
+      # Find paths where the signed rpm has the same basename, but different
+      # full path, as the one we need to link.
+      paths_to_link_to = rpms_to_sign.select { |rpm| File.basename(rpm) == rpm_filename && rpm != link_path }
+      paths_to_link_to.each do |path|
+        FileUtils.ln(path, link_path, :force => true, :verbose => true)
       end
     end
   end


### PR DESCRIPTION
This commit changes how we link noarch packages after signing to only link to the arch where the package came from in the first place.