### PR TITLE
(maint) update foss components to retrieve gems correctly

### DIFF
--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -51,9 +51,8 @@ namespace :pl do
             end
           end
 
-          # also want to fetch the yaml and the signing bundle
-          sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.yaml' #{package_url}/#{remote_target}/"
-          sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --accept '*.tar.gz' #{package_url}/#{remote_target}/"
+          # fetch all top level files so we don't miss anything
+          sh "#{wget} --quiet -r -np -nH -l 0 --cut-dirs 3 -P #{local_target} --reject 'index*' --level=1 #{package_url}/#{remote_target}/"
 
           # Recursively remove empty directories under pkg
           Dir.glob("#{local_target}/**/*").select { |f| File.directory? f }.sort.uniq.reverse.each do |path|


### PR DESCRIPTION
we previously weren't correctly grabbing the packages that we needed resulting in gems not getting shipped. with this update component packages will be appropriately fetched.
![](https://media.giphy.com/media/xT9KVF4zNt70nyNpi8/giphy.gif)

Tested with Puppet 5.5.2
