### PR TITLE
(RE-11291) Improve rsync error message

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -130,7 +130,7 @@ module Pkg::Util::Net
       raise(ArgumentError, "Cannot sync between two remote hosts") if
         options[:origin_host] && options[:target_host]
 
-      raise(ArgumentError, "Cannot sync path '#{origin}' to itself") unless
+      raise(ArgumentError, "Cannot sync path '#{origin}' because both origin_host and target_host are nil. Perhaps you need to set TEAM=release ?") unless
         options[:origin_host] || options[:target_host]
 
       cmd = %W(


### PR DESCRIPTION
This commit updates the error message generated when attempting to rsync while
both origin_host and target_host are nil. This most-often occurs when the TEAM
environment variable is unset, since params from build_data#release are not
fetched in this case. The new message provides more clarity into the nature of
the error and how to resolve it.