### PR TITLE
Revert "(maint) Export PACKAGING_LOCATION before doing remote bundle installs"

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -361,7 +361,7 @@ git clone --recursive /tmp/#{tarball_name} /tmp/#{Pkg::Config.project}-#{appendi
 cd /tmp/#{Pkg::Config.project}-#{appendix} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; export PACKAGING_LOCATION=#{ENV['PACKAGING_LOCATION']}; bundle install --path .bundle/gems ;
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems ;
   bundle_prefix='bundle exec' ;
 fi ;
 $bundle_prefix rake package:bootstrap

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -25,7 +25,7 @@ namespace :pl do
 cd #{remote_repo} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; export PACKAGING_LOCATION=#{ENV['PACKAGING_LOCATION']}; bundle install --path .bundle/gems;
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
   bundle_prefix='bundle exec';
 fi ;
 $bundle_prefix rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -200,7 +200,7 @@ namespace :pl do
 cd #{remote_repo} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; export PACKAGING_LOCATION=#{ENV['PACKAGING_LOCATION']}; bundle install --path .bundle/gems;
+  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
   bundle_prefix='bundle exec';
 fi ;
 $bundle_prefix rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}

--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -146,7 +146,6 @@ pushd project
   pushd git_repo
 
     ### Clone the packaging repo
-    export PACKAGING_LOCATION=&quot;<%= ENV['PACKAGING_LOCATION'] %>&quot;
     bundle install --path .bundle/gems --binstubs .bundle/bin --retry 3
 
     ### Perform the build

--- a/templates/repo.xml.erb
+++ b/templates/repo.xml.erb
@@ -71,7 +71,6 @@ if [ $PACKAGE_BUILD_RESULT -eq 0 ] ; then
     pushd git_repo
 
       ### Clone the packaging repo
-      export PACKAGING_LOCATION=&quot;<%= ENV['PACKAGING_LOCATION'] %>&quot;
       bundle install --path .bundle/gems --binstubs .bundle/bin --retry 3
 
       ### Run repo creation


### PR DESCRIPTION
This reverts commit f91132f15fb0205492c431e1c7ef98971f799270.

Forgot to handle the case of when `PACKAGING_LOCATION` is unset.