### PR TITLE
(maint) Reorganize platform info

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -2,77 +2,295 @@ require 'set'
 
 module Pkg
   module Platforms
+    DEBIAN_SOURCE_FORMATS = ['debian.tar.gz', 'orig.tar.gz', 'dsc', 'changes']
+
     # Each element in this hash
     PLATFORM_INFO = {
       'aix' => {
-        '6.1' => { :architectures => ['power'], :repo => false, :package_format => 'rpm', },
-        '7.1' => { :architectures => ['power'], :repo => false, :package_format => 'rpm', },
+        '6.1' => {
+          architectures: ['power'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          repo: false,
+        },
+        '7.1' => {
+          architectures: ['power'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          repo: false,
+        },
       },
 
       'cisco-wrlinux' => {
-        '5' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        '7' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '5' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        '7' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
       },
 
       'cumulus' => {
-        '2.2' => { :codename => 'cumulus', :architectures => ['amd64'], :repo => true, :package_format => 'deb', },
+        '2.2' => {
+          codename: 'cumulus',
+          architectures: ['amd64'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
       },
 
       'debian' => {
-        '7' => { :codename => 'wheezy', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
-        '8' => { :codename => 'jessie', :architectures  => ['i386', 'amd64', 'powerpc'], :repo => true, :package_format => 'deb', },
-        '9' => { :codename => 'stretch', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
-        '10' => { :codename => 'buster', :architectures  => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
+        '7' => {
+          codename: 'wheezy',
+          architectures: ['i386', 'amd64'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
+        '8' => {
+          codename: 'jessie',
+          architectures: ['i386', 'amd64', 'powerpc'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
+        '9' => {
+          codename: 'stretch',
+          architectures: ['i386', 'amd64'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
+        '10' => {
+          codename: 'buster',
+          architectures: ['i386', 'amd64'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        }
       },
 
       'el' => {
-        '5' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v3', },
-        '6' => { :architectures => ['i386', 'x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        '7' => { :architectures => ['x86_64', 's390x', 'ppc64le', 'aarch64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '5' => {
+          architectures: ['i386', 'x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v3',
+          repo: true,
+        },
+        '6' => {
+          architectures: ['i386', 'x86_64', 's390x'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        '7' => {
+          architectures: ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
       },
 
       'eos' => {
-        '4' => { :architectures => ['i386'], :repo => false, :package_format => 'swix', },
+        '4' => {
+          architectures: ['i386'],
+          package_format: 'swix',
+          repo: false,
+        },
       },
 
       'fedora' => {
-        'f25' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        'f26' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        'f27' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        'f28' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        '25' => { :architectures => ['i386', 'x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        '26' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        '27' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
-        '28' => { :architectures => ['x86_64'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        'f25' => {
+          architectures: ['i386', 'x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        'f26' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        'f27' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        'f28' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        '25' => {
+          architectures: ['i386', 'x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        '26' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        '27' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
+        '28' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
       },
 
       'osx' => {
-        '10.10' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
-        '10.11' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
-        '10.12' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
-        '10.13' => { :architectures => ['x86_64'], :repo => false, :package_format => 'dmg', },
+        '10.10' => {
+          architectures: ['x86_64'],
+          package_format: 'dmg',
+          repo: false,
+        },
+        '10.11' => {
+          architectures: ['x86_64'],
+          package_format: 'dmg',
+          repo: false,
+        },
+        '10.12' => {
+          architectures: ['x86_64'],
+          package_format: 'dmg',
+          repo: false,
+        },
+        '10.13' => {
+          architectures: ['x86_64'],
+          package_format: 'dmg',
+          repo: false,
+        },
+      },
+
+      'redhat-fips' => {
+        '7' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v3',
+          repo: true,
+        }
       },
 
       'sles' => {
-        '11' => { :architectures => ['i386', 'x86_64', 's390x'], :repo => true, :package_format => 'rpm', :signature_format => 'v3', },
-        '12' => { :architectures => ['x86_64', 's390x', 'ppc64le'], :repo => true, :package_format => 'rpm', :signature_format => 'v4', },
+        '11' => {
+          architectures: ['i386', 'x86_64', 's390x'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v3',
+          repo: true,
+        },
+        '12' => {
+          architectures: ['x86_64', 's390x', 'ppc64le'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
       },
 
       'solaris' => {
-        '10' => { :architectures => ['i386', 'sparc'], :repo => false, :package_format => 'svr4', },
-        '11' => { :architectures => ['i386', 'sparc'], :repo => false, :package_format => 'ips', },
+        '10' => {
+          architectures: ['i386', 'sparc'],
+          package_format: 'svr4',
+          repo: false,
+        },
+        '11' => {
+          architectures: ['i386', 'sparc'],
+          package_format: 'ips',
+          repo: false,
+        },
       },
 
       'ubuntu' => {
-        '14.04' => { :codename => 'trusty', :architectures => ['i386', 'amd64'], :repo => true, :package_format => 'deb', },
-        '16.04' => { :codename => 'xenial', :architectures => ['i386', 'amd64', 'ppc64el'], :repo => true, :package_format => 'deb', },
-        '18.04' => { :codename => 'bionic', :architectures => ['amd64', 'ppc64el'], :repo => true, :package_format => 'deb', },
+        '14.04' => {
+          codename: 'trusty',
+          architectures: ['i386', 'amd64'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
+        '16.04' => {
+          codename: 'xenial',
+          architectures: ['i386', 'amd64', 'ppc64el'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
+        '18.04' => {
+          codename: 'bionic',
+          architectures: ['amd64', 'ppc64el'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
       },
 
       'windows' => {
-        '2012' => { :architectures => ['x86', 'x64'], :repo => false, :package_format => 'msi', },
-      },
-    }
+        '2012' => {
+          architectures: ['x86', 'x64'],
+          package_format: 'msi',
+          repo: false,
+        },
+      }
+    }.freeze
 
     # @private List platforms that use a given package format
     # @param format [String] The name of the packaging format to filter on


### PR DESCRIPTION
This commit reorganizes the PLATFORM_INFO hash to look like the one in the 1.0.x branch. The info should all be the same (or additive), but this will make future merge-ups less painful.