### PR TITLE
(maint) Fix legacy fedora repo config issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+## [0.99.27] - 2019-04-10
+### Fixed
+- Presesrve the original tag to keep the `fedora-f` prefix in the repo config
+  artifact path. We have discontinued the `-f` in recent releases but this is
+  still an issue with puppet-agent 1.10.x.
+
 ## [0.99.26] - 2019-04-09
 ### Fixed
 - Ensure existing artifact path is not nil before comparing to additional
@@ -360,7 +366,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.26...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.27...HEAD
+[0.99.27]: https://github.com/puppetlabs/packaging/compare/0.99.26...0.99.27
 [0.99.26]: https://github.com/puppetlabs/packaging/compare/0.99.25...0.99.26
 [0.99.25]: https://github.com/puppetlabs/packaging/compare/0.99.24...0.99.25
 [0.99.24]: https://github.com/puppetlabs/packaging/compare/0.99.23...0.99.24

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -80,11 +80,15 @@ module Pkg
           artifacts = artifacts.split("\n")
           data = {}
           artifacts.each do |artifact|
-            tag = Pkg::Paths.tag_from_artifact_path(artifact)
+            # We need to preserve the original tag to make sure we look for
+            # fedora repo configs in the 1.10.x branch of puppet-agent in
+            # the correct place. For 5.x and 6.x release streams the f prefix
+            # has been removed and so tag will equal original_tag
+            original_tag = Pkg::Paths.tag_from_artifact_path(artifact)
 
             # Remove the f-prefix from the fedora platform tag keys so that
             # beaker can rely on consistent keys once we rip out the f for good
-            tag = tag.sub(/fedora-f/, 'fedora-')
+            tag = original_tag.sub(/fedora-f/, 'fedora-')
 
             data[tag] ||= {}
 
@@ -118,7 +122,8 @@ module Pkg
             when 'deb'
               repo_config = "../repo_configs/deb/pl-#{self.project}-#{self.ref}-#{Pkg::Platforms.get_attribute(tag, :codename)}.list"
             when 'rpm'
-              repo_config = "../repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{tag}.repo" unless tag.include? 'aix'
+              # Using original_tag here to not break legacy fedora repo targets
+              repo_config = "../repo_configs/rpm/pl-#{self.project}-#{self.ref}-#{original_tag}.repo" unless tag.include? 'aix'
             when 'swix', 'svr4', 'ips', 'dmg', 'msi'
               # No repo_configs for these platforms, so do nothing.
             else


### PR DESCRIPTION
With the change to track all artifacts in the yaml metadata, the
location for repo configs for legacy (puppet-agent 1.10.x) fedora repos
was inadvertantly changed. This restores the original behavior.