### PR TITLE
(RE-11600) Skip signing msis if they're already signed

### DIFF
--- a/lib/packaging/sign/msi.rb
+++ b/lib/packaging/sign/msi.rb
@@ -63,23 +63,27 @@ module Pkg::Sign::Msi
     # Once we no longer support Windows 8/Windows Vista, we can remove the
     # first Sha1 signature.
     Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, %Q(for msi in #{msis.map { |d| File.basename(d) }.join(" ")}; do
-      "/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe" sign \
-        -n "Puppet" -i "http://www.puppet.com" \
-        -h sha1 \
-        -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
-        -pass "#{Pkg::Config.msi_signing_cert_pw}" \
-        -t "http://timestamp.verisign.com/scripts/timstamp.dll" \
-        -in "C:/#{work_dir}/$msi" \
-        -out "C:/#{work_dir}/signed-$msi"
-      "/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe" sign \
-        -n "Puppet" -i "http://www.puppet.com" \
-        -nest -h sha256 \
-        -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
-        -pass "#{Pkg::Config.msi_signing_cert_pw}" \
-        -ts "http://sha256timestamp.ws.symantec.com/sha256/timestamp" \
-        -in "C:/#{work_dir}/signed-$msi" \
-        -out "C:/#{work_dir}/$msi"
-      rm "C:/#{work_dir}/signed-$msi"
+      if "/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe" verify -in "C:/#{work_dir}/$msi" ; then
+        echo "$msi is already signed, skipping . . ." ;
+      else
+        "/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe" sign \
+          -n "Puppet" -i "http://www.puppet.com" \
+          -h sha1 \
+          -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
+          -pass "#{Pkg::Config.msi_signing_cert_pw}" \
+          -t "http://timestamp.verisign.com/scripts/timstamp.dll" \
+          -in "C:/#{work_dir}/$msi" \
+          -out "C:/#{work_dir}/signed-$msi"
+        "/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe" sign \
+          -n "Puppet" -i "http://www.puppet.com" \
+          -nest -h sha256 \
+          -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
+          -pass "#{Pkg::Config.msi_signing_cert_pw}" \
+          -ts "http://sha256timestamp.ws.symantec.com/sha256/timestamp" \
+          -in "C:/#{work_dir}/signed-$msi" \
+          -out "C:/#{work_dir}/$msi"
+        rm "C:/#{work_dir}/signed-$msi" ;
+      fi
     done))
     msis.each do | msi |
       Pkg::Util::Net.rsync_from("/cygdrive/c/#{work_dir}/#{File.basename(msi)}", rsync_host_string, File.dirname(msi))


### PR DESCRIPTION
This commit adds a conditional to the msi signing method to skip signing if the
msi is already signed. As we work to move signing up in our build process, we
want to ensure that artifacts are signed only once so that all copies of the
artifact have the same checksum.