### PR TITLE
(PA-2678) Update puppetlabs/packaging platform hash to include Fedora 30 (amd64)

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -209,6 +209,14 @@ module Pkg
           signature_format: 'v4',
           repo: true,
         },
+        '30' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
       },
 
       'osx' => {


### PR DESCRIPTION
Updated the `PLATFORM_INFO` hash at https://github.com/puppetlabs/packaging/blob/master/lib/packaging/platforms.rb to include Fedora 30 (amd64).