### PR TITLE
(RE-12869) Refactor `ship_gem_to_downloads` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
   `Pkg::Paths.debian_component_from_path` since the method was only being used
   for setting components and was not working correctly for packages populated
   to 'release' or 'feature' repos
+- (RE-12869) Skip shipping gems to downloads.puppet.com, but don't exit or fail,
+  when `gem_host` or `gem_path` is unset.
 
 ## [0.99.47] - 2019-10-22
 ### Changed

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -322,14 +322,12 @@ namespace :pl do
 
   desc "Ship built gems to public Downloads server (#{Pkg::Config.gem_host})"
   task :ship_gem_to_downloads => 'pl:fetch' do
-    unless Pkg::Config.gem_host
+    if Pkg::Config.gem_host && Pkg::Config.gem_path
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)
+      end
+    else
       warn 'Value `Pkg::Config.gem_host` not defined; skipping shipping to public Download server'
-      exit
-    end
-    fail 'Value `Pkg::Config.gem_path` not defined; skipping shipping to public Download server' unless Pkg::Config.gem_path
-
-    Pkg::Util::Execution.retry_on_fail(times: 3) do
-      Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)
     end
   end
 


### PR DESCRIPTION
This commit reorganizes the `ship_gem_to_downloads` task to be clearer about
the cases where we do and don't want to actually attemp shipping to downloads.
Previously, the `exit` that was called to prevent the upload in the case of
unset params was preventing downstream tasks from getting run. For example,
because Bolt ships gems to rubygems, but not downloads, they have `build_gem`
set to true but no `gem_host` or `gem_path`. When shipping, none of the
`uber_ship_lite` tasks after `ship_gem_to_downloads` were getting run.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
