### PR TITLE
(RE-12727) Remove reverted packages from artifactory enterprise repos

### DIFF
--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -595,6 +595,26 @@ module Pkg
       end
     end
 
+    # Remove promoted artifacts if promotion is reverted, use information provided in manifest
+    # @param manifest [File] JSON file containing information about what packages to download and the corresponding md5sums
+    # @param remote_path [String] path on artifactory to promoted packages ex. 2019.1/repos/
+    # @param package [String] package name ex. puppet-agent
+    # @param repos [Array] the repos the promoted artifacts live
+    def remove_promoted_packages(manifest, remote_path, package, repos)
+      check_authorization
+      manifest.each do |dist, packages|
+        packages.each do |package_name, info|
+          next unless package_name == package
+          artifacts = Artifactory::Resource::Artifact.checksum_search(md5: "#{info["md5"]}", repos: repos)
+          artifacts.each do |artifact|
+            next unless artifact.download_uri.include? remote_path
+            puts "Removing reverted package #{artifact.download_uri}"
+            artifact.delete
+          end
+        end
+      end
+    end
+
     # Remove shipped PE tarballs from artifactory
     # Used when compose fails, we only want the tarball shipped to artifactory if all platforms succeed
     # Identify which packages were created and shipped based on md5sum and remove them


### PR DESCRIPTION
Tested with puppet-agent package:
`Removing reverted package https://artifactory.delivery.puppetlabs.net/artifactory/rpm_enterprise__local/2018.1/repos/el-6-x86_64/puppet-agent-5.5.16.161.g4fa9432-1.el6.x86_64.rpm
Removing reverted package https://artifactory.delivery.puppetlabs.net/artifactory/rpm_enterprise__local/2018.1/repos/el-7-x86_64/puppet-agent-5.5.16.161.g4fa9432-1.el7.x86_64.rpm
Removing reverted package https://artifactory.delivery.puppetlabs.net/artifactory/rpm_enterprise__local/2018.1/repos/sles-12-x86_64/puppet-agent-5.5.16.161.g4fa9432-1.sles12.x86_64.rpm
Removing reverted package https://artifactory.delivery.puppetlabs.net/artifactory/debian_enterprise__local/2018.1/repos/ubuntu-16.04-amd64/puppet-agent_5.5.16.161.g4fa9432-1xenial_amd64.deb
Removing reverted package https://artifactory.delivery.puppetlabs.net/artifactory/debian_enterprise__local/2018.1/repos/ubuntu-18.04-amd64/puppet-agent_5.5.16.161.g4fa9432-1bionic_amd64.deb`

I think we just want to remove the packages from `<pe version>/repos` and not `<pe version>/feature` ? But if we want it removed from both I can update it to include that, I don't fully understand the extent of how `/feature/` is used