### PR TITLE
 Revert "Revert "(maint) Remove `remote_target` param from `retrieve_all`""

### DIFF
--- a/lib/packaging/retrieve.rb
+++ b/lib/packaging/retrieve.rb
@@ -48,24 +48,24 @@ module Pkg::Retrieve
     unless Pkg::Config.foss_platforms
       fail "FOSS_ONLY specified, but I don't know anything about FOSS_PLATFORMS. Retrieve cancelled."
     end
-    default_wget(local_target, "#{build_url}/artifacts/", { 'level' => 1 })
+    default_wget(local_target, "#{build_url}", { 'level' => 1 })
     yaml_path = File.join(local_target, "#{Pkg::Config.ref}.yaml")
     unless File.readable?(yaml_path)
       fail "Couldn't read #{Pkg::Config.ref}.yaml, which is necessary for FOSS_ONLY. Retrieve cancelled."
     end
     platform_data = Pkg::Util::Serialization.load_yaml(yaml_path)[:platform_data]
     platform_data.each do |platform, paths|
-      default_wget(local_target, "#{build_url}/artifacts/#{paths[:artifact]}") if Pkg::Config.foss_platforms.include?(platform)
+      default_wget(local_target, "#{build_url}/#{paths[:artifact]}") if Pkg::Config.foss_platforms.include?(platform)
     end
   end
 
-  def retrieve_all(build_url, rsync_path, remote_target, local_target)
+  def retrieve_all(build_url, rsync_path, local_target)
     if Pkg::Util::Tool.find_tool("wget")
-      default_wget(local_target, "#{build_url}/#{remote_target}/")
+      default_wget(local_target, build_url)
     else
       warn "Could not find `wget` tool. Falling back to rsyncing from #{Pkg::Config.distribution_server}."
       begin
-        Pkg::Util::Net.rsync_from("#{rsync_path}/#{remote_target}/", Pkg::Config.distribution_server, "#{local_target}/")
+        Pkg::Util::Net.rsync_from(rsync_path, Pkg::Config.distribution_server, "#{local_target}/")
       rescue => e
         fail "Couldn't rsync packages from distribution server.\n#{e}"
       end

--- a/lib/packaging/retrieve.rb
+++ b/lib/packaging/retrieve.rb
@@ -48,7 +48,7 @@ module Pkg::Retrieve
     unless Pkg::Config.foss_platforms
       fail "FOSS_ONLY specified, but I don't know anything about FOSS_PLATFORMS. Retrieve cancelled."
     end
-    default_wget(local_target, "#{build_url}", { 'level' => 1 })
+    default_wget(local_target, "#{build_url}/", { 'level' => 1 })
     yaml_path = File.join(local_target, "#{Pkg::Config.ref}.yaml")
     unless File.readable?(yaml_path)
       fail "Couldn't read #{Pkg::Config.ref}.yaml, which is necessary for FOSS_ONLY. Retrieve cancelled."
@@ -61,11 +61,11 @@ module Pkg::Retrieve
 
   def retrieve_all(build_url, rsync_path, local_target)
     if Pkg::Util::Tool.find_tool("wget")
-      default_wget(local_target, build_url)
+      default_wget(local_target, "#{build_url}/")
     else
       warn "Could not find `wget` tool. Falling back to rsyncing from #{Pkg::Config.distribution_server}."
       begin
-        Pkg::Util::Net.rsync_from(rsync_path, Pkg::Config.distribution_server, "#{local_target}/")
+        Pkg::Util::Net.rsync_from("#{rsync_path}/", Pkg::Config.distribution_server, "#{local_target}/")
       rescue => e
         fail "Couldn't rsync packages from distribution server.\n#{e}"
       end

--- a/spec/lib/packaging/retrieve_spec.rb
+++ b/spec/lib/packaging/retrieve_spec.rb
@@ -17,8 +17,8 @@ describe 'Pkg::Retrieve' do
     'ubuntu-16.04-amd64' => {:artifact => './deb/xenial/PC1/puppet-agent_5.3.2.155.gb25e649-1xenial_amd64.deb'},
     'windows-2012-x64' => {:artifact => './windows/puppet-agent-x64.msi'},
   }}
-  build_url = "builds.delivery.puppetlabs.net/#{project}/#{ref}"
-  build_path = "/opt/jenkins-builds/#{project}/#{ref}"
+  build_url = "builds.delivery.puppetlabs.net/#{project}/#{ref}/#{remote_target}"
+  build_path = "/opt/jenkins-builds/#{project}/#{ref}/#{remote_target}"
 
   before :each do
     allow(Pkg::Config).to receive(:project).and_return(project)
@@ -86,13 +86,13 @@ describe 'Pkg::Retrieve' do
   describe '#retrieve_all' do
     it 'should try to use wget first' do
       expect(Pkg::Retrieve).to receive(:default_wget)
-      Pkg::Retrieve.retrieve_all(build_url, build_path, remote_target, local_target)
+      Pkg::Retrieve.retrieve_all(build_url, build_path, local_target)
     end
 
     it 'should use rsync if wget is not found' do
       allow(Pkg::Util::Tool).to receive(:find_tool).with('wget').and_return(nil)
       expect(Pkg::Util::Net).to receive(:rsync_from)
-      Pkg::Retrieve.retrieve_all(build_url, build_path, remote_target, local_target)
+      Pkg::Retrieve.retrieve_all(build_url, build_path, local_target)
     end
   end
 end

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -17,14 +17,14 @@ namespace :pl do
       remote_target = args.remote_target || "artifacts"
       local_target = args.local_target || "pkg"
       mkdir_p local_target
-      build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
-      build_path = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
+      build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
+      build_path = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
       if Pkg::Config.foss_only
         Pkg::Retrieve.foss_only_retrieve(build_url, local_target)
       else
-        Pkg::Retrieve.retrieve_all(build_url, build_path, remote_target, local_target)
+        Pkg::Retrieve.retrieve_all(build_url, build_path, local_target)
       end
-      fail "Uh oh, looks like we didn't find anything to retrieve from #{build_url}!" if Dir["#{local_target}/*"].empty?
+      fail "Uh oh, looks like we didn't find anything in #{local_target} when attempting to retrieve from #{build_url}!" if Dir["#{local_target}/*"].empty?
       puts "Packages staged in #{local_target}"
     end
   end
@@ -37,9 +37,9 @@ if Pkg::Config.build_pe
       task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
         remote_target = args.remote_target || "artifacts"
         local_target = args.local_target || "pkg"
-        build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
-        build_path = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
-        Pkg::Retrieve.retrieve_all(build_url, build_path, remote_target, local_target)
+        build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
+        build_path = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
+        Pkg::Retrieve.retrieve_all(build_url, build_path, local_target)
       end
     end
   end


### PR DESCRIPTION
The issue was a missing trailing slash..
![](https://m.popkey.co/f59f02/wqDAb_s-200x150.gif)