### PR TITLE
(PE-16465) Implement "all" tarball of repos

### DIFF
--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -5,12 +5,12 @@ module Pkg::Repo
     ##
     ## Construct a local_target based upon the versioning style
     ##
-    def construct_local_target_path(versioning)
+    def construct_local_target_path(project, versioning)
       case versioning
       when 'ref'
-        return File.join(Pkg::Config.project, Pkg::Config.ref)
+        return File.join(project, Pkg::Config.ref)
       when 'version'
-        return File.join(Pkg::Config.project, Pkg::Util::Version.dot_version)
+        return File.join(project, Pkg::Util::Version.dot_version)
       else
         fail "Error: Unknown versioning argument: #{versioning}"
       end
@@ -23,7 +23,7 @@ module Pkg::Repo
     def create_signed_repo_archive(repo_location, archive_name, versioning)
       tar = Pkg::Util::Tool.check_tool('tar')
 
-      local_target = construct_local_target_path(versioning)
+      local_target = construct_local_target_path(Pkg::Config.project, versioning)
 
       if Pkg::Util::File.empty_dir?(File.join('pkg', local_target, repo_location))
         if ENV['FAIL_ON_MISSING_TARGET'] == "true"
@@ -44,7 +44,7 @@ module Pkg::Repo
 
     ##
     ## Add a single repo tarball into the 'all' tarball located in
-    ## 'pkg/<local_target>/<Pkg::Config.project>-all.tar'
+    ## 'pkg/<local_target>/<project>-all.tar'
     ## Create the 'all' tarball if needed.
     ##
     def update_tarball_of_all_repos(project, platform, versioning)
@@ -52,7 +52,7 @@ module Pkg::Repo
 
       all_repos_tarball_name = "#{project}-all.tar"
       archive_name = "#{project}-#{platform['name']}"
-      local_target = construct_local_target_path(versioning)
+      local_target = construct_local_target_path(project, versioning)
       repo_tarball_name = "#{archive_name}.tar.gz"
       repo_tarball_path = File.join('repos', repo_tarball_name)
 
@@ -75,7 +75,7 @@ module Pkg::Repo
 
     ##
     ## Invoke gzip to compress the 'all' tarball located in
-    ## 'pkg/<local_target>/<Pkg::Config.project>-all.tar'
+    ## 'pkg/<local_target>/<project>-all.tar'
     ##
     def compress_tarball_of_all_repos(all_repos_tarball_name)
       gzip = Pkg::Util::Tool.check_tool('gzip')
@@ -92,7 +92,7 @@ module Pkg::Repo
     ##
     def create_all_repo_archives(project, versioning)
       platforms = Pkg::Config.platform_repos
-      local_target = construct_local_target_path(versioning)
+      local_target = construct_local_target_path(project, versioning)
       all_repos_tarball_name = "#{project}-all.tar"
 
       platforms.each do |platform|

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -93,7 +93,7 @@ module Pkg::Repo
     def create_all_repo_archives(project, versioning)
       platforms = Pkg::Config.platform_repos
       local_target = construct_local_target_path(versioning)
-      all_repos_tarball_name = "#{Pkg::Config.project}-all.tar"
+      all_repos_tarball_name = "#{project}-all.tar"
 
       platforms.each do |platform|
         archive_name = "#{project}-#{platform['name']}"

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -30,13 +30,13 @@ module Pkg::Repo
           raise "Error: missing packages under #{repo_location}"
         end
         warn "Warn: Skipping #{archive_name} because #{repo_location} has no files"
+        return
       end
 
       Dir.chdir(File.join('pkg', local_target)) do
         puts "Info: Archiving #{repo_location} as #{archive_name}"
         target_tarball = File.join('repos', "#{archive_name}.tar.gz")
         tar_command = "#{tar} --owner=0 --group=0 --create --gzip --file #{target_tarball} #{repo_location}"
-        puts "Info: Executing tar: #{tar_command}"
         stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
         return stdout
       end
@@ -50,7 +50,7 @@ module Pkg::Repo
     def update_tarball_of_all_repos(project, platform, versioning)
       tar = Pkg::Util::Tool.check_tool('tar')
 
-      all_repos_tarball_name = "#{Pkg::Config.project}-all.tar"
+      all_repos_tarball_name = "#{project}-all.tar"
       archive_name = "#{project}-#{platform['name']}"
       local_target = construct_local_target_path(versioning)
       repo_tarball_name = "#{archive_name}.tar.gz"
@@ -68,7 +68,6 @@ module Pkg::Repo
         end
 
         tar_command = "#{tar} --owner=0 --group=0 #{tar_action} --file #{all_repos_tarball_name} #{repo_tarball_path}"
-        puts "Info: Executing all-repos-tar #{tar_command}"
         stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
         puts stdout
       end
@@ -82,7 +81,6 @@ module Pkg::Repo
       gzip = Pkg::Util::Tool.check_tool('gzip')
 
       gzip_command = "#{gzip} --fast #{all_repos_tarball_name}"
-      puts "Info: Compressing all-repos tarball with: #{gzip_command}"
       stdout, _, _ = Pkg::Util::Execution.capture3(gzip_command)
       puts stdout
     end

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -16,46 +16,45 @@ describe "#Pkg::Repo" do
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(false)
       allow(Pkg::Util::Execution).to receive(:capture3)
 
-      expect(Dir).to receive(:chdir).with("pkg").and_yield
-      expect(Dir).to receive(:chdir).with("project/1.1.1").and_yield
+      expect(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
       Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "version")
     end
 
-    it "should use a ref if ref is specified as versioning" do
-      allow(Pkg::Util::Tool).to receive(:check_tool).and_return("tarcommand")
-      allow(Dir).to receive(:chdir).with("pkg").and_yield
+    it 'should use a ref if ref is specified as versioning' do
+      allow(Pkg::Util::Tool).to receive(:check_tool).and_return('tarcommand')
+      allow(Dir).to receive(:chdir).with('pkg').and_yield
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(false)
       allow(Pkg::Util::Execution).to receive(:capture3)
 
-      expect(Pkg::Config).to receive(:project).and_return("project")
-      expect(Pkg::Config).to receive(:ref).and_return("AAAAAAAAAAAAAAA")
-      expect(Dir).to receive(:chdir).with("project/AAAAAAAAAAAAAAA").and_yield
-      Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "ref")
+      expect(Pkg::Config).to receive(:project).and_return('project')
+      expect(Pkg::Config).to receive(:ref).and_return('AAAAAAAAAAAAAAA')
+      expect(Dir).to receive(:chdir).with('pkg/project/AAAAAAAAAAAAAAA').and_yield
+      Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'ref')
     end
 
-    it "should use dot versions if version is specified as versioning" do
-      allow(Pkg::Util::Tool).to receive(:check_tool).and_return("tarcommand")
-      allow(Dir).to receive(:chdir).with("pkg").and_yield
+    it 'should use dot versions if version is specified as versioning' do
+      allow(Pkg::Util::Tool).to receive(:check_tool).and_return('tarcommand')
+      allow(Dir).to receive(:chdir).with('pkg').and_yield
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(false)
       allow(Pkg::Util::Execution).to receive(:capture3)
 
-      expect(Pkg::Config).to receive(:project).and_return("project")
-      expect(Pkg::Util::Version).to receive(:dot_version).and_return("1.1.1")
-      expect(Dir).to receive(:chdir).with("project/1.1.1").and_yield
-      Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "version")
+      expect(Pkg::Config).to receive(:project).and_return('project')
+      expect(Pkg::Util::Version).to receive(:dot_version).and_return('1.1.1')
+      expect(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
+      Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')
     end
 
-    it "should fail if ENV['FAIL_ON_MISSING_TARGET'] is true and empty_dir? is also true" do
-      allow(Pkg::Util::Tool).to receive(:check_tool).and_return("tarcommand")
-      allow(Pkg::Config).to receive(:project).and_return("project")
-      allow(Pkg::Util::Version).to receive(:dot_version).and_return("1.1.1")
+    it 'should fail if ENV["FAIL_ON_MISSING_TARGET"] is true and empty_dir? is also true' do
+      allow(Pkg::Util::Tool).to receive(:check_tool).and_return('tarcommand')
+      allow(Pkg::Config).to receive(:project).and_return('project')
+      allow(Pkg::Util::Version).to receive(:dot_version).and_return('1.1.1')
       allow(Pkg::Util::Execution).to receive(:capture3)
-      allow(Dir).to receive(:chdir).with("pkg").and_yield
-      allow(Dir).to receive(:chdir).with("project/1.1.1").and_yield
+      allow(Dir).to receive(:chdir).with('pkg').and_yield
+      allow(Dir).to receive(:chdir).with('project/1.1.1').and_yield
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(true)
-      ENV['FAIL_ON_MISSING_TARGET'] = "true"
+      ENV['FAIL_ON_MISSING_TARGET'] = 'true'
 
-      expect{Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "version")}.to raise_error(RuntimeError, "ERROR: missing packages under /path")
+      expect{Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')}.to raise_error(RuntimeError, 'Error: missing packages under /path')
     end
 
     it "should only warn if ENV['FAIL_ON_MISSING_TARGET'] is false and empty_dir? is true" do
@@ -63,35 +62,38 @@ describe "#Pkg::Repo" do
       allow(Pkg::Config).to receive(:project).and_return("project")
       allow(Pkg::Util::Version).to receive(:dot_version).and_return("1.1.1")
       allow(Pkg::Util::Execution).to receive(:capture3)
-      allow(Dir).to receive(:chdir).with("pkg").and_yield
-      allow(Dir).to receive(:chdir).with("project/1.1.1").and_yield
+      allow(Dir).to receive(:chdir).with("pkg/project/1.1.1").and_yield
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(true)
       ENV['FAIL_ON_MISSING_TARGET'] = "false"
 
       expect{Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "version")}.not_to raise_error
     end
 
-    it "should invoke tar correctly" do
-      allow(Pkg::Util::Tool).to receive(:check_tool).and_return("tarcommand")
-      allow(Pkg::Config).to receive(:project).and_return("project")
-      allow(Pkg::Util::Version).to receive(:dot_version).and_return("1.1.1")
-      allow(Dir).to receive(:chdir).with("pkg").and_yield
-      allow(Dir).to receive(:chdir).with("project/1.1.1").and_yield
+    it 'should invoke tar correctly' do
+      allow(Pkg::Util::Tool).to receive(:check_tool).and_return('tarcommand')
+      allow(Pkg::Config).to receive(:project).and_return('project')
+      allow(Pkg::Util::Version).to receive(:dot_version).and_return('1.1.1')
+      allow(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(false)
 
-      expect(Pkg::Util::Execution).to receive(:capture3).with("tarcommand --owner=0 --group=0 --create --gzip --file repos/project-debian-6-i386.tar.gz /path")
-      Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "version")
+      expect(Pkg::Util::Execution).to receive(:capture3).with('tarcommand --owner=0 --group=0 --create --gzip --file repos/project-debian-6-i386.tar.gz /path')
+      Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')
     end
   end
 
-  describe "#create_signed_repo_archive" do
-    it "should invoke create_signed_repo_archive correctly for multiple entries in platform_repos" do
+  describe '#create_signed_repo_archive' do
+    it 'should invoke create_signed_repo_archive correctly for multiple entries in platform_repos' do
       allow(Pkg::Config).to receive(:platform_repos).and_return(platform_repo_stub)
+      allow(Pkg::Config).to receive(:project).and_return('project')
+      allow(Pkg::Util::Version).to receive(:dot_version).and_return('1.1.1')
+      allow(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
 
-      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with("repos/el/4/**/i386", "project-el-4-i386", "version")
-      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with("repos/el/5/**/i386", "project-el-5-i386", "version")
-      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with("repos/el/6/**/i386", "project-el-6-i386", "version")
-      Pkg::Repo.create_all_repo_archives("project", "version")
+      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with('repos/el/4/**/i386', 'project-el-4-i386', 'version')
+      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with('repos/el/5/**/i386', 'project-el-5-i386', 'version')
+      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with('repos/el/6/**/i386', 'project-el-6-i386', 'version')
+
+      allow(Pkg::Util::Execution).to receive(:capture3)
+      Pkg::Repo.create_all_repo_archives('project', 'version')
     end
   end
 

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -68,60 +68,6 @@ DOC
       Pkg::Repo.create_all_repo_archives(name_of_archive, versioning)
     end
 
-    # This is pretty similar to the 'pack_signed_repo' task. The difference here is that instead
-    # of creating a tarball for each repo passed, it adds each repo to a single archive, creating
-    # one 'all' tarball with all of the repos. This is useful for cutomers who have a PE master with
-    # no internet access. They can unpack the puppet-agent-all tarball into the location that
-    # pe_repo expects and use simplified agent install without needing internet access, or having to
-    # manually download each agent that they need to feed to pe_repo.
-    # This task should be invoked after prepare_signed_repos, so that there are repos to pack up.
-    task :pack_all_signed_repos, [:path_to_repo, :name_of_archive, :versioning] => ["pl:fetch"] do |t, args|
-      # path_to_repo should be relative to ./pkg
-      name_of_archive = args.name_of_archive or fail ":name_of_archive is a required argument for #{t}"
-      versioning = args.versioning or fail ":versioning is a required argument for #{t}"
-      tar = Pkg::Util::Tool.check_tool('tar')
-
-      Dir.chdir("pkg") do
-        if versioning == 'ref'
-          local_target = File.join(Pkg::Config.project, Pkg::Config.ref, "repos")
-        elsif versioning == 'version'
-          local_target = File.join(Pkg::Config.project, Pkg::Util::Version.dot_version, "repos")
-        end
-
-        Dir.chdir(local_target) do
-          if !Pkg::Util::File.exist?("#{name_of_archive}.tar.gz")
-            warn "Skipping #{name_of_archive} because it (#{name_of_archive}.tar.gz) has no files"
-          else
-            if File.exist?("#{Pkg::Config.project}-all.tar")
-              tar_cmd = "--update"
-            else
-              tar_cmd = "--create"
-            end
-            Pkg::Util::Execution.ex("#{tar} --owner=0 --group=0 #{tar_cmd} --file #{Pkg::Config.project}-all.tar #{name_of_archive}.tar.gz")
-          end
-        end
-      end
-    end
-
-    # tar does not support adding or updating files in a compressed archive, so
-    # we have a task to compress the "all" tarball from the 'pack_all_signed_repos'
-    # task
-    task :compress_the_all_tarball, [:versioning] => ["pl:fetch"] do |t, args|
-      versioning = args.versioning or fail ":versioning is a required argument for #{t}"
-      gzip = Pkg::Util::Tool.check_tool('gzip')
-      Dir.chdir("pkg") do
-        if versioning == 'ref'
-          local_target = File.join(Pkg::Config.project, Pkg::Config.ref)
-        elsif versioning == 'version'
-          local_target = File.join(Pkg::Config.project, Pkg::Util::Version.dot_version)
-        end
-        Dir.chdir(local_target) do
-          Pkg::Util::Execution.ex("#{gzip} --fast #{File.join("repos", "#{Pkg::Config.project}-all.tar")}")
-        end
-      end
-    end
-
-
     task :prepare_signed_repos, [:target_host, :target_prefix, :versioning] => ["clean", "pl:fetch"] do |t, args|
       target_host = args.target_host or fail ":target_host is a required argument to #{t}"
       target_prefix = args.target_prefix or fail ":target_prefix is a required argument for #{t}"


### PR DESCRIPTION
Refactor repo.rb a bit so that 'create_all_repo_archives' also
creates a tarball of all the repos. Remove some old duplicating
code.

I've been testing with this Jenkins job: https://jenkins-master-prod-1.delivery.puppetlabs.net/job/experimental_exg_all_repos_test/

The resulting tarballs are being uploaded to Artifactory: https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/experimental_exg_all_repos_test