### PR TITLE
(PA-2987) handle puppet gem nightly version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 - Add windowsfips versionless symlinks
+- Add `NIGHTLY_PACKAGE` param to handle diffrent cases for building and shipping
+  nightly packages
 
 ## [0.99.49] - 2019-11-19
 ### Fixed

--- a/lib/packaging.rb
+++ b/lib/packaging.rb
@@ -24,9 +24,9 @@ module Pkg
   # Load configuration defaults
   Pkg::Config.load_defaults
   Pkg::Config.load_default_configs
-  Pkg::Config.load_versioning
   Pkg::Config.load_overrides
   Pkg::Config.load_envvars
+  Pkg::Config.load_versioning
   Pkg::Config.issue_reassignments
   Pkg::Config.issue_deprecations
 end

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -279,7 +279,13 @@ module Pkg
           @ref         = Pkg::Util::Git.sha_or_tag
           @short_ref   = Pkg::Util::Git.sha_or_tag(7)
           @version     = Pkg::Util::Version.dash_version
-          @gemversion  = Pkg::Util::Version.dot_version
+          @gemversion  =  if Pkg::Config.nightly_package
+                            Pkg::Util::Version.dot_version(
+                              Pkg::Util::Version.extended_dash_version
+                            )
+                          else
+                            Pkg::Util::Version.dot_version
+                          end
           @debversion  = Pkg::Util::Version.debversion
           @origversion = Pkg::Util::Version.origversion
           @rpmversion  = Pkg::Util::Version.rpmversion

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -189,6 +189,7 @@ module Pkg::Params
                   :yum_repo_name,
                   :yum_repo_path,
                   :yum_staging_server,
+                  :nightly_package,
                  ]
 
   # Environment variable overrides for Pkg::Config parameters
@@ -303,6 +304,7 @@ module Pkg::Params
               { :var => :yum_repo_path,           :envvar => :YUM_REPO },
               { :var => :yum_staging_server,      :envvar => :YUM_STAGING_SERVER },
               { :var => :internal_gem_host,       :envvar => :INTERNAL_GEM_HOST },
+              { :var => :nightly_package,         :envvar => :NIGHTLY_PACKAGE, :type => :bool },
              ]
   # Default values that are supplied if the user does not supply them
   #
@@ -332,7 +334,8 @@ module Pkg::Params
               { :var => :pe_feature_branch,       :val => false },
               { :var => :pe_release_branch,       :val => false },
               { :var => :s3_ship,                 :val => false },
-              { :var => :apt_releases,            :val => Pkg::Platforms.codenames }]
+              { :var => :apt_releases,            :val => Pkg::Platforms.codenames },
+              { :var => :nightly_package,         :val => false }]
 
   # These are variables which, over time, we decided to rename or replace. For
   # backwards compatibility, we assign the value of the old/deprecated

--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -50,6 +50,10 @@ module Pkg::Util::Version
       end
     end
 
+    def extended_dash_version
+      Pkg::Util::Git.describe(['--tags', '--dirty', '--abbrev=7'])
+    end
+
     # This version is used for gems and platform types that do not support
     # dashes in the package version
     def dot_version(version = Pkg::Config.version)


### PR DESCRIPTION
This commit adds a new param `NIGHTLY_PACKAGE` which
is used to set diffrent things when building packages
for nightly. Eg. handling puppet gem version

Also adds an utility method to retrieve the extended
dash git version

Output:
```
~/Workspace/puppet  origin/master ⇣⇡                                                                                                              
❯ bundle exec rake package:gem NIGHTLY_PACKAGE=true

~/Workspace/puppet  origin/master ⇣⇡                                                                                                             
❯ ls pkg
puppet-6.11.0.79.g61d0522-universal-darwin.gem 
puppet-6.11.0.79.g61d0522-x86-mingw32.gem
puppet-6.11.0.79.g61d0522-x64-mingw32.gem      
puppet-6.11.0.79.g61d0522.gem

```
