### PR TITLE
(RE-12731) Implement Artifactory cleanup policy

### DIFF
--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -383,7 +383,7 @@ module Pkg
             next
           end
           pp uploaded_artifact
-          uploaded_artifact.properties(ARTIFACTORY_CLEANUP_SKIP_PROPERTY => true)
+          # uploaded_artifact.properties(ARTIFACTORY_CLEANUP_SKIP_PROPERTY => true)
         end
       end
     end


### PR DESCRIPTION
Part 1: Set 'cleanup.skip' property on any uploaded pe tarball

Part 2: Create a method to clear all 'cleanup.skip' properties on
artifacts within a directory.

Intended use: call 'unset_cleanup_skip_on_artifacts' from enterprise-dist
just before uploading artifacts to a directory. Then as the new artifacts
are uploaded, 'cleanup.skip' is set on each one, maintaining the property
on the latest.

Some implementation notes:

After a few attempts, this seemed the cleanest approach since it can
be safe and self correcting.

In unset_cleanup_skip_on_artifacts, the call to
Artifactory::Resource::Artifact.property_search followed by a directory
filter seems inefficient to me but resulted in the most concise
code. Any other approach that I could scheme wasn't really well supported
by the Artifactory gem and resulted in more handwavy code.

Also, I'm not terribly happy with the
/#{regexp_safe_repo}\/#{regexp_safe_directory}\/.*\.tar$/.match(artifact.uri)
regular expression. It might be better just to use

next if artifact.uri.include?("#{repo}/#{directory}")

but I was trying to err on the side of caution.