### PR TITLE
(maint) Don't use `set -e` for windows signing

### DIFF
--- a/lib/packaging/sign/msi.rb
+++ b/lib/packaging/sign/msi.rb
@@ -62,50 +62,54 @@ module Pkg::Sign::Msi
     #
     # Once we no longer support Windows 8/Windows Vista, we can remove the
     # first Sha1 signature.
-    Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, %Q(for msi in #{msis.map { |d| File.basename(d) }.join(" ")}; do
-      if "/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe" verify -in "C:/#{work_dir}/$msi" ; then
-        echo "$msi is already signed, skipping . . ." ;
-      else
-          tries=5
-          sha1Servers=(http://timestamp.verisign.com/scripts/timstamp.dll
-            http://timestamp.globalsign.com/scripts/timstamp.dll
-            http://www.startssl.com/timestamp)
-              for timeserver in "${sha1Servers[@]}"; do
-                for ((try=1; try<=$tries; try++)) do
-                  ret=$(/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe sign \
-                            -n "Puppet" -i "http://www.puppet.com" \
-                            -h sha1 \
-                            -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
-                            -pass "#{Pkg::Config.msi_signing_cert_pw}" \
-                            -t "$timeserver" \
-                            -in "C:/#{work_dir}/$msi" \
-                            -out "C:/#{work_dir}/signed-$msi")
-                  if [[ $ret == *"Succeeded"* ]]; then break; fi
-                done;
-                if [[ $ret == *"Succeeded"* ]]; then break; fi
-              done;
-          echo $ret
-          if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
-          sha256Servers=(http://sha256timestamp.ws.symantec.com/sha256/timestamp
-            http://timestamp.comodoca.com?td=sha256)
-              for timeserver in "${sha256Servers[@]}"; do
-                for ((try=1; try<=$tries; try++)) do
-                  ret=$(/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe sign \
-                    -n "Puppet" -i "http://www.puppet.com" \
-                    -nest -h sha256 \
-                    -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
-                    -pass "#{Pkg::Config.msi_signing_cert_pw}" \
-                    -ts "$timeserver" \
-                    -in "C:/#{work_dir}/signed-$msi" \
-                    -out "C:/#{work_dir}/$msi")
-                    if [[ $ret == *"Succeeded"* ]]; then break; fi
-                done;
-                if [[ $ret == *"Succeeded"* ]]; then break; fi
-              done;
-          echo $ret
-          if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
-      fi
-    done), false, '', false)
+    sign_command = <<-CMD
+for msi in #{msis.map { |d| File.basename(d) }.join(" ")}; do
+  if "/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe" verify -in "C:/#{work_dir}/$msi" ; then
+    echo "$msi is already signed, skipping . . ." ;
+  else
+    tries=5
+    sha1Servers=(http://timestamp.verisign.com/scripts/timstamp.dll
+    http://timestamp.globalsign.com/scripts/timstamp.dll
+    http://www.startssl.com/timestamp)
+    for timeserver in "${sha1Servers[@]}"; do
+      for ((try=1; try<=$tries; try++)) do
+        ret=$(/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe sign \
+          -n "Puppet" -i "http://www.puppet.com" \
+          -h sha1 \
+          -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
+          -pass "#{Pkg::Config.msi_signing_cert_pw}" \
+          -t "$timeserver" \
+          -in "C:/#{work_dir}/$msi" \
+          -out "C:/#{work_dir}/signed-$msi")
+        if [[ $ret == *"Succeeded"* ]]; then break; fi
+      done;
+      if [[ $ret == *"Succeeded"* ]]; then break; fi
+    done;
+    echo $ret
+    if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
+    sha256Servers=(http://sha256timestamp.ws.symantec.com/sha256/timestamp
+      http://timestamp.comodoca.com?td=sha256)
+    for timeserver in "${sha256Servers[@]}"; do
+      for ((try=1; try<=$tries; try++)) do
+        ret=$(/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe sign \
+          -n "Puppet" -i "http://www.puppet.com" \
+          -nest -h sha256 \
+          -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
+          -pass "#{Pkg::Config.msi_signing_cert_pw}" \
+          -ts "$timeserver" \
+          -in "C:/#{work_dir}/signed-$msi" \
+          -out "C:/#{work_dir}/$msi")
+        if [[ $ret == *"Succeeded"* ]]; then break; fi
+      done;
+      if [[ $ret == *"Succeeded"* ]]; then break; fi
+    done;
+    echo $ret
+    if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
+  fi
+done
+CMD
+
+    Pkg::Util::Net.remote_ssh_cmd(ssh_host_string, sign_command, false, '', false)
     msis.each do | msi |
       Pkg::Util::Net.rsync_from("/cygdrive/c/#{work_dir}/#{File.basename(msi)}", rsync_host_string, File.dirname(msi))
     end

--- a/lib/packaging/sign/msi.rb
+++ b/lib/packaging/sign/msi.rb
@@ -80,30 +80,32 @@ module Pkg::Sign::Msi
                             -t "$timeserver" \
                             -in "C:/#{work_dir}/$msi" \
                             -out "C:/#{work_dir}/signed-$msi")
-                    if [[ $ret == *"Succeeded"* ]]; then break; fi
-                  done;
-              if [[ $ret == *"Succeeded"* ]]; then break; fi
-            done;
-            echo $ret
-            sha256Servers=(http://sha256timestamp.ws.symantec.com/sha256/timestamp
-              http://timestamp.comodoca.com?td=sha256)
-                for timeserver in "${sha256Servers[@]}"; do
-                  for ((try=1; try<=$tries; try++)) do
-                    ret=$(/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe sign \
-                      -n "Puppet" -i "http://www.puppet.com" \
-                      -nest -h sha256 \
-                      -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
-                      -pass "#{Pkg::Config.msi_signing_cert_pw}" \
-                      -ts "$timeserver" \
-                      -in "C:/#{work_dir}/signed-$msi" \
-                      -out "C:/#{work_dir}/$msi")
-                      if [[ $ret == *"Succeeded"* ]]; then break; fi
-                    done;
+                  if [[ $ret == *"Succeeded"* ]]; then break; fi
+                done;
                 if [[ $ret == *"Succeeded"* ]]; then break; fi
               done;
-              echo $ret
+          echo $ret
+          if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
+          sha256Servers=(http://sha256timestamp.ws.symantec.com/sha256/timestamp
+            http://timestamp.comodoca.com?td=sha256)
+              for timeserver in "${sha256Servers[@]}"; do
+                for ((try=1; try<=$tries; try++)) do
+                  ret=$(/cygdrive/c/tools/osslsigncode-fork/osslsigncode.exe sign \
+                    -n "Puppet" -i "http://www.puppet.com" \
+                    -nest -h sha256 \
+                    -pkcs12 "#{Pkg::Config.msi_signing_cert}" \
+                    -pass "#{Pkg::Config.msi_signing_cert_pw}" \
+                    -ts "$timeserver" \
+                    -in "C:/#{work_dir}/signed-$msi" \
+                    -out "C:/#{work_dir}/$msi")
+                    if [[ $ret == *"Succeeded"* ]]; then break; fi
+                done;
+                if [[ $ret == *"Succeeded"* ]]; then break; fi
+              done;
+          echo $ret
+          if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
       fi
-    done))
+    done), false, '', false)
     msis.each do | msi |
       Pkg::Util::Net.rsync_from("/cygdrive/c/#{work_dir}/#{File.basename(msi)}", rsync_host_string, File.dirname(msi))
     end


### PR DESCRIPTION
We need to be able to loop through timestamp servers, and if the first
signing fails `set -e` will cause the code to exit. Instead, after each
signature if it was unable to sign successfully, explicitly `exit 1`.