### PR TITLE
(RE-10177) Update packaging and repo templates to bundle install

### DIFF
--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -37,7 +37,7 @@ pl:jenkins:uber_build NOTIFY=foo@puppetlabs.com&#xd;
   Successful completion of packaging will result in the automatic creation of&#xd;
   apt/yum repositories on the distribution server with the built packages.  To&#xd;
   generate client apt/yum repository config files for accessing these packages,&#xd;
-  check out the ref of the git sha that was packaged, and run `rake&#xd;
+  check out the ref of the git sha that was packaged, and run `bundle exec rake&#xd;
   pl:jenkins:(deb|rpm)_repo_configs`. Configuration files will be generated and&#xd;
   deposited locally in pkg/repo_configs.&#xd;
 &lt;/p&gt;&#xd;
@@ -146,13 +146,13 @@ pushd project
   pushd git_repo
 
     ### Clone the packaging repo
-    rake package:bootstrap
+    bundle install --path .bundle/gems --binstubs .bundle/bin --retry 3
 
     ### Perform the build
-    rake $command PARAMS_FILE=&quot;$WORKSPACE/BUILD_PROPERTIES&quot; --trace
+    bundle exec rake $command PARAMS_FILE=&quot;$WORKSPACE/BUILD_PROPERTIES&quot; --trace
 
     ### Send the results
-    rake pl:jenkins:ship[&quot;artifacts&quot;] PARAMS_FILE=&quot;$WORKSPACE/BUILD_PROPERTIES&quot; --trace
+    bundle exec rake pl:jenkins:ship[&quot;artifacts&quot;] PARAMS_FILE=&quot;$WORKSPACE/BUILD_PROPERTIES&quot; --trace
 
   popd
 popd</command>

--- a/templates/repo.xml.erb
+++ b/templates/repo.xml.erb
@@ -71,16 +71,16 @@ if [ $PACKAGE_BUILD_RESULT -eq 0 ] ; then
     pushd git_repo
 
       ### Clone the packaging repo
-      rake package:bootstrap --trace
+      bundle install --path .bundle/gems --binstubs .bundle/bin --retry 3
 
       ### Run repo creation
 <% if Pkg::Config.final_mocks and not Pkg::Config.final_mocks.empty? %>
-      rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:rpm_repos --trace
+      bundle exec rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:rpm_repos --trace
 <% else %>
       echo "No mock/rpm targets found, skipping rpm repo creation"
 <% end %>
 <% if Pkg::Config.cows and not Pkg::Config.cows.empty? %>
-      rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:deb_repos --trace
+      bundle exec rake PARAMS_FILE=../../BUILD_PROPERTIES pl:jenkins:deb_repos --trace
 <% else %>
       echo "No cow/deb targets found, skipping deb repo creation"
 <% end %>


### PR DESCRIPTION
This commit updates the templates used to generate the jenkins jobs for
building gems and tarballs (e.g. for razor-client, puppet, etc.) to `bundle
install` in order to use packaging as a gem.