### PR TITLE
(maint) Bump rvm ruby version used in remote bundle install

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -361,7 +361,7 @@ git clone --recursive /tmp/#{tarball_name} /tmp/#{Pkg::Config.project}-#{appendi
 cd /tmp/#{Pkg::Config.project}-#{appendix} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems ;
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems ;
   bundle_prefix='bundle exec' ;
 fi ;
 $bundle_prefix rake package:bootstrap

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -25,7 +25,7 @@ namespace :pl do
 cd #{remote_repo} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems;
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
   bundle_prefix='bundle exec';
 fi ;
 $bundle_prefix rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -200,7 +200,7 @@ namespace :pl do
 cd #{remote_repo} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.3.1; bundle install --path .bundle/gems;
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
   bundle_prefix='bundle exec';
 fi ;
 $bundle_prefix rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}


### PR DESCRIPTION
This commit changes the ruby used when bundle installing on remote hosts from
2.3.1 to 2.4.1. Due to a rubygems bug
(https://github.com/rubygems/rubygems/issues/1448), bundler was attempting to
install the packaging gem in the wrong path. I was only able to reproduce this
issue using ruby 2.3.1, so I am bumping to the next later version that is
installed on the jenkins workers.