### PR TITLE
(maint) Fail retrieval if destination directory is empty

### DIFF
--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -24,6 +24,7 @@ namespace :pl do
       else
         Pkg::Retrieve.retrieve_all(build_url, build_path, remote_target, local_target)
       end
+      fail "Uh oh, looks like we didn't find anything to retrieve from #{build_url}!" if Dir["#{local_target}/*"].empty?
       puts "Packages staged in #{local_target}"
     end
   end


### PR DESCRIPTION
This commit adds a failure to the retrieve task if the local target (usually 'pkg') is empty at the end of the retrieve. Previously, the retrieve would appear successful, but future tasks would have nothing to operate on.