### PR TITLE
(CPR-566) Grab all artifacts for a given platform/architecture

### DIFF
--- a/lib/packaging/retrieve.rb
+++ b/lib/packaging/retrieve.rb
@@ -55,7 +55,8 @@ module Pkg::Retrieve
     end
     platform_data = Pkg::Util::Serialization.load_yaml(yaml_path)[:platform_data]
     platform_data.each do |platform, paths|
-      default_wget(local_target, "#{build_url}/#{paths[:artifact]}") if Pkg::Config.foss_platforms.include?(platform)
+      path_to_retrieve = File.dirname(paths[:artifact])
+      default_wget(local_target, "#{build_url}/#{path_to_retrieve}/") if Pkg::Config.foss_platforms.include?(platform)
     end
   end
 


### PR DESCRIPTION
FOSS_ONLY automation was previously relying on the artifact path in
<sha>.yaml to determine which artifacts to fetch. Rather than grabbing a
single artifact, grab all artifacts from the parent directory so we can
do things like ship termini packages.