### PR TITLE
(RE-9870) Update Solaris 11 signing certs

### DIFF
--- a/lib/packaging/ips.rb
+++ b/lib/packaging/ips.rb
@@ -30,10 +30,10 @@ module Pkg::IPS
         #            - Sean P. McDonald
         #
         # We sign the entire repo
-        sign_cmd = "sudo -E /usr/bin/pkgsign -c /root/signing/signing_cert_interim_SHA1.pem \
+        sign_cmd = "sudo -E /usr/bin/pkgsign -c /root/signing/signing_cert_2018.pem \
                     -i /root/signing/Thawte_Code_Signing_Certificate_interim_SHA1.pem \
                     -i /root/signing/Thawte_Primary_Root_CA_interim_SHA1.pem \
-                    -k /root/signing/signing_key_interim_SHA1.pem \
+                    -k /root/signing/signing_key_2018.pem \
                     -s 'file://#{work_dir}/repo' '*'"
         puts "About to sign #{p5p} with #{sign_cmd} in #{work_dir}"
         Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, sign_cmd.squeeze(' '))


### PR DESCRIPTION
Update to our new thawte code signing cert, good until March 2020.
The current cert expires later this month, so we shoudl start signing with the new one.