### PR TITLE
(maint) Skip tarball signing if signature already exists

### DIFF
--- a/lib/packaging/util/gpg.rb
+++ b/lib/packaging/util/gpg.rb
@@ -51,6 +51,10 @@ module Pkg::Util::Gpg
       gpg ||= Pkg::Util::Tool.find_tool('gpg')
 
       if gpg
+        if File.exist? "#{file}.asc"
+          warn "Signature on #{file} exists, skipping..."
+          return TRUE
+        end
         use_tty = "--no-tty --use-agent" if ENV['RPM_GPG_AGENT']
         stdout, _, _ = Pkg::Util::Execution.capture3("#{gpg} #{use_tty} --armor --detach-sign -u #{key} #{file}")
         stdout


### PR DESCRIPTION
Currently the tarball signature will fail if the external
signature file already exists. This adds logic
to skip the tarball signing if it's already signed.