### PR TITLE
(RE-10422) Make separate signing step before shipping to builds

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -11,8 +11,9 @@ namespace :pl do
   end
 
   desc "Sign the Arista EOS swix packages, defaults to PL key, pass GPG_KEY to override or edit build_defaults"
-  task :sign_swix do
-    packages = Dir["pkg/**/*.swix"]
+  task :sign_swix, :root_dir do |_t, args|
+    swix_dir = args.root_dir || "pkg"
+    packages = Dir["#{swix_dir}/**/*.swix"]
     unless packages.empty?
       Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
       packages.each do |swix_package|
@@ -22,10 +23,11 @@ namespace :pl do
   end
 
   desc "Detach sign any solaris svr4 packages"
-  task :sign_svr4 do
-    unless Dir["pkg/**/*.pkg.gz"].empty?
+  task :sign_svr4, :root_dir do |_t, args|
+    svr4_dir = args.root_dir || "pkg"
+    unless Dir["#{svr4_dir}/**/*.pkg.gz"].empty?
       Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
-      Dir["pkg/**/*.pkg.gz"].each do |pkg|
+      Dir["#{svr4_dir}/**/*.pkg.gz"].each do |pkg|
         Pkg::Util::Gpg.sign_file pkg
       end
     end
@@ -97,13 +99,15 @@ namespace :pl do
   end
 
   desc "Sign ips package, uses PL certificates by default, update privatekey_pem, certificate_pem, and ips_inter_cert in build_defaults.yaml to override."
-  task :sign_ips do
-    Pkg::Sign::Ips.sign unless Dir['pkg/**/*.p5p'].empty?
+  task :sign_ips, :root_dir do |_t, args|
+    ips_dir = args.root_dir || "pkg"
+    Pkg::Sign::Ips.sign(ips_dir) unless Dir["#{ips_dir}/**/*.p5p"].empty?
   end
 
   desc "Sign built gems, defaults to PL key, pass GPG_KEY to override or edit build_defaults"
-  task :sign_gem do
-    gems = FileList["pkg/*.gem"]
+  task :sign_gem, :root_dir do |_t, args|
+    gems_dir = args.root_dir || "pkg"
+    gems = FileList["#{gems_dir}/*.gem"]
     gems.each do |gem|
       puts "signing gem #{gem}"
       Pkg::Util::Gpg.sign_file(gem)
@@ -111,9 +115,10 @@ namespace :pl do
   end
 
   desc "Check if all rpms are signed"
-  task :check_rpm_sigs do
+  task :check_rpm_sigs, :root_dir do |_t, args|
+    rpm_dir = args.root_dir || "pkg"
     signed = TRUE
-    rpms = Dir["pkg/**/*.rpm"]
+    rpms = Dir["#{rpm_dir}/**/*.rpm"]
     print 'Checking rpm signatures'
     rpms.each do |rpm|
       if Pkg::Sign::Rpm.has_sig? rpm
@@ -128,12 +133,13 @@ namespace :pl do
   end
 
   desc "Sign generated debian changes files. Defaults to PL Key, pass GPG_KEY to override"
-  task :sign_deb_changes do
+  task :sign_deb_changes, :root_dir do |_t, args|
     begin
-      change_files = Dir["pkg/**/*.changes"]
+      deb_dir = args.root_dir || "pkg"
+      change_files = Dir["#{deb_dir}/**/*.changes"]
       unless change_files.empty?
         Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
-        Pkg::Sign::Deb.sign_changes("pkg/**/*.changes")
+        Pkg::Sign::Deb.sign_changes("#{deb_dir}/**/*.changes")
       end
     ensure
       Pkg::Util::Gpg.kill_keychain
@@ -141,13 +147,15 @@ namespace :pl do
   end
 
   desc "Sign OSX packages"
-  task :sign_osx => "pl:fetch" do
-    Pkg::Sign::Dmg.sign unless Dir['pkg/**/*.dmg'].empty?
+  task :sign_osx, [:root_dir] => "pl:fetch" do |_t, args|
+    dmg_dir = args.root_dir || "pkg"
+    Pkg::Sign::Dmg.sign(dmg_dir) unless Dir["#{dmg_dir}/**/*.dmg"].empty?
   end
 
   desc "Sign MSI packages"
-  task :sign_msi => "pl:fetch" do
-    Pkg::Sign::Msi.sign unless Dir['pkg/**/*.msi'].empty?
+  task :sign_msi, [:root_dir] => "pl:fetch" do |_t, args|
+    msi_dir = args.root_dir || "pkg"
+    Pkg::Sign::Msi.sign(msi_dir) unless Dir["#{msi_dir}/**/*.msi"].empty?
   end
 
   ##
@@ -156,8 +164,10 @@ namespace :pl do
   #
   namespace :jenkins do
     desc "Sign all locally staged packages on #{Pkg::Config.signing_server}"
-    task :sign_all => "pl:fetch" do
-      Dir["pkg/*"].empty? and fail "There were files found in pkg/. Maybe you wanted to build/retrieve something first?"
+    task :sign_all, :root_dir do |_t, args|
+      Pkg::Util::RakeUtils.invoke_task('pl:fetch')
+      root_dir = args.root_dir || "pkg"
+      Dir["#{root_dir}/*"].empty? and fail "There were no files found in #{root_dir}. Maybe you wanted to build/retrieve something first?"
 
       # Because rpms and debs are laid out differently in PE under pkg/ they
       # have a different sign task to address this. Rather than create a whole
@@ -172,7 +182,7 @@ namespace :pl do
       rpm_sign_task = Pkg::Config.build_pe ? "pe:sign_rpms" : "pl:sign_rpms"
       deb_sign_task = Pkg::Config.build_pe ? "pe:sign_deb_changes" : "pl:sign_deb_changes"
       sign_tasks    = [rpm_sign_task]
-      sign_tasks    << deb_sign_task unless Dir['pkg/**/*.changes'].empty?
+      sign_tasks    << deb_sign_task unless Dir["#{root_dir}/**/*.changes"].empty?
       sign_tasks    << "pl:sign_tar" if Pkg::Config.build_tar
       sign_tasks    << "pl:sign_gem" if Pkg::Config.build_gem
       sign_tasks    << "pl:sign_osx" if Pkg::Config.build_dmg || Pkg::Config.vanagon_project
@@ -182,7 +192,7 @@ namespace :pl do
       sign_tasks    << "pl:sign_msi" if Pkg::Config.build_msi || Pkg::Config.vanagon_project
       remote_repo   = Pkg::Util::Net.remote_bootstrap(Pkg::Config.signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(Pkg::Config.signing_server, Pkg::Config)
-      Pkg::Util::Net.rsync_to('pkg', Pkg::Config.signing_server, remote_repo)
+      Pkg::Util::Net.rsync_to(root_dir, Pkg::Config.signing_server, remote_repo)
       rake_command = <<-DOC
 cd #{remote_repo} ;
 bundle_prefix= ;
@@ -190,10 +200,10 @@ if [[ -r Gemfile ]]; then
   source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems;
   bundle_prefix='bundle exec';
 fi ;
-$bundle_prefix rake #{sign_tasks.join(' ')} PARAMS_FILE=#{build_params}
+$bundle_prefix rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}
 DOC
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, rake_command)
-      Pkg::Util::Net.rsync_from("#{remote_repo}/pkg/", Pkg::Config.signing_server, "pkg/")
+      Pkg::Util::Net.rsync_from("#{remote_repo}/#{root_dir}/", Pkg::Config.signing_server, "pkg/")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm #{build_params}")
       puts "Signed packages staged in 'pkg/ directory"


### PR DESCRIPTION
This change modifies the packaging ship rake task to work with signing before shipping to builds. It takes a repo_dir that a user wants it to sign, copies the files into mozart, transfers them into the /pkg dir (this part i'm not 100% on because testing is hard in mozart... ideally it would just sign in whatever dir you give it but in case there is not an updated version of packaging pulled in it will be looking to sign files that are in the pkg/ dir so that's what i have it doing for now) signs them, and sends them back to your local pkg/. This commit relates to https://github.com/puppetlabs/vanagon/pull/549 where you can see packages that have gotten signed. Working on getting more tests for different package types. 