### PR TITLE
(RE-12520) Don't try to ship gems with unset params

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -324,6 +324,7 @@ namespace :pl do
   task :ship_gem_to_downloads => 'pl:fetch' do
     unless Pkg::Config.gem_host
       warn 'Value `Pkg::Config.gem_host` not defined; skipping shipping to public Download server'
+      exit
     end
 
     Pkg::Util::Execution.retry_on_fail(times: 3) do

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -326,6 +326,7 @@ namespace :pl do
       warn 'Value `Pkg::Config.gem_host` not defined; skipping shipping to public Download server'
       exit
     end
+    fail 'Value `Pkg::Config.gem_path` not defined; skipping shipping to public Download server' unless Pkg::Config.gem_path
 
     Pkg::Util::Execution.retry_on_fail(times: 3) do
       Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)


### PR DESCRIPTION
tldr: allow skipping the `ship_gem_to_downloads` task if `gem_host` is unset so that projects can keep using `uber_ship_lite` (which includes `ship_gem`, which includes `ship_gem_to_downloads`), but fail if `gem_path` is unset so that we don't accidentally ship to a weird path.

see individual commit messages for details