### PR TITLE
(RE-12463) Try to find the source of the SIGTERMs in packaging.

### DIFF
--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -64,13 +64,18 @@ module Pkg::Util::Net
       return errs
     end
 
-    def remote_ssh_cmd(target, command, capture_output = false, extra_options = '', fail_fast = true)
+    def remote_ssh_cmd(target, command, capture_output = false, extra_options = '', fail_fast = true, trace = false)  # rubocop:disable Style/ParameterLists
+
       ssh = Pkg::Util::Tool.check_tool('ssh')
 
       # we pass some pretty complicated commands in via ssh. We need this to fail
       # if any part of the remote ssh command fails.
-      command = "set -e; #{command}" if fail_fast
-      cmd = "#{ssh} #{extra_options} -t #{target} '#{command.gsub("'", "'\\\\''")}'"
+      shell_flags = ''
+      shell_flags += 'set -e;' if fail_fast
+      shell_flags += 'set -x;' if trace
+      shell_commands = "#{shell_flags}#{command}"
+
+      cmd = "#{ssh} #{extra_options} -t #{target} '#{shell_commands.gsub("'", "'\\\\''")}'"
 
       # This is NOT a good way to support this functionality.
       # It needs to be refactored into a set of methods that

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -65,26 +65,33 @@ describe "Pkg::Util::Net" do
         Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar", false, '', false)
-     end
+    end
+
+    it "should be able to trace output" do
+        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -x;bar'")
+        Pkg::Util::Execution.should_receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_ssh_cmd("foo", "bar", false, '', false, true)
+    end
 
     context "without output captured" do
       it "should execute a command :foo on a host :bar using Kernel" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar")
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar")
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e; bar'")
+        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar") }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end
@@ -93,21 +100,21 @@ describe "Pkg::Util::Net" do
     context "with output captured" do
       it "should execute a command :foo on a host :bar using Pkg::Util::Execution.capture3" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
+        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true)
       end
 
       it "should escape single quotes in the command" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; b'\\''ar'")
+        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(true)
         Pkg::Util::Net.remote_ssh_cmd("foo", "b'ar", true)
       end
 
       it "should raise an error if ssh fails" do
         Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e; bar'")
+        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
         Pkg::Util::Execution.should_receive(:success?).and_return(false)
         expect{ Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true) }.to raise_error(RuntimeError, /Remote ssh command failed./)
       end

--- a/tasks/pe_ship.rake
+++ b/tasks/pe_ship.rake
@@ -145,11 +145,23 @@ if Pkg::Config.build_pe
         # single line. By breaking it into a series of concatenated strings, we can maintain
         # a semblance of formatting and structure (nevermind readability).
         command  = %(for dir in #{repo_base_path}/{#{rpm_family_and_version.join(",")}}-*; do)
-        command += %(  sudo createrepo --checksum=sha --checkts --update --delta-workers=0 --quiet --database --update $dir; )
+
+        # For (RE-12463), make this less quiet than it has been.
+        # We're trying to find out why its aborting. Preserve the original
+        # so it can be restored.
+        command += %(  sudo createrepo --checksum=sha --checkts --update --delta-workers=0 --database --update $dir; )
+
+        ## Original
+        # command += %(  sudo createrepo --checksum=sha --checkts --update --delta-workers=0 --quiet --database --update $dir; )
+        ##
         command += %(done; )
         command += %(sync)
 
-        Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_host, command)
+        # Again for (RE-12463). Make this more verbose temporarily
+        Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_host, command, false, '', true, true)
+
+        ## Original one below
+        # Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.yum_host, command)
       end
 
       desc "Remotely add shipped packages to apt repo on #{Pkg::Config.apt_host}"


### PR DESCRIPTION
These are intended as debugging. Not sure whether we'll want to keep them
after the bug has been indentified.

    * Turn off --quiet in createrepo
    * Let remote_ssh_cmd take a 'trace' flag
    * Turn on the remote_ssh_cmd trace flag in the :update_remote_repo task
    * Update some of the specs to deal with multiple shell 'set' commands