### PR TITLE
(PA-1958) Rename redhat-fips platform to redhatfips

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -213,7 +213,7 @@ module Pkg
         },
       },
 
-      'redhat-fips' => {
+      'redhatfips' => {
         '7' => {
           architectures: ['x86_64'],
           source_architecture: 'SRPMS',

--- a/spec/lib/packaging/util/platform_spec.rb
+++ b/spec/lib/packaging/util/platform_spec.rb
@@ -37,6 +37,10 @@ describe "Pkg::Util::Platform" do
       expect(Pkg::Util::Platform.artifacts_path('el-7-x86_64')).to eq('artifacts/el/7')
     end
 
+    it 'should be correct for redhatfips 7' do
+      expect(Pkg::Util::Platform.artifacts_path('redhatfips-7-x86_64')).to eq('artifacts/redhatfips/7')
+    end
+
     it 'should be correct for trusty' do
       expect(Pkg::Util::Platform.artifacts_path('ubuntu-14.04-amd64')).to eq('artifacts/deb/trusty')
     end


### PR DESCRIPTION
Having dashes in platform names causes problems when it comes to adding
a platform to pe_repo, so the redhat-fips platform name is being changed
to redhatfips.