### PR TITLE
(RE-10926) Check for signature before signing rpms

### DIFF
--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -37,4 +37,70 @@ module Pkg::Sign::Rpm
     %x(rpm -Kv #{rpm} | grep "#{Pkg::Util::Gpg.key.downcase}" &> /dev/null)
     $?.success?
   end
+
+  def sign_all(rpm_directory)
+    # Create a hash mapping full paths to basenames.
+    # This will allow us to keep track of the different paths that may be
+    # associated with a single basename, e.g. noarch packages.
+    all_rpms = {}
+    rpms_to_sign = Dir["#{rpm_directory}/**/*.rpm"]
+    rpms_to_sign.each do |rpm_path|
+      all_rpms[rpm_path] = File.basename(rpm_path)
+    end
+    # Delete a package, both from the signing server and from the rpm array, if
+    # there are other packages with the same basename so that we only sign the
+    # package once.
+    all_rpms.each do |rpm_path, rpm_filename|
+      if rpms_to_sign.map { |rpm| File.basename(rpm) }.count(rpm_filename) > 1
+        FileUtils.rm(rpm_path)
+        rpms_to_sign.delete(rpm_path)
+      end
+    end
+
+    v3_rpms = []
+    v4_rpms = []
+    rpms_to_sign.each do |rpm|
+      if has_sig? rpm
+        puts "#{rpm} is already signed, skipping . . ."
+        next
+      end
+      platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
+      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
+
+      # We don't sign AIX rpms
+      next if platform_tag.include?('aix')
+
+      sig_type = Pkg::Platforms.signature_format_for_platform_version(platform, version)
+      case sig_type
+      when 'v3'
+        v3_rpms << rpm
+      when 'v4'
+        v4_rpms << rpm
+      else
+        fail "Cannot find signature type for package '#{rpm}'"
+      end
+    end
+
+    unless v3_rpms.empty?
+      puts "Signing old rpms..."
+      legacy_sign(v3_rpms.join(' '))
+    end
+
+    unless v4_rpms.empty?
+      puts "Signing modern rpms..."
+      sign(v4_rpms.join(' '))
+    end
+
+    # Using the map of paths to basenames, we re-hardlink the rpms we deleted.
+    all_rpms.each do |link_path, rpm_filename|
+      next if File.exist? link_path
+      FileUtils.mkdir_p(File.dirname(link_path))
+      # Find paths where the signed rpm has the same basename, but different
+      # full path, as the one we need to link.
+      paths_to_link_to = rpms_to_sign.select { |rpm| File.basename(rpm) == rpm_filename && rpm != link_path }
+      paths_to_link_to.each do |path|
+        FileUtils.ln(path, link_path, :force => true, :verbose => true)
+      end
+    end
+  end
 end

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -70,8 +70,7 @@ module Pkg::Sign::Rpm
       # We don't sign AIX rpms
       next if platform_tag.include?('aix')
 
-      sig_type = Pkg::Platforms.signature_format_for_platform_version(platform, version)
-      case sig_type
+      case Pkg::Platforms.signature_format_for_platform_version(platform, version)
       when 'v3'
         v3_rpms << rpm
       when 'v4'
@@ -82,12 +81,12 @@ module Pkg::Sign::Rpm
     end
 
     unless v3_rpms.empty?
-      puts "Signing old rpms..."
+      puts "Signing legacy (v3) rpms..."
       legacy_sign(v3_rpms.join(' '))
     end
 
     unless v4_rpms.empty?
-      puts "Signing modern rpms..."
+      puts "Signing modern (v4) rpms..."
       sign(v4_rpms.join(' '))
     end
 

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+require 'packaging/sign'
+
+describe 'Pkg::Sign' do
+  describe 'Pkg::Sign::Rpm' do
+
+    before :each do
+      allow(Pkg::Config).to receive(:gpg_key).and_return('7F438280EF8D349F')
+    end
+
+    describe '#sign_all' do
+      let(:rpm_directory) { 'foo' }
+      let(:rpms_not_to_sign) { [
+        "#{rpm_directory}/aix/6.1/PC1/ppc/puppet-agent-5.5.3-1.aix6.1.ppc.rpm",
+        "#{rpm_directory}/aix/7.1/PC1/ppc/puppet-agent-5.5.3-1.aix7.1.ppc.rpm",
+      ] }
+      let(:v3_rpms) { [
+        "#{rpm_directory}/el/5/PC1/i386/puppet-agent-5.5.3-1.el5.i386.rpm",
+        "#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm",
+      ] }
+      let(:v4_rpms) { [
+        "#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm",
+        "#{rpm_directory}/sles/12/PC1/s390x/puppet-agent-5.5.3-1.sles12.s390x.rpm",
+      ] }
+      let(:rpms) { rpms_not_to_sign + v3_rpms + v4_rpms }
+      let(:already_signed_rpms) { [
+        "#{rpm_directory}/cisco-wrlinux/7/PC1/x86_64/puppet-agent-5.5.3-1.cisco_wrlinux7.x86_64.rpm",
+        "#{rpm_directory}/el/6/PC1/x86_64/puppet-agent-5.5.3-1.el6.x86_64.rpm",
+      ] }
+      let(:noarch_rpms) { [
+        "#{rpm_directory}/el/6/puppet5/i386/puppetserver-5.3.3-1.el6.noarch.rpm",
+        "#{rpm_directory}/el/6/puppet5/x86_64/puppetserver-5.3.3-1.el6.noarch.rpm",
+        "#{rpm_directory}/el/7/puppet5/i386/puppetserver-5.3.3-1.el7.noarch.rpm",
+        "#{rpm_directory}/el/7/puppet5/x86_64/puppetserver-5.3.3-1.el7.noarch.rpm",
+        "#{rpm_directory}/sles/12/puppet5/i386/puppetserver-5.3.3-1.sles12.noarch.rpm",
+        "#{rpm_directory}/sles/12/puppet5/x86_64/puppetserver-5.3.3-1.sles12.noarch.rpm"
+      ] }
+
+      it 'signs both v3 and v4 rpms' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms)
+        rpms.each do |rpm|
+          allow(Pkg::Sign::Rpm).to receive(:has_sig?).and_return(false)
+        end
+        expect(Pkg::Sign::Rpm).to receive(:legacy_sign).with(v3_rpms.join(' '))
+        expect(Pkg::Sign::Rpm).to receive(:sign).with(v4_rpms.join(' '))
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'does not sign AIX rpms' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms_not_to_sign)
+        expect(Pkg::Sign::Rpm).to_not receive(:legacy_sign)
+        expect(Pkg::Sign::Rpm).to_not receive(:sign)
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'does not sign already-signed rpms' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(already_signed_rpms)
+        already_signed_rpms.each do |rpm|
+          allow(Pkg::Sign::Rpm).to receive(:has_sig?).and_return(true)
+        end
+        expect(Pkg::Sign::Rpm).to_not receive(:legacy_sign)
+        expect(Pkg::Sign::Rpm).to_not receive(:sign)
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'deletes and relinks rpms with the same basename' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(noarch_rpms)
+        allow(Pkg::Sign::Rpm).to receive(:sign)
+        expect(FileUtils).to receive(:rm).exactly(noarch_rpms.count/2).times
+        expect(FileUtils).to receive(:ln).exactly(noarch_rpms.count/2).times
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'does not fail if there are no rpms to sign' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return([])
+        expect(Pkg::Sign::Rpm.sign_all(rpm_directory)).to_not raise_error
+      end
+    end
+  end
+end

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -38,71 +38,8 @@ namespace :pl do
 
   desc "Sign mocked rpms, Defaults to PL Key, pass GPG_KEY to override"
   task :sign_rpms, :root_dir do |t, args|
-    rpm_dir = args.root_dir || $DEFAULT_DIRECTORY
-
-    # Create a hash mapping full paths to basenames.
-    # This will allow us to keep track of the different paths that may be
-    # associated with a single basename, e.g. noarch packages.
-    all_rpms = {}
-    rpms_to_sign = Dir["#{rpm_dir}/**/*.rpm"]
-    rpms_to_sign.each do |rpm_path|
-      all_rpms[rpm_path] = File.basename(rpm_path)
-    end
-    # Delete a package, both from the signing server and from the rpm array, if
-    # there are other packages with the same basename so that we only sign the
-    # package once.
-    all_rpms.each do |rpm_path, rpm_filename|
-      if rpms_to_sign.map { |rpm| File.basename(rpm) }.count(rpm_filename) > 1
-        FileUtils.rm(rpm_path)
-        rpms_to_sign.delete(rpm_path)
-      end
-    end
-
-    v3_rpms = []
-    v4_rpms = []
-    rpms_to_sign.each do |rpm|
-      if Pkg::Sign::Rpm.has_sig? rpm
-        puts "#{rpm} is already signed, skipping . . ."
-        next
-      end
-      platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
-      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
-
-      # We don't sign AIX rpms
-      next if platform_tag.include?('aix')
-
-      sig_type = Pkg::Platforms.signature_format_for_platform_version(platform, version)
-      case sig_type
-      when 'v3'
-        v3_rpms << rpm
-      when 'v4'
-        v4_rpms << rpm
-      else
-        fail "Cannot find signature type for package '#{rpm}'"
-      end
-    end
-
-    unless v3_rpms.empty?
-      puts "Signing old rpms..."
-      Pkg::Sign::Rpm.legacy_sign(v3_rpms.join(' '))
-    end
-
-    unless v4_rpms.empty?
-      puts "Signing modern rpms..."
-      Pkg::Sign::Rpm.sign(v4_rpms.join(' '))
-    end
-
-    # Using the map of paths to basenames, we re-hardlink the rpms we deleted.
-    all_rpms.each do |link_path, rpm_filename|
-      next if File.exist? link_path
-      FileUtils.mkdir_p(File.dirname(link_path))
-      # Find paths where the signed rpm has the same basename, but different
-      # full path, as the one we need to link.
-      paths_to_link_to = rpms_to_sign.select { |rpm| File.basename(rpm) == rpm_filename && rpm != link_path }
-      paths_to_link_to.each do |path|
-        FileUtils.ln(path, link_path, :force => true, :verbose => true)
-      end
-    end
+    rpm_directory = args.root_dir || $DEFAULT_DIRECTORY
+    sign_all(rpm_directory)
   end
 
   desc "Sign ips package, uses PL certificates by default, update privatekey_pem, certificate_pem, and ips_inter_cert in build_defaults.yaml to override."

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -61,6 +61,10 @@ namespace :pl do
     v3_rpms = []
     v4_rpms = []
     rpms_to_sign.each do |rpm|
+      if Pkg::Sign::Rpm.has_sig? rpm
+        puts "#{rpm} is already signed, skipping . . ."
+        next
+      end
       platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
       platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
 


### PR DESCRIPTION
This commit adds a check to the `sign_rpms` task to skip signing if the rpm is already signed. Previously, if we tried to sign more than once, a non-zero exit code would be returned, which caused failures.