### PR TITLE
(RE-11600) Skip signing OSX pkgs if they're already signed

### DIFF
--- a/lib/packaging/sign/dmg.rb
+++ b/lib/packaging/sign/dmg.rb
@@ -22,7 +22,12 @@ module Pkg::Sign::Dmg
       /usr/bin/hdiutil attach #{work_dir}/$dmg.dmg -mountpoint #{mount} -nobrowse -quiet ;
       /usr/bin/security -q unlock-keychain -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" ;
         for pkg in $(ls #{mount}/*.pkg | xargs -n 1 basename); do
-          /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}" --sign "#{Pkg::Config.osx_signing_cert}" #{mount}/$pkg #{signed}/$pkg ;
+          if /usr/sbin/pkgutil --check-signature #{mount}/$pkg ; then
+            echo "$pkg is already signed, skipping . . ." ;
+            cp #{mount}/$pkg #{signed}/$pkg ;
+          else
+            /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}" --sign "#{Pkg::Config.osx_signing_cert}" #{mount}/$pkg #{signed}/$pkg ;
+          fi
         done
       /usr/bin/hdiutil detach #{mount} -quiet ;
       /bin/rm #{work_dir}/$dmg.dmg ;


### PR DESCRIPTION
This commit adds a conditional to the dmg signing method to skip signing if the
unpacked pkg file is already signed. As we work to move signing up in our build
process, we want to ensure that artifacts are signed only once so that all
copies of the artifact have the same checksum.