### PR TITLE
(maint) Sign deb changes files individually

### DIFF
--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -83,7 +83,9 @@ namespace :pl do
       change_files = Dir["#{deb_dir}/**/*.changes"]
       unless change_files.empty?
         Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
-        Pkg::Sign::Deb.sign_changes("#{deb_dir}/**/*.changes")
+        change_files.each do |file|
+          Pkg::Sign::Deb.sign_changes(file)
+        end
       end
     ensure
       Pkg::Util::Gpg.kill_keychain


### PR DESCRIPTION
This commit updates the `sign_deb_changes` task to loop through the .changes
files and sign them individually instead of passing a glob to the sign method.
Previously, this task was probably never getting called, since our shipping
workflow doesn't retrieve .changes files. Now that we have moved signing to
build time, we encountered an issue where the glob was not being interpretted /
expanded properly. This aims to fix that issue.