### PR TITLE
(maint) Don't delete packages from rsync servers

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -240,7 +240,8 @@ namespace :pl do
         Pkg::Util::Execution.retry_on_fail(:times => 3) do
           Pkg::Config.rsync_servers.each do |rsync_server|
             ['apt', 'yum'].each do |repo|
-              command = "sudo su - rsync --command 'rsync --verbose -a --exclude '*.html' --delete /opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/ rsync@#{rsync_server}:/opt/repository/#{repo}'"
+              # Don't --delete so that folks using archived packages can continue to do so
+              command = "sudo su - rsync --command 'rsync --verbose -a --exclude '*.html' /opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/ rsync@#{rsync_server}:/opt/repository/#{repo}'"
               Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.staging_server, command)
             end
           end


### PR DESCRIPTION
This commit removes the `--delete` flag from the `deploy_to_rsync_server`
process. As we plan to archive EOL packages, we want people using our rsync
servers to be able continue to do so with minimal effort on our part, so,
rather than maintaining a separate rsync server for archives, we'll just keep
packages available on the existing ones FOREVER.