### PR TITLE
(PA-3021) add windowsfips versionless symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+- Add windowsfips versionless symlinks
 
 ## [0.99.49] - 2019-11-19
 ### Fixed


### PR DESCRIPTION
This will create puppet-agent-x64.msi under windowsfips foder.
Build: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/631/
Output: http://builds.delivery.puppetlabs.net/puppet-agent/70994f8381ef94515592bde898a00fc579acfccb/artifacts/windowsfips/?C=M&O=A