### PR TITLE
(RE-11802) Update the release spreadsheet when shipping

### DIFF
--- a/lib/packaging.rb
+++ b/lib/packaging.rb
@@ -19,6 +19,7 @@ module Pkg
   require 'packaging/retrieve'
   require 'packaging/sign'
   require 'packaging/archive'
+  require 'packaging/metrics'
 
   # Load configuration defaults
   Pkg::Config.load_defaults

--- a/lib/packaging/metrics.rb
+++ b/lib/packaging/metrics.rb
@@ -1,0 +1,58 @@
+module Pkg::Metrics
+  module_function
+
+  require "google/apis/sheets_v4"
+  require "googleauth"
+  require "googleauth/stores/file_token_store"
+
+  # Ensure valid credentials, either by restoring from the saved credentials
+  # files or intitiating an OAuth2 authorization. If authorization is required,
+  # the user's default browser will be launched to approve the request.
+  #
+  # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
+  def authorize_google_sheets
+    oob_uri = "urn:ietf:wg:oauth:2.0:oob".freeze
+    credentials_path = ENV['CREDENTIALS_PATH'] || File.expand_path('credentials.json')
+    fail "Error: Could not read credentials file at #{credentials_path}. Set CREDENTIALS_PATH to override the default 'credentials.json'." unless File.readable? credentials_path
+    # The file token.yaml stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    token_path = ENV['TOKEN_PATH'] || File.expand_path('token.yaml')
+    scope = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
+
+    client_id = Google::Auth::ClientId.from_file credentials_path
+    token_store = Google::Auth::Stores::FileTokenStore.new file: token_path
+    authorizer = Google::Auth::UserAuthorizer.new client_id, scope, token_store
+    user_id = "default"
+    credentials = authorizer.get_credentials user_id
+    if credentials.nil?
+      url = authorizer.get_authorization_url base_url: oob_uri
+      puts "Open the following URL in the browser and enter the " \
+           "resulting code after authorization:\n" + url
+      code = gets
+      credentials = authorizer.get_and_store_credentials_from_code(
+        user_id: user_id, code: code, base_url: oob_uri
+      )
+    end
+    credentials
+  end
+
+  def add_new_row_values(spreadsheet_id, range, values)
+    # Initialize the API
+    service = Google::Apis::SheetsV4::SheetsService.new
+    service.authorization = authorize_google_sheets
+
+    value_range_object = Google::Apis::SheetsV4::ValueRange.new(values: values)
+    service.append_spreadsheet_value(spreadsheet_id, range, value_range_object, value_input_option: 'USER_ENTERED', insert_data_option: 'INSERT_ROWS', include_values_in_response: true)
+  end
+
+  def update_release_spreadsheet
+    # This is Molly's test spreadsheet for now; will update once all testing has been done
+    spreadsheet_id = '1Kvz3lJ_xymk-H4DsyAApOeT6NDjSArH7KYukWegx9-A'
+    range = 'Sheet1'
+    values = [[Pkg::Util::Date.today, Pkg::Config.project, Pkg::Config.ref, 'y']]
+
+    puts "Adding #{Pkg::Config.project} #{Pkg::Config.ref} to release spreadsheet . . ."
+    add_new_row_values(spreadsheet_id, range, values)
+  end
+end

--- a/lib/packaging/util/date.rb
+++ b/lib/packaging/util/date.rb
@@ -11,5 +11,10 @@ module Pkg::Util::Date
       end
       Time.now.strftime(format)
     end
+
+    def today
+      format = "%m/%d/%Y"
+      Time.now.strftime(format)
+    end
   end
 end

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('pry')
   gem.add_runtime_dependency('rake', ['>= 12.3'])
   gem.add_runtime_dependency('artifactory', ['~> 2'])
+  gem.add_runtime_dependency('google-api-client', ['~> 0.32'])
   gem.require_path = 'lib'
 
   # Ensure the gem is built out of versioned files

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -267,6 +267,12 @@ namespace :pl do
       end
       # mark the build as successfully shipped
       Rake::Task["pl:jenkins:ship"].invoke("shipped")
+      # update the release spreadsheet
+      begin
+        Rake::Task["pl:update_release_spreadsheet"].invoke
+      rescue => e
+        puts "Uh oh! Something went wrong updating the release spreadsheet:\n#{e}\nPlease update it manually. Proceeding..."
+      end
     end
 
     task :stage_nightlies => "pl:fetch" do

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -434,6 +434,11 @@ namespace :pl do
     Pkg::Util::Ship.ship_msi('pkg', Pkg::Config.nonfinal_msi_path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"], nonfinal: true)
   end
 
+  desc "Update the release spreadsheet for #{Pkg::Config.project} version #{Pkg::Config.ref}"
+  task :update_release_spreadsheet => "pl:fetch" do
+    Pkg::Metrics.update_release_spreadsheet
+  end
+
   desc 'UBER ship: ship all the things in pkg'
   task uber_ship: 'pl:fetch' do
     if Pkg::Util.confirm_ship(FileList['pkg/**/*'])


### PR DESCRIPTION
This commit adds methods for updating the Google Sheet we use to track all our
software releases. These methods get called as part of `uber_ship_lite` so that
we can use the already-defined Pkg::Config.project and Pkg::Config.ref params.