### PR TITLE
Updates to remove stickler and nexus configs

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -76,8 +76,6 @@ module Pkg::Params
                   :gpg_name,
                   :homepage,
                   :internal_gem_host,
-                  :internal_nexus_host,
-                  :internal_stickler_host,
                   :ips_build_host,
                   :ips_host,
                   :ips_inter_cert,
@@ -292,8 +290,6 @@ module Pkg::Params
               { :var => :yum_repo_path,           :envvar => :YUM_REPO },
               { :var => :yum_staging_server,      :envvar => :YUM_STAGING_SERVER },
               { :var => :internal_gem_host,       :envvar => :INTERNAL_GEM_HOST },
-              { :var => :internal_nexus_host,     :envvar => :INTERNAL_NEXUS_HOST },
-              { :var => :internal_stickler_host,  :envvar => :INTERNAL_STICKLER_HOST },
              ]
   # Default values that are supplied if the user does not supply them
   #
@@ -332,8 +328,6 @@ module Pkg::Params
   # in case it is not set.
   #
   REASSIGNMENTS = [
-                    { :oldvar => :internal_gem_host,      :newvar => :internal_nexus_host },
-                    { :oldvar => :internal_gem_host,      :newvar => :internal_stickler_host },
                     # These are fall-through values for shipping endpoints
                     { :oldvar => :staging_server,         :newvar => :apt_staging_server },
                     { :oldvar => :staging_server,         :newvar => :dmg_staging_server },

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -1,89 +1,11 @@
 module Pkg::Gem
-  @nexus_config = "#{ENV['HOME']}/.gem/nexus"
-
   class << self
     # This is preserved because I don't want to update the deprecated code path
     # yet; I'm not entirely sure I've fixed everything that might attempt
     # to call this method so this is now a wrapper for a wrapper.
     def ship(file)
-      ship_to_stickler(file)
-      ship_to_nexus(file)
       rsync_to_downloads(file)
       ship_to_rubygems(file)
-    end
-
-    def load_nexus_config
-      if Pkg::Util::File.file_exists?(@nexus_config)
-        config = YAML.load_file(@nexus_config)
-      end
-      config || {}
-    end
-
-    def write_nexus_config
-      hash = load_nexus_config
-      if hash["GEM_INTERNAL"].nil? || hash["GEM_INTERNAL"][:authorization].nil?
-        puts "Please enter nexus username:"
-        username = Pkg::Util.get_input
-        puts "Please enter nexus password:"
-        password = Pkg::Util.get_input(false)
-        hash["GEM_INTERNAL"] = { :authorization => "Basic #{Pkg::Util.base64_encode("#{username}:#{password}")}" }
-      end
-      if hash["GEM_INTERNAL"][:url].nil? || hash["GEM_INTERNAL"][:url] != Pkg::Config.internal_nexus_host
-        hash["GEM_INTERNAL"][:url] = Pkg::Config.internal_nexus_host
-      end
-      File.open(@nexus_config, "w") do |file|
-        file.write(hash.to_yaml)
-      end
-    end
-
-    # Ship a Ruby gem file to a Nexus server, because
-    # you've lost the ability to feel joy anymore.
-    def ship_to_nexus(file)
-      write_nexus_config
-      cmd = "gem nexus #{file} --repo GEM_INTERNAL"
-      if ENV['DRYRUN']
-        puts "[DRY-RUN] #{cmd}"
-      else
-        stdout, _, _ = Pkg::Util::Execution.capture3(cmd, true)
-        # The `gem nexus` command always returns `0` regardless of what the
-        # command results in. In order to properly handle fail cases, this
-        # checks for the success case and fails otherwise. The `ex` command
-        # above will print any output, so the user should have enough info
-        # to debug the failure, and potentially update this fail case if
-        # needed.
-        fail unless stdout.include? "Created"
-        puts "#{file} pushed to nexus server at #{Pkg::Config.internal_nexus_host}"
-      end
-    rescue => e
-      puts "###########################################"
-      puts "#  Nexus failed, ensure the nexus gem is installed,"
-      puts "#  you have access to #{Pkg::Config.internal_nexus_host}"
-      puts "#  and your settings in #{@nexus_config} are correct"
-      puts "###########################################"
-      puts
-      puts e
-      raise e
-    end
-
-    # Ship a Ruby gem file to a Stickler server, because
-    # you've lost the ability to feel joy anymore.
-    def ship_to_stickler(file)
-      Pkg::Util::Tool.check_tool("stickler")
-      cmd = "stickler push #{file} --server=#{Pkg::Config.internal_stickler_host} 2>/dev/null"
-      if ENV['DRYRUN']
-        puts "[DRY-RUN] #{cmd}"
-      else
-        Pkg::Util::Execution.capture3(cmd)
-        puts "#{file} pushed to stickler server at #{Pkg::Config.internal_stickler_host}"
-      end
-    rescue => e
-      puts "###########################################"
-      puts "#  Stickler failed, ensure it's installed"
-      puts "#  and you have access to #{Pkg::Config.internal_stickler_host}"
-      puts "###########################################"
-      puts
-      puts e
-      raise e
     end
 
     # Use rsync to deploy a file and any associated detached signatures,

--- a/lib/packaging/nuget.rb
+++ b/lib/packaging/nuget.rb
@@ -2,7 +2,7 @@ module Pkg::Nuget
   class << self
     def ship(packages)
       #
-      # Support shipping of Nuget style packages to a nexus based nuget feed
+      # Support shipping of Nuget style packages to an Artifactory based nuget feed
       # Using curl to submit the packages rather than windows based choco/mono.
       # This approach gives more flexibility and fits in with the current Puppet
       # release automation practices using linux/mac systems.

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -309,22 +309,6 @@ namespace :pl do
     unless Pkg::Config.internal_gem_host
       warn 'Value `Pkg::Config.internal_gem_host` not defined; skipping internal ship'
     end
-
-    puts "Do you want to ship #{args[:file]} to the internal stickler server(#{Pkg::Config.internal_stickler_host})?"
-    if Pkg::Util.ask_yes_or_no
-      puts "Shipping gem #{args[:file]} to internal Gem server (#{Pkg::Config.internal_stickler_host})"
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Gem.ship_to_stickler(args[:file])
-      end
-    end
-
-    puts "Do you want to ship #{args[:file]} to the internal nexus server(#{Pkg::Config.internal_nexus_host})?"
-    if Pkg::Util.ask_yes_or_no
-      puts "Shipping gem #{args[:file]} to internal Gem server (#{Pkg::Config.internal_nexus_host})"
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Gem.ship_to_nexus(args[:file])
-      end
-    end
   end
 
   desc "Ship built gems to public Downloads server (#{Pkg::Config.gem_host})"
@@ -511,22 +495,6 @@ namespace :pl do
     end
 
     if Pkg::Config.build_gem
-      # Do we have stickler and nexus?
-      if Pkg::Util::Misc.check_gem('stickler')
-        `stickler list --server #{Pkg::Config.internal_stickler_host} > /dev/null 2>&1`
-        unless $CHILD_STATUS.zero?
-          errs << "Listing gems at the stickler server #{Pkg::Config.internal_stickler_host} failed!"
-        end
-      else
-        errs << 'gem stickler not found'
-      end
-
-      errs << 'gem nexus not found' unless Pkg::Util::Misc.check_gem('nexus')
-      `gem list --source #{Pkg::Config.internal_nexus_host} > /dev/null 2>&1`
-      unless $CHILD_STATUS.zero?
-        errs << "Listing gems at the nexus server #{Pkg::Config.internal_nexus_host} failed!"
-      end
-
       # Do we have rubygems access set up
       if Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials")
         # Do we have permissions to publish this gem on rubygems


### PR DESCRIPTION
As we're migrating to Artifactory, we're deprecating nexus and stickler. This removes those configs and stops shipping to those services.