### PR TITLE
(RE-10177) Remove bootstrap functionality

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -359,12 +359,12 @@ module Pkg::Util::Net
 #{tar} -zxvf /tmp/#{tarball_name}.tar.gz -C /tmp/ ;
 git clone --recursive /tmp/#{tarball_name} /tmp/#{Pkg::Config.project}-#{appendix} ;
 cd /tmp/#{Pkg::Config.project}-#{appendix} ;
-bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems ;
-  bundle_prefix='bundle exec' ;
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems --binstubs .bundle/bin ;
+else
+  echo "ERROR: Couldn't read Gemfile, can't bundle install."
+  exit 1
 fi ;
-$bundle_prefix rake package:bootstrap
 DOC
       Pkg::Util::Net.remote_ssh_cmd(host, command)
       "/tmp/#{Pkg::Config.project}-#{appendix}"

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -53,13 +53,13 @@
 #     pushd git_repo
 #
 #     ### Clone the packaging repo
-#     rake package:bootstrap
+#     bundle install --path .bundle/gems --binstubs .bundle/bin --retry 3
 #
 #     ### Perform the build
-#     rake pl:build_from_params PARAMS_FILE=$WORKSPACE/BUILD_PROPERTIES
+#     bundle exec rake pl:build_from_params PARAMS_FILE=$WORKSPACE/BUILD_PROPERTIES
 #
 #     ### Send the results
-#     rake pl:jenkins:ship["artifacts"] PARAMS_FILE=$WORKSPACE/BUILD_PROPERTIES
+#     bundle exec rake pl:jenkins:ship["artifacts"] PARAMS_FILE=$WORKSPACE/BUILD_PROPERTIES
 #
 #   popd
 # popd
@@ -75,7 +75,7 @@
 # if [ -n "$DOWNSTREAM_JOB" ] ; then
 #   pushd project
 #     pushd git_repo
-#       rake pl:jenkins:post["$DOWNSTREAM_JOB"] PARAMS_FILE=$WORKSPACE/BUILD_PROPERTIES
+#       bundle exec rake pl:jenkins:post["$DOWNSTREAM_JOB"] PARAMS_FILE=$WORKSPACE/BUILD_PROPERTIES
 #     popd
 #   popd
 # fi

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -23,12 +23,13 @@ namespace :pl do
       Pkg::Util::Net.rsync_to('repos', signing_server, remote_repo)
       rake_command = <<-DOC
 cd #{remote_repo} ;
-bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
-  bundle_prefix='bundle exec';
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems --binstubs .bundle/bin;
+else
+  echo "ERROR: Couldn't read Gemfile, can't bundle install."
+  exit 1
 fi ;
-$bundle_prefix rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}
+bundle exec rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}
 DOC
       Pkg::Util::Net.remote_ssh_cmd(signing_server, rake_command)
       Pkg::Util::Net.rsync_from("#{remote_repo}/repos/", signing_server, target)

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -198,12 +198,13 @@ namespace :pl do
       Pkg::Util::Net.rsync_to(root_dir, Pkg::Config.signing_server, remote_repo)
       rake_command = <<-DOC
 cd #{remote_repo} ;
-bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
-  bundle_prefix='bundle exec';
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems --binstubs .bundle/bin;
+else
+  echo "ERROR: Couldn't read Gemfile, can't bundle install."
+  exit 1
 fi ;
-$bundle_prefix rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}
+bundle exec rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}
 DOC
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, rake_command)
       Pkg::Util::Net.rsync_from("#{remote_repo}/#{root_dir}/", Pkg::Config.signing_server, "#{$DEFAULT_DIRECTORY}/")


### PR DESCRIPTION
This commit removes all invocations of `rake package:bootstrap` and replaces
them with `bundle install`s. As we are moving towards everything using the
packaging gem, package:bootstrap is no longer needed.