### PR TITLE
(maint) Include filename when copying in Artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- Include filename when copying PE tarballs so the parent directory is created.
+
 ### Added
 - (PDK-1546) Add Fedora 31 to platforms
 

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -557,7 +557,11 @@ module Pkg
       final_tarballs.each do |artifact|
         next unless artifact.download_uri.include? remote_path
         next if artifact.download_uri.include? "-rc"
-        artifact.copy("#{repo}/#{target_path}")
+        filename = File.basename(artifact.download_uri)
+        # Artifactory does NOT like when you use `File.join`, so let's concatenate!
+        full_target_path = "#{repo}/#{target_path}/#{filename}"
+        puts "INFO: Copying #{filename} to #{full_target_path} . . ."
+        artifact.copy(full_target_path)
       end
     end
 


### PR DESCRIPTION
This commit updates the `copy_final_pe_tarballs` method to include the filename
in the target path when copying to archives/releases. Previously, when trying to
copy, instead of creating a directory to copy into, it would create a single
file with the desired directory name.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
