### PR TITLE
(RE-11984) Use quotes when grepping a regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+## [0.99.22] - 2019-01-22
+### Changed
+- (RE-11984) Add quotes and escape '\d' in the regex used to find the latest
+  version of a particular project.
+
 ## [0.99.21] - 2019-01-08
 ### Changed
 - (RE-11741) Search for '<project_name>-\d' in order to prevent aggressive
@@ -330,7 +335,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.21...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.22...HEAD
+[0.99.22]: https://github.com/puppetlabs/packaging/compare/0.99.21...0.99.22
 [0.99.21]: https://github.com/puppetlabs/packaging/compare/0.99.20...0.99.21
 [0.99.20]: https://github.com/puppetlabs/packaging/compare/0.99.19...0.99.20
 [0.99.19]: https://github.com/puppetlabs/packaging/compare/0.99.18...0.99.19

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -293,7 +293,7 @@ module Pkg::Util::Net
     #   @option :excludes [Array] Strings you want to exclude from your search,
     #     e.g. 'agent' if only searching for 'puppet'.
     def remote_create_latest_symlink(package_name, dir, platform_ext, options = {})
-      ls_cmd = "ls -1 *.#{platform_ext} | grep -v latest | grep -v rc | grep -P #{package_name}-\d "
+      ls_cmd = "ls -1 *.#{platform_ext} | grep -v latest | grep -v rc | grep -P '#{package_name}-\\d' "
 
       # store this in a separate var to avoid side affects
       full_package_name = String.new(package_name)


### PR DESCRIPTION
This commit escapes the '\d' and adds quotes around the <package_name>-\<version>
regex we use for finding the latest version of a project and symlinking to it.
Previously, without the escape or quotes, we ended up searching for the literal
string '-d' after the package name (e.g. 'puppet-bolt-d'), which resulted in no
new -latest symlinks when we shipped a new version.