### PR TITLE
(RE-10396) Fail explicitly when signing fails

### DIFF
--- a/lib/packaging/sign/deb.rb
+++ b/lib/packaging/sign/deb.rb
@@ -4,6 +4,6 @@ module Pkg::Sign::Deb
   def sign_changes(file)
     # Lazy lazy lazy lazy lazy
     sign_program = "-p'gpg --use-agent --no-tty'" if ENV['RPM_GPG_AGENT']
-    %x(debsign #{sign_program} --re-sign -k#{Pkg::Config.gpg_key} #{file})
+    Pkg::Util::Execution.capture3("debsign #{sign_program} --re-sign -k#{Pkg::Config.gpg_key} #{file}")
   end
 end

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -25,7 +25,7 @@ module Pkg::Sign::Rpm
       # This definition of %__gpg_sign_cmd is the default on modern rpm. We
       # accept extra flags to override certain signing behavior for older
       # versions of rpm, e.g. specifying V3 signatures instead of V4.
-      %x(#{rpm_command} #{gpg_check_command} --define '%_gpg_name #{Pkg::Util::Gpg.key}' --define '%__gpg_sign_cmd %{__gpg} gpg #{sign_flags} #{input_flag} --batch --no-verbose --no-armor --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}' --addsign #{rpm})
+      Pkg::Util::Execution.capture3("#{rpm_command} #{gpg_check_command} --define '%_gpg_name #{Pkg::Util::Gpg.key}' --define '%__gpg_sign_cmd %{__gpg} gpg #{sign_flags} #{input_flag} --batch --no-verbose --no-armor --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}' --addsign #{rpm}")
     end
   end
 


### PR DESCRIPTION
This commit changes the local signing functions to use `capture3` rather than `%x` so that failures are captured and reported.