### PR TITLE
(maint) Always ship .yaml and .json files

### DIFF
--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -545,7 +545,9 @@ namespace :pl do
 
       local_dir = args.local_dir || 'pkg'
       Dir.glob("#{local_dir}/**/*").reject { |e| File.directory? e }.each do |artifact|
-        if artifactory.package_exists_on_artifactory?(artifact)
+        if File.extname(artifact) == ".yaml" || File.extname(artifact) == ".json"
+          artifactory.deploy_package(artifact)
+        elsif artifactory.package_exists_on_artifactory?(artifact)
           warn "Attempt to upload '#{artifact}' failed. Package already exists!"
         else
           artifactory.deploy_package(artifact)


### PR DESCRIPTION
Because these files when built are exclusively named after the version of the package
there will be multiple files with that name (ex. 2019.2.0.yaml) so we can't treat these files like other built packages where we do not ship if a package of that name already exists on artifactory

Tested with a set of packages that already existed on artifactory, yaml was shipped but others were not