### PR TITLE
(maint) Export PACKAGING_LOCATION before doing remote bundle installs (take two)

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -361,13 +361,19 @@ git clone --recursive /tmp/#{tarball_name} /tmp/#{Pkg::Config.project}-#{appendi
 cd /tmp/#{Pkg::Config.project}-#{appendix} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems ;
+  #{remote_bundle_install_command}
   bundle_prefix='bundle exec' ;
 fi ;
 $bundle_prefix rake package:bootstrap
 DOC
       Pkg::Util::Net.remote_ssh_cmd(host, command)
       "/tmp/#{Pkg::Config.project}-#{appendix}"
+    end
+
+    def remote_bundle_install_command
+      export_packaging_location = ''
+      export_packaging_location = "export PACKAGING_LOCATION=#{ENV['PACKAGING_LOCATION']};" if ENV['PACKAGING_LOCATION'] && !ENV['PACKAGING_LOCATION'].empty?
+      command = "source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; #{export_packaging_location} bundle install --path .bundle/gems ;"
     end
 
     # Given a BuildInstance object and a host, send its params to the host. Return

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -25,7 +25,7 @@ namespace :pl do
 cd #{remote_repo} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
+  #{Pkg::Util::Net.remote_bundle_install_command}
   bundle_prefix='bundle exec';
 fi ;
 $bundle_prefix rake pl:jenkins:sign_repos GPG_KEY=#{Pkg::Util::Gpg.key} PARAMS_FILE=#{build_params}

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -200,7 +200,7 @@ namespace :pl do
 cd #{remote_repo} ;
 bundle_prefix= ;
 if [[ -r Gemfile ]]; then
-  source /usr/local/rvm/scripts/rvm; rvm use ruby-2.4.1; bundle install --path .bundle/gems;
+  #{Pkg::Util::Net.remote_bundle_install_command}
   bundle_prefix='bundle exec';
 fi ;
 $bundle_prefix rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}

--- a/templates/packaging.xml.erb
+++ b/templates/packaging.xml.erb
@@ -146,6 +146,9 @@ pushd project
   pushd git_repo
 
     ### Clone the packaging repo
+    <% if ENV['PACKAGING_LOCATION'] && !ENV['PACKAGING_LOCATION'].empty? %>
+      export PACKAGING_LOCATION=&quot;<%= ENV['PACKAGING_LOCATION'] %>&quot;
+    <% end %>
     bundle install --path .bundle/gems --binstubs .bundle/bin --retry 3
 
     ### Perform the build

--- a/templates/repo.xml.erb
+++ b/templates/repo.xml.erb
@@ -71,6 +71,9 @@ if [ $PACKAGE_BUILD_RESULT -eq 0 ] ; then
     pushd git_repo
 
       ### Clone the packaging repo
+      <% if ENV['PACKAGING_LOCATION'] && !ENV['PACKAGING_LOCATION'].empty? %>
+        export PACKAGING_LOCATION=&quot;<%= ENV['PACKAGING_LOCATION'] %>&quot;
+      <% end %>
       bundle install --path .bundle/gems --binstubs .bundle/bin --retry 3
 
       ### Run repo creation


### PR DESCRIPTION
Previously, even when PACKAGING_LOCATION is set locally, remote tasks (like
signing) were still pulling in the default version of packaging. Now, we pass
along this environment variable as part of our remote commands. Note that this
will not work if PACKAGING_LOCATION is set to a local directory. Instead, use
a git branch.