### PR TITLE
(RE-13101) Change warning to hard fail when release-metrics doesn't work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-13101) Change warning to hard fail when release-metrics update doesn't
+  work.
 
 ## [0.99.52] - 2019-12-17
 ### Fixed

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -271,7 +271,7 @@ namespace :pl do
       begin
         Rake::Task["pl:update_release_metrics"].invoke
       rescue => e
-        puts "Uh oh! Something went wrong updating release-metrics:\n#{e}\nPlease add this release manually. Proceeding..."
+        fail "Error updating release-metrics:\n#{e}\nYou will need to add this release manually."
       end
     end
 


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.