### PR TITLE
(RE-10703) Add `PROJECT` environment variable

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -266,6 +266,7 @@ module Pkg::Params
               { :var => :pe_feature_branch,       :envvar => :PE_FEATURE_BRANCH },
               { :var => :pe_version,              :envvar => :PE_VER },
               { :var => :privatekey_pem,          :envvar => :PRIVATE_PEM },
+              { :var => :project,                 :envvar => :PROJECT },
               { :var => :project_root,            :envvar => :PROJECT_ROOT },
               { :var => :random_mockroot,         :envvar => :RANDOM_MOCKROOT, :type => :bool },
               { :var => :rc_mocks,                :envvar => :MOCK },

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -14,6 +14,9 @@ namespace :pl do
   namespace :jenkins do
     desc "Retrieve packages from the distribution server\. Check out commit to retrieve"
     task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
+      unless Pkg::Config.project
+        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+      end
       remote_target = args.remote_target || "artifacts"
       local_target = args.local_target || "pkg"
       mkdir_p local_target
@@ -35,6 +38,9 @@ if Pkg::Config.build_pe
     namespace :jenkins do
       desc "Retrieve packages from the distribution server\. Check out commit to retrieve"
       task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
+        unless Pkg::Config.project
+          fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+        end
         remote_target = args.remote_target || "artifacts"
         local_target = args.local_target || "pkg"
         build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -527,6 +527,9 @@ namespace :pl do
     desc 'ship pkg directory contents to artifactory'
     task :ship_to_artifactory, :local_dir do |_t, args|
       Pkg::Util::RakeUtils.invoke_task('pl:fetch')
+      unless Pkg::Config.project
+        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+      end
       artifactory = Pkg::ManageArtifactory.new(Pkg::Config.project, Pkg::Config.ref)
 
       local_dir = args.local_dir || 'pkg'
@@ -538,6 +541,9 @@ namespace :pl do
     desc 'Ship pkg directory contents to distribution server'
     task :ship, :target, :local_dir do |_t, args|
       Pkg::Util::RakeUtils.invoke_task('pl:fetch')
+      unless Pkg::Config.project
+        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+      end
       target = args.target || 'artifacts'
       local_dir = args.local_dir || 'pkg'
       project_basedir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"


### PR DESCRIPTION
This commit adds a `PROJECT` environment variable that overrides/sets
`Pkg::Config.project` and adds explicit failures when shipping or retrieving
if the project is unset. Since we now have some repos that build multiple
different packages, we need to allow for different project names so that these
packages end up in separate directories on builds.