### PR TITLE
Added platform support for Ubuntu 18.10 Cosmic

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -294,6 +294,14 @@ module Pkg
           source_package_formats: DEBIAN_SOURCE_FORMATS,
           repo: true,
         },
+        '18.10' => {
+          codename: 'cosmic',
+          architectures: ['amd64', 'ppc64el'],
+          source_architecture: 'source',
+          package_format: 'deb',
+          source_package_formats: DEBIAN_SOURCE_FORMATS,
+          repo: true,
+        },
       },
 
       'windows' => {

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -36,7 +36,7 @@ describe 'Pkg::Platforms' do
 
   describe '#codenames' do
     it 'should return all codenames for a given platform' do
-      codenames = ['bionic', 'buster', 'cumulus', 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial']
+      codenames = ['bionic', 'buster', 'cosmic', 'cumulus', 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial']
       expect(Pkg::Platforms.codenames).to match_array(codenames)
     end
   end


### PR DESCRIPTION
Added support for Ubuntu 18.10 cosmic cuttlefish.
I need this change in order be able to build pl-build-tools-release package.