### PR TITLE
(RE-10428) Paths were wrong for nightlies

### DIFF
--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -61,6 +61,8 @@ module Pkg::Paths
   def repo_name(nonfinal = false)
     if nonfinal && Pkg::Config.nonfinal_repo_name
       Pkg::Config.nonfinal_repo_name
+    elsif nonfinal
+      fail "Nonfinal is set to true but Pkg::Config.nonfinal_repo_name is unset!"
     else
       Pkg::Config.repo_name || ""
     end
@@ -79,8 +81,10 @@ module Pkg::Paths
   # projects, where `Pkg::Config.yum_repo_name` is set instead of
   # `Pkg::Config.repo_name`. Defaults to 'products' if nothing is set.
   def yum_repo_name(nonfinal = false)
-    if nonfinal
-      return Pkg::Config.nonfinal_repo_name || Pkg::Config.repo_name || Pkg::Config.yum_repo_name || 'products'
+    if nonfinal && Pkg::Config.nonfinal_repo_name
+      return Pkg::Config.nonfinal_repo_name
+    elsif nonfinal
+      fail "Nonfinal is set to true but Pkg::Config.nonfinal_repo_name is unset!"
     end
 
     return Pkg::Config.repo_name || Pkg::Config.yum_repo_name || 'products'
@@ -90,8 +94,10 @@ module Pkg::Paths
   # projects, where `Pkg::Config.apt_repo_name` is set instead of
   # `Pkg::Config.repo_name`. Defaults to 'main' if nothing is set.
   def apt_repo_name(nonfinal = false)
-    if nonfinal
-      return Pkg::Config.nonfinal_repo_name || Pkg::Config.repo_name || Pkg::Config.apt_repo_name || 'main'
+    if nonfinal && Pkg::Config.nonfinal_repo_name
+      return Pkg::Config.nonfinal_repo_name
+    elsif nonfinal
+      fail "Nonfinal is set to true but Pkg::Config.nonfinal_repo_name is unset!"
     end
 
     return Pkg::Config.repo_name || Pkg::Config.apt_repo_name || 'main'

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -24,14 +24,14 @@ module Pkg::Util::Ship
   #
   # If this is platform_independent the packages will not get reorganized,
   # just copied under the tmp directory for more consistent workflows
-  def reorganize_packages(pkgs, tmp, platform_independent = false)
+  def reorganize_packages(pkgs, tmp, platform_independent = false, nonfinal = false)
     new_pkgs = []
     pkgs.each do |pkg|
       if platform_independent
         path = 'pkg'
       else
         platform_tag = Pkg::Paths.tag_from_artifact_path(pkg)
-        path = Pkg::Paths.artifacts_path(platform_tag, 'pkg')
+        path = Pkg::Paths.artifacts_path(platform_tag, 'pkg', nonfinal)
       end
       FileUtils.mkdir_p File.join(tmp, path)
       FileUtils.cp pkg, File.join(tmp, path)
@@ -64,7 +64,8 @@ module Pkg::Util::Ship
     options = {
       excludes: [],
       chattr: true,
-      platform_independent: false }.merge(opts)
+      platform_independent: false,
+      nonfinal: false }.merge(opts)
 
     # First find the packages to be shipped. We must find them before moving
     # to our temporary staging directory
@@ -72,7 +73,7 @@ module Pkg::Util::Ship
     return if local_packages.empty?
 
     tmpdir = Dir.mktmpdir
-    staged_pkgs = reorganize_packages(local_packages, tmpdir, options[:platform_independent])
+    staged_pkgs = reorganize_packages(local_packages, tmpdir, options[:platform_independent], options[:nonfinal])
 
     puts staged_pkgs.sort
     puts "Do you want to ship the above files to (#{staging_server})?"

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -80,10 +80,10 @@ describe 'Pkg::Paths' do
       expect(Pkg::Paths.repo_name(true)).to eq('puppet5-nightly')
     end
 
-    it 'should return repo_name if nonfinal_repo_name is not set for non-final version' do
+    it 'should fail if nonfinal_repo_name is not set for non-final version' do
       allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
-      expect(Pkg::Paths.repo_name(true)).to eq('puppet5')
+      expect { Pkg::Paths.repo_name(true) }.to raise_error
     end
   end
 
@@ -165,6 +165,17 @@ describe 'Pkg::Paths' do
       allow(Pkg::Config).to receive(:apt_repo_name).and_return(nil)
       expect(Pkg::Paths.apt_repo_name).to eq('main')
     end
+    it 'should return nonfinal_repo_name for nonfinal version' do
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet5-nightly')
+      expect(Pkg::Paths.apt_repo_name(true)).to eq('puppet5-nightly')
+    end
+
+    it 'should fail if nonfinal_repo_name is not set for non-final version' do
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
+      expect { Pkg::Paths.apt_repo_name(true) }.to raise_error
+    end
   end
 
   describe '#yum_repo_name' do
@@ -184,6 +195,18 @@ describe 'Pkg::Paths' do
       allow(Pkg::Config).to receive(:repo_name).and_return(nil)
       allow(Pkg::Config).to receive(:yum_repo_name).and_return(nil)
       expect(Pkg::Paths.yum_repo_name).to eq('products')
+    end
+
+    it 'should return nonfinal_repo_name for nonfinal version' do
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet5-nightly')
+      expect(Pkg::Paths.yum_repo_name(true)).to eq('puppet5-nightly')
+    end
+
+    it 'should fail if nonfinal_repo_name is not set for non-final version' do
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
+      expect { Pkg::Paths.yum_repo_name(true) }.to raise_error
     end
   end
 

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -67,27 +67,23 @@ describe 'Pkg::Paths' do
 
     it 'should return repo_name for final version' do
       allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
-      allow(Pkg::Util::Version).to receive(:final?).and_return(true)
       expect(Pkg::Paths.repo_name).to eq('puppet5')
     end
 
     it 'should be empty string if repo_name is not set for final version' do
       allow(Pkg::Config).to receive(:repo_name).and_return(nil)
-      allow(Pkg::Util::Version).to receive(:final?).and_return(true)
       expect(Pkg::Paths.repo_name).to eq('')
     end
 
     it 'should return nonfinal_repo_name for non-final version' do
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet5-nightly')
-      allow(Pkg::Util::Version).to receive(:final?).and_return(false)
-      expect(Pkg::Paths.repo_name).to eq('puppet5-nightly')
+      expect(Pkg::Paths.repo_name(true)).to eq('puppet5-nightly')
     end
 
     it 'should return repo_name if nonfinal_repo_name is not set for non-final version' do
       allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
-      allow(Pkg::Util::Version).to receive(:final?).and_return(false)
-      expect(Pkg::Paths.repo_name).to eq('puppet5')
+      expect(Pkg::Paths.repo_name(true)).to eq('puppet5')
     end
   end
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -205,7 +205,7 @@ DOC
 
       if args.foss_only && Pkg::Config.foss_platforms && !Pkg::Config.foss_platforms.empty?
         Pkg::Config.foss_platforms.each do |platform|
-          include_paths << Pkg::Paths.repo_path(platform, legacy: true)
+          include_paths << Pkg::Paths.repo_path(platform, legacy: true, nonfinal: true)
           if Pkg::Paths.repo_config_path(platform)
             include_paths << Pkg::Paths.repo_config_path(platform)
           end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -256,7 +256,7 @@ namespace :pl do
 
   desc "Ship nightly rpms to #{Pkg::Config.yum_staging_server}"
   task ship_nightly_rpms: 'pl:fetch' do
-    Pkg::Util::Ship.ship_rpms('pkg', Pkg::Config.nonfinal_yum_repo_path)
+    Pkg::Util::Ship.ship_rpms('pkg', Pkg::Config.nonfinal_yum_repo_path, nonfinal: true)
   end
 
   desc "Ship cow-built debs to #{Pkg::Config.apt_signing_server}"
@@ -266,7 +266,7 @@ namespace :pl do
 
   desc "Ship nightly debs to #{Pkg::Config.apt_signing_server}"
   task ship_nightly_debs: 'pl:fetch' do
-    Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.nonfinal_apt_repo_staging_path, chattr: false)
+    Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.nonfinal_apt_repo_staging_path, chattr: false, nonfinal: true)
   end
 
   desc 'Ship built gem to rubygems.org, internal Gem mirror, and public file server'
@@ -375,7 +375,7 @@ namespace :pl do
 
   desc "ship nightly apple dmgs to #{Pkg::Config.dmg_staging_server}"
   task ship_nightly_dmg: 'pl:fetch' do
-    Pkg::Util::Ship.ship_dmg('pkg', Pkg::Config.nonfinal_dmg_path)
+    Pkg::Util::Ship.ship_dmg('pkg', Pkg::Config.nonfinal_dmg_path, nonfinal: true)
   end
 
   desc "ship Arista EOS swix packages and signatures to #{Pkg::Config.swix_staging_server}"
@@ -397,7 +397,7 @@ namespace :pl do
 
   desc "ship nightly Arista EOS swix packages and signatures to #{Pkg::Config.swix_staging_server}"
   task ship_nightly_swix: 'pl:fetch' do
-    Pkg::Util::Ship.ship_swix('pkg', Pkg::Config.nonfinal_swix_path)
+    Pkg::Util::Ship.ship_swix('pkg', Pkg::Config.nonfinal_swix_path, nonfinal: true)
   end
 
   desc "ship tarball and signature to #{Pkg::Config.tar_staging_server}"
@@ -436,7 +436,7 @@ namespace :pl do
 
   desc "Ship nightly MSI packages to #{Pkg::Config.msi_staging_server}"
   task ship_nightly_msi: 'pl:fetch' do
-    Pkg::Util::Ship.ship_msi('pkg', Pkg::Config.nonfinal_msi_path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"])
+    Pkg::Util::Ship.ship_msi('pkg', Pkg::Config.nonfinal_msi_path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"], nonfinal: true)
   end
 
   desc 'UBER ship: ship all the things in pkg'


### PR DESCRIPTION
Since the nightly ship tasks have been separated from the final ship
tasks, we can pass a variable through when we're working on a nightly
ship so we don't need to rely on the magic checking of whether or not
this is a final version.