### PR TITLE
(RE-9870) Update intermediate and root CA certs

### DIFF
--- a/lib/packaging/ips.rb
+++ b/lib/packaging/ips.rb
@@ -31,8 +31,8 @@ module Pkg::IPS
         #
         # We sign the entire repo
         sign_cmd = "sudo -E /usr/bin/pkgsign -c /root/signing/signing_cert_2018.pem \
-                    -i /root/signing/Thawte_Code_Signing_Certificate_interim_SHA1.pem \
-                    -i /root/signing/Thawte_Primary_Root_CA_interim_SHA1.pem \
+                    -i /root/signing/Thawte_SHA256_Code_Signing_CA.pem \
+                    -i /root/signing/Thawte_Primary_Root_CA.pem \
                     -k /root/signing/signing_key_2018.pem \
                     -s 'file://#{work_dir}/repo' '*'"
         puts "About to sign #{p5p} with #{sign_cmd} in #{work_dir}"


### PR DESCRIPTION
Our new code signing cert was signed with a different set
of intermediate and root CA certs, so we need to update those on
the solaris signer as well.