### PR TITLE
(maint) Use 'ppc' in AIX artifact paths

### DIFF
--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -82,7 +82,6 @@ module Pkg
           artifacts.each do |artifact|
             tag = Pkg::Paths.tag_from_artifact_path(artifact)
             platform, version, arch = Pkg::Platforms.parse_platform_tag(tag)
-            arch = 'ppc' if platform == 'aix'
             package_format = Pkg::Platforms.get_attribute(tag, :package_format)
 
             # Skip this if it's an unversioned MSI. We create these to help

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -345,6 +345,9 @@ module Pkg
       architecture = platform_tag.sub(/^(#{platform}-#{version}|#{codename})-?/, '')
 
       fail unless supported_arches.include?(architecture) || architecture.empty?
+
+      # AIX uses 'ppc' as its architecture in paths and file names
+      architecture = 'ppc' if platform == 'aix'
       return [platform, version, architecture]
     rescue
       raise "Could not verify that '#{platform_tag}' is a valid tag"


### PR DESCRIPTION
This commit updates the `parse_platform_tag` function to return 'ppc' as the
architecture for AIX platforms. Officially, 'power' is the AIX arch, but we use
'ppc' in paths and file names, to be consistent with upstream expectations.