### PR TITLE
(RE-11765) remove symlinks in the gem

### DIFF
--- a/spec/fixtures/config/ext/build_defaults.yaml
+++ b/spec/fixtures/config/ext/build_defaults.yaml
@@ -1,1 +1,2 @@
-../params.yaml
+---
+:apt_host: foo

--- a/spec/fixtures/config/ext/project_data.yaml
+++ b/spec/fixtures/config/ext/project_data.yaml
@@ -1,1 +1,2 @@
-../params.yaml
+---
+:apt_host: foo

--- a/spec/fixtures/config/params.yaml
+++ b/spec/fixtures/config/params.yaml
@@ -1,2 +1,0 @@
----
-:apt_host: foo

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -357,7 +357,7 @@ describe "Pkg::Config" do
         # apt_host: is set to "foo" in the fixture
         orig = Pkg::Config.apt_host
         Pkg::Config.apt_host = "bar"
-        Pkg::Config.config_from_yaml(File.join(FIXTURES, 'config', 'params.yaml'))
+        Pkg::Config.config_from_yaml(File.join(FIXTURES, 'config', 'ext', 'build_defaults.yaml'))
         expect(Pkg::Config.apt_host).to eq("foo")
         Pkg::Config.apt_host = orig
       end


### PR DESCRIPTION
Be nice to Windows users (and generally a good citizen overall) by replacing
symlinks in the spec directory with actual files.

See the Jira for testing notes for this change.