### PR TITLE
 (maint) Update regex for error when repromoting a package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+## [0.99.34] - 2019-06-05
+### Updated
+- Update the regular expression to skip errors both when a package already exists and
+  when you don't have permissions to overwrite the existing package when deploying to
+  artifactory.
+- Add rake tasks to sync yum, apt, and downloads archives individually.
+- Don't delete packages from rsync servers so we don't need to stand up additional archive
+  hosts.
+
 ## [0.99.33] - 2019-05-29
 ### Added
 - (PA-2678) Add support for Fedora 30.
@@ -407,7 +416,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.33...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.34...HEAD
+[0.99.34]: https://github.com/puppetlabs/packaging/compare/0.99.33...0.99.34
 [0.99.33]: https://github.com/puppetlabs/packaging/compare/0.99.32...0.99.33
 [0.99.32]: https://github.com/puppetlabs/packaging/compare/0.99.31...0.99.32
 [0.99.31]: https://github.com/puppetlabs/packaging/compare/0.99.30...0.99.31

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -305,10 +305,10 @@ module Pkg
             promoted_artifact.properties(properties)
           end
         rescue Artifactory::Error::HTTPError => e
-          if e.message =~ /destination and source are the same/i
+          if e.message =~ /(destination and source are the same|user doesn't have permissions to override)/i
             puts "Skipping promotion of #{artifact_name}; it has already been promoted"
           else
-            puts "#{e.level}: #{e.message}"
+            puts "#{e.message}"
             raise e
           end
         rescue => e


### PR DESCRIPTION
We recently found anonymous deletions were enabled on the repo we were
targeting. When we removed that permission, the error message for
promoting a package that already exists changed. As a result of this, we
also found we were using an invalid field in our error messages.