### PR TITLE
(maint) Capture debug output when updating release-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- Capture debug output when updating release-metrics.
 
 ## [0.99.46] - 2019-10-14
 ### Added

--- a/lib/packaging/metrics.rb
+++ b/lib/packaging/metrics.rb
@@ -10,6 +10,6 @@ bundle exec add-release --date #{Pkg::Util::Date.today} --project #{Pkg::Config.
 cd ..
 rm -r #{metrics_repo}
 CMD
-    Pkg::Util::Execution.capture3(command)
+    Pkg::Util::Execution.capture3(command, true)
   end
 end


### PR DESCRIPTION
This commit turns on the `capture3` `debug` setting so that we can see command
output. In the last Puppet Platform release, puppet-agent components did not
get added for 1 out of 3 releases, so this should help us determine why.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
