### PR TITLE
(PA-2987) fix link_nightly_shipped_gems_to_latest task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+- Fixed link_nightly_shipped_gems_to_latest task
 
 ## [0.99.51] - 2019-12-11
 ### Fixed

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -250,7 +250,7 @@ namespace :pl do
     end
 
     desc "Remotely link nightly shipped gems to latest versions on #{Pkg::Config.gem_host}"
-    task :link_nightly_shipped_gems_to_latest do
+    task link_nightly_shipped_gems_to_latest: 'pl:fetch' do
       Pkg::Config.gemversion = Pkg::Util::Version.extended_dot_version
 
       remote_path = Pkg::Config.nonfinal_gem_path


### PR DESCRIPTION
Execute `pl:fetch` before  `pl:remote:link_nightly_shipped_gems_to_latest `