### PR TITLE
(maint) Sync latest filename instead of the directory

### DIFF
--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -337,7 +337,7 @@ DOC
 
       latest_filename = File.join(latest_filepath, "LATEST")
       File.open(latest_filename, 'w') { |file| file.write(version) }
-      Pkg::Util::Net.s3sync_to(latest_filepath, target_bucket, Pkg::Config.project, ["--acl-public", "--follow-symlinks"])
+      Pkg::Util::Net.s3sync_to(latest_filename, target_bucket, Pkg::Config.project, ["--acl-public", "--follow-symlinks"])
       FileUtils.rm_rf latest_filepath
     end
   end


### PR DESCRIPTION
This commit fixes a copy paste error where we were shipping the
directory with the LATEST file in it instead of just the LATEST file
itself to the pdk repo.