### PR TITLE
(RE-12771) clean out release repos after PE release

### DIFF
--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -567,6 +567,20 @@ module Pkg
       end
     end
 
+    # Remove all artifacts in repo based on pattern, used when we purge all artifacts in release/ after PE release
+    # @param repos [Array] repos that we want to search for artifacts in
+    # @param pattern [String] pattern for artifacts that should be deleted ex. `2019.1/release/*/*`
+    def teardown_repo(repos, pattern)
+      check_authorization
+      repos.each do |repo|
+        artifacts = Artifactory::Resource::Artifact.pattern_search(repo: repo, pattern: pattern)
+        artifacts.each do |artifact|
+          puts "Deleting #{artifact.download_uri}"
+          artifact.delete
+        end
+      end
+    end
+
     # Remove shipped PE tarballs from artifactory
     # Used when compose fails, we only want the tarball shipped to artifactory if all platforms succeed
     # Identify which packages were created and shipped based on md5sum and remove them


### PR DESCRIPTION
this is a generalized function that can be used to delete all the artifacts with any specified repo + pattern but we'll use it for clearing out release artifacts from release/ 

tested [here](https://artifactory.delivery.puppetlabs.net/artifactory/rpm_enterprise__local/2018.1/release/el-6-x86_64/) by deleting some artifacts

previously I had also written a pretty ugly method that copies release artifacts back from release/ to repos/ but after thinking about it I realize that this isn't necessary because all packages specified in the base branch's packages.json will already have been promoted to repos/ and this would just be copying over packages that either already exist there or are out of date.

enterprise-dist pr to come
