### PR TITLE
(RE-12711) Don't re-ship already shipped packages to artifactory

### DIFF
--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -190,6 +190,20 @@ module Pkg
       properties_hash
     end
 
+    # Basic method to check if a package exists on artifactory
+    # @param package [String] The full relative path to the package to be
+    #   checked, relative from the current working directory
+    # Return true if package already exists on artifactory
+    def package_exists_on_artifactory?(package)
+      check_authorization
+      artifact = Artifactory::Resource::Artifact.search(name: File.basename(package), :artifactory_uri => @artifactory_uri)
+      if artifact.empty?
+        return false
+      else
+        return true
+      end
+    end
+
     # @param package [String] The full relative path to the package to be
     #   shipped, relative from the current working directory
     def deploy_package(package)

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -545,7 +545,11 @@ namespace :pl do
 
       local_dir = args.local_dir || 'pkg'
       Dir.glob("#{local_dir}/**/*").reject { |e| File.directory? e }.each do |artifact|
-        artifactory.deploy_package(artifact)
+        if artifactory.package_exists_on_artifactory?(artifact)
+          warn "Attempt to upload '#{artifact}' failed. Package already exists!"
+        else
+          artifactory.deploy_package(artifact)
+        end
       end
     end
 


### PR DESCRIPTION
We only wanna be able to ship a package once, no overriding allowed!
Make basic helper method to check if a specified package already exists somewhere on artifactory, if it does we want to notify and not try to ship that package again.
Tested by attempting to ship a set of packages where some already existed on artifactory and some did not, only the ones that didn't already exist were shipped. 
