### PR TITLE
(maint) Fix find_tool for windows

### DIFF
--- a/lib/packaging/util/tool.rb
+++ b/lib/packaging/util/tool.rb
@@ -19,7 +19,7 @@ module Pkg::Util::Tool
           exts.each do |ext|
             locationext = File.expand_path(location + ext)
 
-            return locationext if FileTest.executable?(locationext)
+            return '"' + locationext + '"' if FileTest.executable?(locationext)
           end
         end
 


### PR DESCRIPTION
Windows executables can have spaces in the path, so surround the path found by
find_tool with "s on windows