### PR TITLE
(maint) Add `ship_gem` to ubership_lite

### DIFF
--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -259,6 +259,7 @@ namespace :pl do
         ship_swix
         ship_tar
         ship_msi
+        ship_gem
       )
       tasks.map { |t| "pl:#{t}" }.each do |t|
         puts "Running #{t} . . ."


### PR DESCRIPTION
Added jenkins as an owner to the relevant gems, just need to make sure jenkins rubygems credentials are available on mozart.