### PR TITLE
(RE-12874) Re-do the Artifactory 'cleanup.skip' logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed
+- (RE-12874) Simplify the logic for setting 'cleanup.skip' for Artifactory
+  artifact directories
 - Replace `Pkg::Paths.two_digit_pe_version_from_path` with
   `Pkg::Paths.debian_component_from_path` since the method was only being used
   for setting components and was not working correctly for packages populated


### PR DESCRIPTION
This is a *breaking change* and will need to be coordinated with
changes to enterprise-dist.

This changes the way we handle the Artifactory 'cleanup.skip' logic.
Rather than try to calculate it at the time we upload the tarballs,
we set the 'cleanup.skip' property when we upload the 'LATEST' file.

The former approach had the problem that the version string for the tarballs
that we wanted to keep was unavailable. This approach simply uses
the string in the LATEST file as a pattern to keep.

It starts by setting 'cleanup.skip' to *false* on all the files in the target
Artifactory directory, then sets 'cleanup.skip' to *true* for all tarballs
containing the string in the LATEST file.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.