### PR TITLE
(maint) Add and use separate functions for shipping different package types

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -485,6 +485,14 @@ module Pkg::Platforms # rubocop:disable Metrics/ModuleLength
     platform_tags
   end
 
+  # Return a supported platform tag for the given platform, not caring about
+  # version or architecture
+  def generic_platform_tag(platform)
+    version = versions_for_platform(platform).first
+    arch = arches_for_platform_version(platform, version).first
+    return "#{platform}-#{version}-#{arch}"
+  end
+
   # @method by_deb
   # @return [Array] An Array of Strings, containing all platforms
   #   that use .deb packages

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -105,15 +105,7 @@ module Pkg::Util::Ship
   def ship_rpms(local_staging_directory, remote_path, opts = {})
     ship_pkgs(["#{local_staging_directory}/**/*.rpm", "#{local_staging_directory}/**/*.srpm"], Pkg::Config.yum_staging_server, remote_path, opts)
 
-    # I really don't care which one we grab, it just has to be some supported
-    # version and architecture from the `el` hash. So here we're just grabbing
-    # the first one, parsing out some info, and breaking out of the loop. Not
-    # elegant, I know, but effective. [written by Melissa, copied by Molly]
-    Pkg::Platforms::PLATFORM_INFO['el'].each do |key, value|
-      generic_platform_tag = "el-#{key}-#{value[:architectures[0]]}"
-      create_rolling_repo_link(generic_platform_tag, Pkg::Config.yum_staging_server, remote_path)
-      break
-    end
+    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('el'), Pkg::Config.yum_staging_server, remote_path)
   end
 
   def ship_debs(local_staging_directory, remote_path, opts = {})
@@ -141,15 +133,7 @@ module Pkg::Util::Ship
   def ship_dmg(local_staging_directory, remote_path, opts = {})
     ship_pkgs(["#{local_staging_directory}/**/*.dmg"], Pkg::Config.dmg_staging_server, remote_path, opts)
 
-    # I really don't care which one we grab, it just has to be some supported
-    # version and architecture from the `osx` hash. So here we're just grabbing
-    # the first one, parsing out some info, and breaking out of the loop. Not
-    # elegant, I know, but effective. [written by Melissa, copied by Molly]
-    Pkg::Platforms::PLATFORM_INFO['osx'].each do |key, value|
-      generic_platform_tag = "osx-#{key}-#{value[:architectures][0]}"
-      create_rolling_repo_link(generic_platform_tag, Pkg::Config.dmg_staging_server, remote_path)
-      break
-    end
+    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('osx'), Pkg::Config.dmg_staging_server, remote_path)
 
     Pkgs::Platforms.platform_tags_for_package_format('dmg').each do |platform_tag|
       # TODO remove the PC1 links when we no longer need to maintain them
@@ -164,32 +148,16 @@ module Pkg::Util::Ship
   def ship_swix(local_staging_directory, remote_path, opts = {})
     ship_pkgs(["#{local_staging_directory}/**/*.swix"], Pkg::Config.swix_staging_server, remote_path, opts)
 
-    # I really don't care which one we grab, it just has to be some supported
-    # version and architecture from the `eos` hash. So here we're just grabbing
-    # the first one, parsing out some info, and breaking out of the loop. Not
-    # elegant, I know, but effective. [written by Melissa, copied by Molly]
-    Pkg::Platforms::PLATFORM_INFO['eos'].each do |key, value|
-      generic_platform_tag = "eos-#{key}-#{value[:architectures][0]}"
-      create_rolling_repo_link(generic_platform_tag, Pkg::Config.swix_staging_server, remote_path)
-      break
-    end
+    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('eos'), Pkg::Config.swix_staging_server, remote_path)
   end
 
   def ship_msi(local_staging_directory, remote_path, opts = {})
     ship_pkgs(["#{local_staging_directory}/**/*.msi"], Pkg::Config.msi_staging_server, remote_path, opts)
 
-    # I really don't care which one we grab, it just has to be some supported
-    # version and architecture from the `windows` hash. So here we're just grabbing
-    # the first one, parsing out some info, and breaking out of the loop. Not
-    # elegant, I know, but effective. [written by Melissa, copied by Molly]
-    Pkg::Platforms::PLATFORM_INFO['windows'].each do |key, value|
-      generic_platform_tag = "windows-#{key}-#{value[:architectures][0]}"
-      create_rolling_repo_link(generic_platform_tag, Pkg::Config.msi_staging_server, remote_path)
-      # Create the symlinks for the latest supported repo
-      Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', Pkg::Paths.artifacts_path(generic_platform_tag, remote_path), 'msi', arch: 'x64')
-      Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', Pkg::Paths.artifacts_path(generic_platform_tag, remote_path), 'msi', arch: 'x86')
-      break
-    end
+    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('windows'), Pkg::Config.msi_staging_server, remote_path)
+    # Create the symlinks for the latest supported repo
+    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', Pkg::Paths.artifacts_path(Pkg::Platforms.generic_platform_tag('windows'), remote_path), 'msi', arch: 'x64')
+    Pkg::Util::Net.remote_create_latest_symlink('puppet-agent', Pkg::Paths.artifacts_path(Pkg::Platforms.generic_platform_tag('windows'), remote_path), 'msi', arch: 'x86')
 
     # We provide symlinks to the latest package in a given directory. This
     # allows users to upgrade more easily to the latest version that we release

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -102,6 +102,42 @@ module Pkg::Util::Ship
     end
   end
 
+  def ship_rpms(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/**/*.rpm", "#{local_staging_directory}/**/*.srpm"], Pkg::Config.yum_staging_server, remote_path, opts)
+  end
+
+  def ship_debs(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/**/*.debian.tar.gz", "#{local_staging_directory}/**/*.orig.tar.gz" "#{local_staging_directory}/**/*.dsc", "#{local_staging_directory}/**/*.deb", "#{local_staging_directory}/**/*.changes"], Pkg::Config.apt_signing_server, remote_path, opts)
+  end
+
+  def ship_svr4(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/**/*.pkg.gz"], Pkg::Config.svr4_host, remote_path, opts)
+  end
+
+  def ship_p5p(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/**/*.p5p"], Pkg::Config.p5p_host, remote_path, opts)
+  end
+
+  def ship_dmg(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/**/*.dmg"], Pkg::Config.dmg_staging_server, remote_path, opts)
+  end
+
+  def ship_swix(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/**/*.swix"], Pkg::Config.swix_staging_server, remote_path, opts)
+  end
+
+  def ship_msi(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/**/*.msi"], Pkg::Config.msi_staging_server, remote_path, opts)
+  end
+
+  def ship_gem(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/*.gem*"], Pkg::Config.gem_host, remote_path, opts)
+  end
+
+  def ship_tar(local_staging_directory, remote_path, opts = {})
+    ship_pkgs(["#{local_staging_directory}/*.tar.gz*"], Pkg::Config.tar_staging_server, remote_path, opts)
+  end
+
   def rolling_repo_link_command(platform_tag, repo_path)
     base_path, link_path = Pkg::Paths.artifacts_base_path_and_link_path(platform_tag, repo_path)
 

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -162,4 +162,16 @@ describe 'Pkg::Platforms' do
       end
     end
   end
+
+  describe '#generic_platform_tag' do
+    it 'fails for unsupported platforms' do
+      expect { Pkg::Platforms.generic_platform_tag('butts') }.to raise_error
+    end
+
+    it 'returns a supported platform tag containing the supplied platform' do
+      Pkg::Platforms.supported_platforms.each do |platform|
+        expect(Pkg::Platforms.platform_tags).to include(Pkg::Platforms.generic_platform_tag(platform))
+      end
+    end
+  end
 end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -256,7 +256,7 @@ namespace :pl do
     else
       path = Pkg::Config.nonfinal_yum_repo_path || Pkg::Config.yum_repo_path
     end
-    Pkg::Util::Ship.ship_pkgs(['pkg/**/*.rpm', 'pkg/**/*.srpm'], Pkg::Config.yum_staging_server, path)
+    Pkg::Util::Ship.ship_rpms('pkg', path)
 
     # I really don't care which one we grab, it just has to be some supported
     # version and architecture from the `el` hash. So here we're just grabbing
@@ -276,7 +276,7 @@ namespace :pl do
     else
       staging_path = Pkg::Config.nonfinal_apt_repo_staging_path || Pkg::Config.apt_repo_staging_path
     end
-    Pkg::Util::Ship.ship_pkgs(['pkg/**/*.debian.tar.gz', 'pkg/**/*.orig.tar.gz', 'pkg/**/*.dsc', 'pkg/**/*.deb', 'pkg/**/*.changes'], Pkg::Config.apt_signing_server, staging_path, chattr: false)
+    Pkg::Util::Ship.ship_debs('pkg', staging_path, chattr: false)
 
     # We need to iterate through all the supported platforms here because of
     # how deb repos are set up. Each codename will have its own link from the
@@ -353,7 +353,7 @@ namespace :pl do
     end
 
     Pkg::Util::Execution.retry_on_fail(times: 3) do
-      Pkg::Util::Ship.ship_pkgs(['pkg/*.gem*'], Pkg::Config.gem_host, Pkg::Config.gem_path, platform_independent: true)
+      Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)
     end
   end
 
@@ -366,7 +366,7 @@ namespace :pl do
         else
           path = Pkg::Config.nonfinal_svr4_path || Pkg::Config.svr4_path
         end
-        Pkg::Util::Ship.ship_pkgs(['pkg/**/*.pkg.gz'], Pkg::Config.svr4_host, path)
+        Pkg::Util::Ship.ship_svr4('pkg', path)
       end
     end
   end
@@ -380,7 +380,7 @@ namespace :pl do
         else
           path = Pkg::Config.nonfinal_p5p_path || Pkg::Config.p5p_path
         end
-        Pkg::Util::Ship.ship_pkgs(['pkg/**/*.p5p'], Pkg::Config.p5p_host, path)
+        Pkg::Util::Ship.ship_p5p('pkg', path)
       end
     end
   end
@@ -401,7 +401,7 @@ namespace :pl do
     end
     path = Pkg::Config.nonfinal_dmg_path if Pkg::Config.nonfinal_dmg_path && !Pkg::Util::Version.final?
 
-    Pkg::Util::Ship.ship_pkgs(['pkg/**/*.dmg'], Pkg::Config.dmg_staging_server, path)
+    Pkg::Util::Ship.ship_dmg('pkg', path)
 
     # I really don't care which one we grab, it just has to be some supported
     # version and architecture from the `osx` hash. So here we're just grabbing
@@ -439,7 +439,7 @@ namespace :pl do
     end
     path = Pkg::Config.nonfinal_swix_path if Pkg::Config.nonfinal_swix_path && !Pkg::Util::Version.final?
 
-    Pkg::Util::Ship.ship_pkgs(['pkg/**/*.swix*'], Pkg::Config.swix_staging_server, path)
+    Pkg::Util::Ship.ship_swix('pkg', path)
 
     # I really don't care which one we grab, it just has to be some supported
     # version and architecture from the `eos` hash. So here we're just grabbing
@@ -455,7 +455,7 @@ namespace :pl do
   desc "ship tarball and signature to #{Pkg::Config.tar_staging_server}"
   task ship_tar: 'pl:fetch' do
     if Pkg::Config.build_tar
-      Pkg::Util::Ship.ship_pkgs(['pkg/*.tar.gz*'], Pkg::Config.tar_staging_server, Pkg::Config.tarball_path, excludes: ['signing_bundle', 'packaging-bundle'], platform_independent: true)
+      Pkg::Util::Ship.ship_tar('pkg', Pkg::Config.tarball_path, excludes: ['signing_bundle', 'packaging-bundle'], platform_independent: true)
     end
   end
 
@@ -485,7 +485,7 @@ namespace :pl do
     end
     path = Pkg::Config.nonfinal_msi_path if Pkg::Config.nonfinal_msi_path && !Pkg::Util::Version.final?
 
-    Pkg::Util::Ship.ship_pkgs(['pkg/**/*.msi'], Pkg::Config.msi_staging_server, path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"])
+    Pkg::Util::Ship.ship_msi('pkg', path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"])
 
     # I really don't care which one we grab, it just has to be some supported
     # version and architecture from the `windows` hash. So here we're just grabbing


### PR DESCRIPTION
This PR adds wrapper functions that use `ship_pkgs` and various link creation functions to ship different types of packages (rpms, debs, msis, etc.) and uses those in the various rake tasks for shipping.

This will be useful for [RE-10284](https://tickets.puppetlabs.com/browse/RE-10284).


