### PR TITLE
(PA-2326) Addded RHEL8 to platforms.rb

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -118,6 +118,14 @@ module Pkg
           signature_format: 'v4',
           repo: true,
         },
+        '8' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        }
       },
 
       'eos' => {

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -26,7 +26,7 @@ describe 'Pkg::Platforms' do
 
   describe '#versions_for_platform' do
     it 'should return all supported versions for a given platform' do
-      expect(Pkg::Platforms.versions_for_platform('el')).to match_array(['5', '6', '7'])
+      expect(Pkg::Platforms.versions_for_platform('el')).to match_array(['5', '6', '7', '8'])
     end
 
     it 'should raise an error if given a nonexistent platform' do


### PR DESCRIPTION
I've added RHEL 8 to the platforms list, but I need someones confirmation that I've added it to the correct place. It's a bit confusing that there is only one entry for RHEL, (and that is 'redhatfips'). 
The current version is a common x86_64 arch, how come redhatfips is separate from the others?
