### PR TITLE
(maint) Rename the `PROJECT` environment variable to `PROJECT_OVERRIDE`

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -266,7 +266,7 @@ module Pkg::Params
               { :var => :pe_feature_branch,       :envvar => :PE_FEATURE_BRANCH },
               { :var => :pe_version,              :envvar => :PE_VER },
               { :var => :privatekey_pem,          :envvar => :PRIVATE_PEM },
-              { :var => :project,                 :envvar => :PROJECT },
+              { :var => :project,                 :envvar => :PROJECT_OVERRIDE },
               { :var => :project_root,            :envvar => :PROJECT_ROOT },
               { :var => :random_mockroot,         :envvar => :RANDOM_MOCKROOT, :type => :bool },
               { :var => :rc_mocks,                :envvar => :MOCK },


### PR DESCRIPTION
`PROJECT` is in use in many places and with the nature of that change,
things are ending up in the incorrect repos on our builds server.
Updating that environment variable to `PROJECT_OVERRIDE` will allow us
to maintain the feature as needed while being less disruptive to
existing workflows.