### PR TITLE
(PA-2987) Handle puppet nightly gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 - Add windowsfips versionless symlinks
+- Add rake task to build nightly gem packages
+- Add rake task to remotely link nightly shipped gems to latest versions
 
 ## [0.99.49] - 2019-11-19
 ### Fixed

--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -50,10 +50,18 @@ module Pkg::Util::Version
       end
     end
 
+    def extended_dash_version
+      Pkg::Util::Git.describe(['--tags', '--dirty', '--abbrev=7'])
+    end
+
     # This version is used for gems and platform types that do not support
     # dashes in the package version
     def dot_version(version = Pkg::Config.version)
       version.tr('-', '.')
+    end
+
+    def extended_dot_version
+      dot_version(extended_dash_version)
     end
 
     # Given a version, reformat it to be appropriate for a final package

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -248,6 +248,23 @@ namespace :pl do
         end
       end
     end
+
+    desc "Remotely link nightly shipped gems to latest versions on #{Pkg::Config.gem_host}"
+    task :link_nightly_shipped_gems_to_latest do
+      Pkg::Config.gemversion = Pkg::Util::Version.extended_dot_version
+
+      remote_path = Pkg::Config.nonfinal_gem_path
+      gems = FileList['pkg/*.gem'].map! { |path| path.gsub!('pkg/', '') }
+      command = %(cd #{remote_path}; )
+
+      command += gems.map! do |gem_name|
+        %(sudo ln -sf #{gem_name} #{gem_name.gsub(Pkg::Config.gemversion, 'latest')})
+      end.join(';')
+
+      command += %(; sync)
+
+      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.gem_host, command)
+    end
   end
 
   desc "Ship mocked rpms to #{Pkg::Config.yum_staging_server}"


### PR DESCRIPTION
Scope of this pull-request is to add possibility build nightly gem and to create `#{gem_name}-latest-#{platform}`symlinks.

Usage: 
```
package:nightly_gem
pl:remote:link_nightly_shipped_gems_to_latest
```

Eg. result :
```
puppet-6.11.0.79.g61d0522-x86-mingw32.gem
puppet-6.11.0.79.g61d0522-x86-mingw32.gem -> puppet-6.11.0.73-x64-mingw32.gem
```

Having `-latest` version would let puppet nightly gem consumers to download the latest nightly gem with minimal effort.

I'm thinking on structuring the gems in nightlies.puppet.com like this:
```
puppet 5:
   /downloads/gems/puppet5-nightly/puppet-latest.gem
   /downloads/gems/puppet5-nightly/puppet-x64-mingw32.gem
etc...

puppet6: 
  /downloads/gems/puppet6-nightly/puppet-latest.gem
etc...
```