### PR TITLE
(maint) Calculate + ship md5sum of package

### DIFF
--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -198,10 +198,13 @@ module Pkg
 
       check_authorization
       artifact = Artifactory::Resource::Artifact.new(local_path: package)
+      artifact_md5 = Digest::MD5.file(package).hexdigest
+      headers = { "X-Checksum-Md5" => artifact_md5 }
       artifact.upload(
         data[:repo_name],
         File.join(data[:alternate_subdirectories], File.basename(package)),
-        deploy_properties(platform_tag)
+        deploy_properties(platform_tag),
+        headers
       )
     rescue
       raise "Attempt to upload '#{package}' to #{File.join(@artifactory_uri, data[:full_artifactory_path])} failed"


### PR DESCRIPTION
There are sometimes md5sum mismatch errors when shipping to artifactory, so let's calculate the md5sum of the file we want to ship to artifactory and include it when shipping to ensure accuracy. I'm hoping this will resolve the md5sum mismatch errors we've been seeing when trying to compose (mismatch md5s between packages.json and what lives in artifactory). 