### PR TITLE
(maint) Pin artifactory gem to ~> 2

### DIFF
--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rubocop', ['~> 0.24.1'])
   gem.add_development_dependency('pry')
   gem.add_runtime_dependency('rake', ['~> 12.3'])
-  gem.add_runtime_dependency('artifactory')
+  gem.add_runtime_dependency('artifactory', ['~> 2'])
   gem.require_path = 'lib'
 
   # Ensure the gem is built out of versioned files


### PR DESCRIPTION
This commit pins the artifactory gem to ~> 2. Version 3.0.0 was just released
and it requires ruby >= 2.3. Since we still support older versions of ruby, we
must continue using a pre-3.0 version of artifactory.