### PR TITLE
(maint) rsync back to root_dir after signing

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -147,10 +147,10 @@ fi ;
 $bundle_prefix rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}
 DOC
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, rake_command)
-      Pkg::Util::Net.rsync_from("#{remote_repo}/#{root_dir}/", Pkg::Config.signing_server, "#{$DEFAULT_DIRECTORY}/")
+      Pkg::Util::Net.rsync_from("#{remote_repo}/#{root_dir}/", Pkg::Config.signing_server, "#{root_dir}/")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm -rf #{remote_repo}")
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.signing_server, "rm #{build_params}")
-      puts "Signed packages staged in #{$DEFAULT_DIRECTORY}/ directory"
+      puts "Signed packages staged in #{root_dir}/ directory"
     end
   end
 end


### PR DESCRIPTION
This commit updates the `sign_all` task to rsync the signed packages back to
the `root_dir` that the packages were originally in, before signing.
Previously, we rsync'd back to `DEFAULT_DIRECTORY`, which may or may not be the
same as `root_dir`. This was an issue when signing vanagon projects: builds are
staged in a directory called 'output' and then shipped (internally) from there;
the `DEFAULT_DIRECTORY` is 'pkg', so when we attemped to sign between building
and shipping (internally), signed packages were getting rsync'd to 'pkg' but
the unsigned packages in 'output' were getting shipped.