### PR TITLE
(RE-12868) Update timestamp server for windows signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Changed
 - Capture debug output when updating release-metrics.
+- (RE-12868) Update timestamp server for windows signing.
 
 ## [0.99.46] - 2019-10-14
 ### Added

--- a/lib/packaging/sign/msi.rb
+++ b/lib/packaging/sign/msi.rb
@@ -87,7 +87,7 @@ for msi in #{msis.map { |d| File.basename(d) }.join(" ")}; do
     done;
     echo $ret
     if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
-    sha256Servers=(http://sha256timestamp.ws.symantec.com/sha256/timestamp
+    sha256Servers=(http://timestamp.digicert.com/sha256/timestamp
       http://timestamp.comodoca.com?td=sha256)
     for timeserver in "${sha256Servers[@]}"; do
       for ((try=1; try<=$tries; try++)) do


### PR DESCRIPTION
based on https://app.updates.digicert.com/e/es?s=1701211846&e=253970&elqTrackId=9f7f91354c5449a39c8dec628cf9060b&elq=38c682e663bb41df880e4dcb5755ceec&elqaid=6754&elqat=1 we replace `sha256timestamp.ws.symantec.com` with `timestamp.digicert.com`

Tested by building + signing msi package
```
echo $ret
    if [[ $ret != *"Succeeded"* ]]; then exit 1; fi
    sha256Servers=(http://timestamp.digicert.com/sha256/timestamp
      http://timestamp.comodoca.com?td=sha256)
    for timeserver in "${sha256Servers[@]}"; do
```

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
