### PR TITLE
RE-12062 Copy all the build_metadata*.json files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ notifications:
   email: false
 rvm:
   - 2.0.0
-  - 2.1.1
-  - 2.3.3
+  - 2.1.9
+  - 2.3.8
   - 2.4.1
 
 env:

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -571,12 +571,14 @@ namespace :pl do
         cp(ezbake_yaml, File.join(local_dir, "#{Pkg::Config.ref}.ezbake.manifest.yaml"))
       end
 
-      # We are starting to collect additional metadata which contains
+      # Inside build_metadata*.json files there is additional metadata containing
       # information such as git ref and dependencies that are needed at build
-      # time. If this file exists we will make it available for downstream.
-      build_data_json = File.join("ext", "build_metadata.json")
-      if File.exists?(build_data_json)
-        cp(build_data_json, File.join(local_dir, "#{Pkg::Config.ref}.build_metadata.json"))
+      # time. If these files exist, copy them downstream.
+      # Typically these files are named 'ext/build_metadata.<project>.<platform>.json'
+      build_metadata_json_files = Dir.glob('ext/build_metadata*.json')
+      build_metadata_json_files.each do |source_file|
+        target_file = File.join(local_dir, "#{Pkg::Config.ref}.#{File.basename(source_file)}")
+        cp(source_file, target_file)
       end
 
       # Sadly, the packaging repo cannot yet act on its own, without living


### PR DESCRIPTION
Vanagon now generates build_metadata.\<project>\.\<platform\>.json for each
<project> and <platform> rather than overwriting 'build_metadata.json'

Make packaging copy all the files it finds (via glob) rather than the single
static file.

This seems like a simple change. However, I've not yet tested it -- trying to figure out how to test packaging changes has been elusive to me. The purpose of the PR at the moment is to see if it makes sense to people more familiar.