### PR TITLE
(RE-10924) Package signing fails if already signed

### DIFF
--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -37,4 +37,69 @@ module Pkg::Sign::Rpm
     %x(rpm -Kv #{rpm} | grep "#{Pkg::Util::Gpg.key.downcase}" &> /dev/null)
     $?.success?
   end
+
+  def sign_all(rpm_directory)
+    # Create a hash mapping full paths to basenames.
+    # This will allow us to keep track of the different paths that may be
+    # associated with a single basename, e.g. noarch packages.
+    all_rpms = {}
+    rpms_to_sign = Dir["#{rpm_directory}/**/*.rpm"]
+    rpms_to_sign.each do |rpm_path|
+      all_rpms[rpm_path] = File.basename(rpm_path)
+    end
+    # Delete a package, both from the signing server and from the rpm array, if
+    # there are other packages with the same basename so that we only sign the
+    # package once.
+    all_rpms.each do |rpm_path, rpm_filename|
+      if rpms_to_sign.map { |rpm| File.basename(rpm) }.count(rpm_filename) > 1
+        FileUtils.rm(rpm_path)
+        rpms_to_sign.delete(rpm_path)
+      end
+    end
+
+    v3_rpms = []
+    v4_rpms = []
+    rpms_to_sign.each do |rpm|
+      if has_sig? rpm
+        puts "#{rpm} is already signed, skipping . . ."
+        next
+      end
+      platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
+      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
+
+      # We don't sign AIX rpms
+      next if platform_tag.include?('aix')
+
+      case Pkg::Platforms.signature_format_for_platform_version(platform, version)
+      when 'v3'
+        v3_rpms << rpm
+      when 'v4'
+        v4_rpms << rpm
+      else
+        fail "Cannot find signature type for package '#{rpm}'"
+      end
+    end
+
+    unless v3_rpms.empty?
+      puts "Signing legacy (v3) rpms..."
+      legacy_sign(v3_rpms.join(' '))
+    end
+
+    unless v4_rpms.empty?
+      puts "Signing modern (v4) rpms..."
+      sign(v4_rpms.join(' '))
+    end
+
+    # Using the map of paths to basenames, we re-hardlink the rpms we deleted.
+    all_rpms.each do |link_path, rpm_filename|
+      next if File.exist? link_path
+      FileUtils.mkdir_p(File.dirname(link_path))
+      # Find paths where the signed rpm has the same basename, but different
+      # full path, as the one we need to link.
+      paths_to_link_to = rpms_to_sign.select { |rpm| File.basename(rpm) == rpm_filename && rpm != link_path }
+      paths_to_link_to.each do |path|
+        FileUtils.ln(path, link_path, :force => true, :verbose => true)
+      end
+    end
+  end
 end

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -39,7 +39,7 @@ module Pkg::Sign::Rpm
     # lowercase, since that's what the `rpm -Kv` output uses.
     key = Pkg::Util::Gpg.key.downcase.chars.last(8).join
     signature_check_output, _, _ = Pkg::Util::Execution.capture3("rpm --checksig --verbose #{rpm}")
-    return signature_check_output.include? key
+    return signature_check_output.include? "key ID #{key}"
   end
 
   def sign_all(rpm_directory)

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+require 'packaging/sign'
+
+describe 'Pkg::Sign' do
+  describe 'Pkg::Sign::Rpm' do
+
+    before :each do
+      allow(Pkg::Config).to receive(:gpg_key).and_return('7F438280EF8D349F')
+    end
+
+    describe '#sign_all' do
+      let(:rpm_directory) { 'foo' }
+      let(:rpms_not_to_sign) { [
+        "#{rpm_directory}/aix/6.1/PC1/ppc/puppet-agent-5.5.3-1.aix6.1.ppc.rpm",
+        "#{rpm_directory}/aix/7.1/PC1/ppc/puppet-agent-5.5.3-1.aix7.1.ppc.rpm",
+      ] }
+      let(:v3_rpms) { [
+        "#{rpm_directory}/el/5/PC1/i386/puppet-agent-5.5.3-1.el5.i386.rpm",
+        "#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm",
+      ] }
+      let(:v4_rpms) { [
+        "#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm",
+        "#{rpm_directory}/sles/12/PC1/s390x/puppet-agent-5.5.3-1.sles12.s390x.rpm",
+      ] }
+      let(:rpms) { rpms_not_to_sign + v3_rpms + v4_rpms }
+      let(:already_signed_rpms) { [
+        "#{rpm_directory}/cisco-wrlinux/7/PC1/x86_64/puppet-agent-5.5.3-1.cisco_wrlinux7.x86_64.rpm",
+        "#{rpm_directory}/el/6/PC1/x86_64/puppet-agent-5.5.3-1.el6.x86_64.rpm",
+      ] }
+      let(:noarch_rpms) { [
+        "#{rpm_directory}/el/6/puppet5/i386/puppetserver-5.3.3-1.el6.noarch.rpm",
+        "#{rpm_directory}/el/6/puppet5/x86_64/puppetserver-5.3.3-1.el6.noarch.rpm",
+        "#{rpm_directory}/el/7/puppet5/i386/puppetserver-5.3.3-1.el7.noarch.rpm",
+        "#{rpm_directory}/el/7/puppet5/x86_64/puppetserver-5.3.3-1.el7.noarch.rpm",
+        "#{rpm_directory}/sles/12/puppet5/i386/puppetserver-5.3.3-1.sles12.noarch.rpm",
+        "#{rpm_directory}/sles/12/puppet5/x86_64/puppetserver-5.3.3-1.sles12.noarch.rpm"
+      ] }
+
+      it 'signs both v3 and v4 rpms' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms)
+        rpms.each do |rpm|
+          allow(Pkg::Sign::Rpm).to receive(:has_sig?).and_return(false)
+        end
+        expect(Pkg::Sign::Rpm).to receive(:legacy_sign).with(v3_rpms.join(' '))
+        expect(Pkg::Sign::Rpm).to receive(:sign).with(v4_rpms.join(' '))
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'does not sign AIX rpms' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms_not_to_sign)
+        expect(Pkg::Sign::Rpm).to_not receive(:legacy_sign)
+        expect(Pkg::Sign::Rpm).to_not receive(:sign)
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'does not sign already-signed rpms' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(already_signed_rpms)
+        already_signed_rpms.each do |rpm|
+          allow(Pkg::Sign::Rpm).to receive(:has_sig?).and_return(true)
+        end
+        expect(Pkg::Sign::Rpm).to_not receive(:legacy_sign)
+        expect(Pkg::Sign::Rpm).to_not receive(:sign)
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'deletes and relinks rpms with the same basename' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(noarch_rpms)
+        allow(Pkg::Sign::Rpm).to receive(:sign)
+        expect(FileUtils).to receive(:rm).exactly(noarch_rpms.count/2).times
+        expect(FileUtils).to receive(:ln).exactly(noarch_rpms.count/2).times
+        Pkg::Sign::Rpm.sign_all(rpm_directory)
+      end
+
+      it 'does not fail if there are no rpms to sign' do
+        allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return([])
+        expect(Pkg::Sign::Rpm.sign_all(rpm_directory)).to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -37,20 +37,24 @@ MD5 digest: OK (816095f3cee145091c3fa07a0915ce85)
 DOC
       }
       it 'returns true if rpm has been signed (el7)' do
-        allow(Pkg::Util::Execution).to receive(:capture3).and_return([el7_signed_response, '', 0])
+        allow(Pkg::Sign::Rpm).to receive(:`).and_return(el7_signed_response)
         expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
       end
       it 'returns true if rpm has been signed (el5)' do
-        allow(Pkg::Util::Execution).to receive(:capture3).and_return([el5_signed_response, '', 0])
+        allow(Pkg::Sign::Rpm).to receive(:`).and_return(el5_signed_response)
         expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
       end
       it 'returns true if rpm has been signed (sles12)' do
-        allow(Pkg::Util::Execution).to receive(:capture3).and_return([sles12_signed_response, '', 0])
+        allow(Pkg::Sign::Rpm).to receive(:`).and_return(sles12_signed_response)
         expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
       end
       it 'returns false if rpm has not been signed' do
-        allow(Pkg::Util::Execution).to receive(:capture3).and_return([unsigned_response, '', 0])
+        allow(Pkg::Sign::Rpm).to receive(:`).and_return(unsigned_response)
         expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be false
+      end
+      it 'fails with unexpected output' do
+        allow(Pkg::Sign::Rpm).to receive(:`).and_return('something that is definitely not a normal response')
+        expect { Pkg::Sign::Rpm.has_sig?(rpm) }.to raise_error(RuntimeError, /Something went wrong checking the signature/)
       end
       it 'fails if gpg_key is not set' do
         allow(Pkg::Config).to receive(:gpg_key).and_return(nil)

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -30,6 +30,10 @@ DOC
         allow(Pkg::Util::Execution).to receive(:capture3).and_return([unsigned_response, '', 0])
         expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be false
       end
+      it 'fails if gpg_key is not set' do
+        allow(Pkg::Config).to receive(:gpg_key).and_return(nil)
+        expect { Pkg::Sign::Rpm.has_sig?(rpm) }.to raise_error(RuntimeError, /You need to set `gpg_key` in your build defaults./)
+      end
     end
 
     describe '#sign_all' do

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -10,11 +10,25 @@ describe 'Pkg::Sign' do
 
     describe '#has_sig?' do
       let(:rpm) { 'foo.rpm' }
-      let(:signed_response) { <<-DOC
+      let(:el7_signed_response) { <<-DOC
 Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
 Header SHA1 digest: OK (3cb7e9861e8bc09783a1b6c8d88243a3c16daa81)
 V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
 MD5 digest: OK (d5f06ba2a9053de532326d0659ec0d11)
+DOC
+      }
+      let(:el5_signed_response) { <<-DOC
+Header V3 RSA/SHA1 signature: NOKEY, key ID ef8d349f
+Header SHA1 digest: OK (12ea7bd578097a3aecc5deb8ada6aca6147d68e3)
+V3 RSA/SHA1 signature: NOKEY, key ID ef8d349f
+MD5 digest: OK (27353c6153068a3c9902fcb4ad5b8b92)
+DOC
+      }
+      let(:sles12_signed_response) { <<-DOC
+Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
+Header SHA1 digest: OK (e713487cf21ebeb933aefd5ec9211a34603233d2)
+V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
+MD5 digest: OK (3093a09ac39bc17751f913e19ca74432)
 DOC
       }
       let(:unsigned_response) { <<-DOC
@@ -22,8 +36,16 @@ Header SHA1 digest: OK (f9404cc95f200568c2dbb1fd24e1119e3e4a40a9)
 MD5 digest: OK (816095f3cee145091c3fa07a0915ce85)
 DOC
       }
-      it 'returns true if rpm has been signed' do
-        allow(Pkg::Util::Execution).to receive(:capture3).and_return([signed_response, '', 0])
+      it 'returns true if rpm has been signed (el7)' do
+        allow(Pkg::Util::Execution).to receive(:capture3).and_return([el7_signed_response, '', 0])
+        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
+      end
+      it 'returns true if rpm has been signed (el5)' do
+        allow(Pkg::Util::Execution).to receive(:capture3).and_return([el5_signed_response, '', 0])
+        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
+      end
+      it 'returns true if rpm has been signed (sles12)' do
+        allow(Pkg::Util::Execution).to receive(:capture3).and_return([sles12_signed_response, '', 0])
         expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
       end
       it 'returns false if rpm has not been signed' do

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -38,67 +38,8 @@ namespace :pl do
 
   desc "Sign mocked rpms, Defaults to PL Key, pass GPG_KEY to override"
   task :sign_rpms, :root_dir do |t, args|
-    rpm_dir = args.root_dir || $DEFAULT_DIRECTORY
-
-    # Create a hash mapping full paths to basenames.
-    # This will allow us to keep track of the different paths that may be
-    # associated with a single basename, e.g. noarch packages.
-    all_rpms = {}
-    rpms_to_sign = Dir["#{rpm_dir}/**/*.rpm"]
-    rpms_to_sign.each do |rpm_path|
-      all_rpms[rpm_path] = File.basename(rpm_path)
-    end
-    # Delete a package, both from the signing server and from the rpm array, if
-    # there are other packages with the same basename so that we only sign the
-    # package once.
-    all_rpms.each do |rpm_path, rpm_filename|
-      if rpms_to_sign.map { |rpm| File.basename(rpm) }.count(rpm_filename) > 1
-        FileUtils.rm(rpm_path)
-        rpms_to_sign.delete(rpm_path)
-      end
-    end
-
-    v3_rpms = []
-    v4_rpms = []
-    rpms_to_sign.each do |rpm|
-      platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
-      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
-
-      # We don't sign AIX rpms
-      next if platform_tag.include?('aix')
-
-      sig_type = Pkg::Platforms.signature_format_for_platform_version(platform, version)
-      case sig_type
-      when 'v3'
-        v3_rpms << rpm
-      when 'v4'
-        v4_rpms << rpm
-      else
-        fail "Cannot find signature type for package '#{rpm}'"
-      end
-    end
-
-    unless v3_rpms.empty?
-      puts "Signing old rpms..."
-      Pkg::Sign::Rpm.legacy_sign(v3_rpms.join(' '))
-    end
-
-    unless v4_rpms.empty?
-      puts "Signing modern rpms..."
-      Pkg::Sign::Rpm.sign(v4_rpms.join(' '))
-    end
-
-    # Using the map of paths to basenames, we re-hardlink the rpms we deleted.
-    all_rpms.each do |link_path, rpm_filename|
-      next if File.exist? link_path
-      FileUtils.mkdir_p(File.dirname(link_path))
-      # Find paths where the signed rpm has the same basename, but different
-      # full path, as the one we need to link.
-      paths_to_link_to = rpms_to_sign.select { |rpm| File.basename(rpm) == rpm_filename && rpm != link_path }
-      paths_to_link_to.each do |path|
-        FileUtils.ln(path, link_path, :force => true, :verbose => true)
-      end
-    end
+    rpm_directory = args.root_dir || $DEFAULT_DIRECTORY
+    Pkg::Sign::Rpm.sign_all(rpm_directory)
   end
 
   desc "Sign ips package, uses PL certificates by default, update privatekey_pem, certificate_pem, and ips_inter_cert in build_defaults.yaml to override."


### PR DESCRIPTION
This PR includes:
- Reverting the revert of the work I did on this previously, which includes:
  - moving the rpm `sign_all` functionality out of the rake file and into the Pkg::Sign::Rpm module
  - adding a `has_sig?` check to the `sign_all` method, so we skip signing already-signed things
- Refactoring `has_sig?`, including tests (see commit message for details)