### PR TITLE
(RE-12788) Set `deb.component` property when copying PE packages

### DIFF
--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -580,6 +580,13 @@ module Pkg
           rescue Artifactory::Error::HTTPError
             STDERR.puts "Could not copy #{artifact_target_path}. Source and destination are the same. Skipping..."
           end
+          if File.extname(info["filename"]) == '.deb'
+            copied_artifact_search = Artifactory::Resource::Artifact.pattern_search(repo: 'debian_enterprise__local', pattern: "#{target_path}/*/#{info["filename"]}")
+            fail "Error: what the hell, could not find just-copied package #{info["filename"]} under debian_enterprise__local/#{target_path}" if copied_artifact_search.nil?
+            copied_artifact = copied_artifact_search.first
+            properties = { 'deb.component' => Pkg::Paths.two_digit_pe_version_from_path(target_path) }
+            copied_artifact.properties(properties)
+          end
         end
       end
     end

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -302,4 +302,10 @@ module Pkg::Paths
       return nil
     end
   end
+
+  def two_digit_pe_version_from_path(path)
+    matches = path.match(/\d+\.\d+/)
+    fail "Error: Could not determine PE version from path #{path}" if matches.nil?
+    return matches[0]
+  end
 end


### PR DESCRIPTION
This commit sets the `deb.component` property on copied debian packages when
populating a new PE repo. We set this to the PE version, which allows the
versioned subdirectories in Artifactory to be treated as separate repository
components. Without this, packages won't show up in the `dists` directory and
repo metadata won't pick them up, meaning we can't download the packages via
package manager.