### PR TITLE
(maint) Fix fail messages when 'project' is unset

### DIFF
--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -15,7 +15,7 @@ namespace :pl do
     desc "Retrieve packages from the distribution server\. Check out commit to retrieve"
     task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
       unless Pkg::Config.project
-        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
       end
       remote_target = args.remote_target || "artifacts"
       local_target = args.local_target || "pkg"
@@ -39,7 +39,7 @@ if Pkg::Config.build_pe
       desc "Retrieve packages from the distribution server\. Check out commit to retrieve"
       task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
         unless Pkg::Config.project
-          fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+          fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
         end
         remote_target = args.remote_target || "artifacts"
         local_target = args.local_target || "pkg"

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -528,7 +528,7 @@ namespace :pl do
     task :ship_to_artifactory, :local_dir do |_t, args|
       Pkg::Util::RakeUtils.invoke_task('pl:fetch')
       unless Pkg::Config.project
-        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
       end
       artifactory = Pkg::ManageArtifactory.new(Pkg::Config.project, Pkg::Config.ref)
 
@@ -542,7 +542,7 @@ namespace :pl do
     task :ship, :target, :local_dir do |_t, args|
       Pkg::Util::RakeUtils.invoke_task('pl:fetch')
       unless Pkg::Config.project
-        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT' environment variable."
+        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
       end
       target = args.target || 'artifacts'
       local_dir = args.local_dir || 'pkg'


### PR DESCRIPTION
We updated the `PROJECT` environment variable to `PROJECT_OVERRIDE` but forgot
to update error messages.