### PR TITLE
(RE-11802) Add task for updating release-metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ sudo: false
 notifications:
   email: false
 rvm:
-  - 2.0.0
-  - 2.1.9
   - 2.3.8
   - 2.4.1
+  - 2.6.5
 
 env:
   - "CHECK='rspec spec --color --format documentation --order random'"
@@ -15,9 +14,7 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.0.0
-      env: "CHECK='rubocop -D'"
-    - rvm: 2.1.9
-      env: "CHECK='rubocop -D'"
     - rvm: 2.3.8
+      env: "CHECK='rubocop -D'"
+    - rvm: 2.4.1
       env: "CHECK='rubocop -D'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-11802) Add `update_release_metrics` task for adding a release to the
   release-metrics repo.
 
+### Changed
+- Stop testing against Ruby 2.0.0 and 2.1.9.
+- Start testing against Ruby 2.6.5.
+
 ## [0.99.45] - 2019-10-08
 ### Fixed
 - (RE-12788) Set `deb.component` property when copying enterprise packages so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Added
 - Allow Gemfile source to be overridden with `GEM SOURCE`
+- (RE-11802) Add `update_release_metrics` task for adding a release to the
+  release-metrics repo.
 
 ## [0.99.45] - 2019-10-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- Allow Gemfile source to be overridden with `GEM SOURCE`
 
 ## [0.99.45] - 2019-10-08
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "https://rubygems.org"
+source ENV["GEM_SOURCE"] || "https://rubygems.org"
 
 gemspec

--- a/lib/packaging.rb
+++ b/lib/packaging.rb
@@ -19,6 +19,7 @@ module Pkg
   require 'packaging/retrieve'
   require 'packaging/sign'
   require 'packaging/archive'
+  require 'packaging/metrics'
 
   # Load configuration defaults
   Pkg::Config.load_defaults

--- a/lib/packaging/metrics.rb
+++ b/lib/packaging/metrics.rb
@@ -1,0 +1,15 @@
+module Pkg::Metrics
+  module_function
+
+  def update_release_metrics
+    metrics_repo = 'release-metrics'
+    command = <<CMD
+git clone git@github.com:puppetlabs/#{metrics_repo}.git
+cd #{metrics_repo}
+bundle exec add-release --date #{Pkg::Util::Date.today} --project #{Pkg::Config.project} --version #{Pkg::Config.ref}
+cd ..
+rm -r #{metrics_repo}
+CMD
+    Pkg::Util::Execution.capture3(command)
+  end
+end

--- a/lib/packaging/util/date.rb
+++ b/lib/packaging/util/date.rb
@@ -11,5 +11,10 @@ module Pkg::Util::Date
       end
       Time.now.strftime(format)
     end
+
+    def today
+      format = "%m/%d/%Y"
+      Time.now.strftime(format)
+    end
   end
 end

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('pry')
   gem.add_runtime_dependency('rake', ['>= 12.3'])
   gem.add_runtime_dependency('artifactory', ['~> 2'])
+  gem.add_runtime_dependency('release-metrics')
   gem.require_path = 'lib'
 
   # Ensure the gem is built out of versioned files

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -267,6 +267,12 @@ namespace :pl do
       end
       # mark the build as successfully shipped
       Rake::Task["pl:jenkins:ship"].invoke("shipped")
+      # add the release to release-metrics
+      begin
+        Rake::Task["pl:update_release_metrics"].invoke
+      rescue => e
+        puts "Uh oh! Something went wrong updating release-metrics:\n#{e}\nPlease add this release manually. Proceeding..."
+      end
     end
 
     task :stage_nightlies => "pl:fetch" do

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -434,6 +434,11 @@ namespace :pl do
     Pkg::Util::Ship.ship_msi('pkg', Pkg::Config.nonfinal_msi_path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"], nonfinal: true)
   end
 
+  desc "Add #{Pkg::Config.project} version #{Pkg::Config.ref} to release-metrics"
+  task :update_release_metrics => "pl:fetch" do
+    Pkg::Metrics.update_release_metrics
+  end
+
   desc 'UBER ship: ship all the things in pkg'
   task uber_ship: 'pl:fetch' do
     if Pkg::Util.confirm_ship(FileList['pkg/**/*'])


### PR DESCRIPTION
This commit adds an `update_release_metrics` task for adding a release to the release-metrics repo (previously the release spreadsheet). This task gets called during `uber_ship_lite` in order to retain the context of what was just shipped.
