### PR TITLE
[RFC] Moar artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Addeed
+### Added
 - Added the option to specify a search path to the `download_packages` artifactory
-  method.
+  method. If packages are found in the correct repositories but not in the
+  search path, they will be copied to the search path.
+
+### Fixed
+- `debian_component_from_path` now supports the master branch.
+- `debian_component_from_path` substitutes `.` and `/` with `_` so the components
+   are valid.
 
 ## [0.99.58] - 2020-03-03
 ### Changed

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -417,6 +417,17 @@ module Pkg
         packages.each do |name, info|
           artifacts = Artifactory::Resource::Artifact.checksum_search(md5: "#{info["md5"]}", repos: ["rpm_enterprise__local", "debian_enterprise__local"])
           artifact_to_download = artifacts.select { |artifact| artifact.download_uri.include? remote_path }.first
+          # If we found matching artifacts, but not in the correct path, copy the artifact to the correct path
+          # This should help us keep repos up to date with the packages we are expecting to be there
+          # while helping us avoid 'what the hell, could not find package' errors
+          if artifact_to_download.nil? && !artifacts.empty?
+            artifact_to_copy = artifacts.first
+            filename = info['filename'] || File.basename(artifact_to_copy.download_uri)
+            copy_artifact(artifact_to_copy, artifact_to_copy.repo, "#{remote_path}/#{dist}/#{filename}")
+            artifacts = Artifactory::Resource::Artifact.checksum_search(md5: "#{info["md5"]}", repos: ["rpm_enterprise__local", "debian_enterprise__local"])
+            artifact_to_download = artifacts.select { |artifact| artifact.download_uri.include? remote_path }.first
+          end
+
           if artifact_to_download.nil?
             filename = info["filename"] || name
             message = "Error: what the hell, could not find package #{filename} with md5sum #{info["md5"]}"
@@ -590,6 +601,33 @@ module Pkg
       end
     end
 
+    # Copy an artifact to a target repo/path
+    #
+    # @param artifact [Artifactory::Resource::Artifact] The artifact to be copied
+    # @param target_repo [String] The repository to copy the artifact to
+    # @param target_path [String] The path in the target repository to copy the artifact to
+    # @param target_debian_component [String] `deb.component` property to set on the copied artifact
+    #        defaults to `Pkg::Paths.debian_component_from_path(target_path)`
+    def copy_artifact(artifact, target_repo, target_path, target_debian_component = nil)
+      filename = File.basename(artifact.download_uri)
+      artifactory_target_path = "#{target_repo}/#{target_path}"
+      puts "Copying #{artifact.download_uri} to #{artifactory_target_path}"
+      begin
+        artifact.copy(artifactory_target_path)
+      rescue Artifactory::Error::HTTPError
+        STDERR.puts "Could not copy #{artifactory_target_path}. Source and destination are the same. Skipping..."
+      end
+
+      if File.extname(filename) == '.deb'
+        target_debian_component ||= Pkg::Paths.debian_component_from_path(target_path)
+        copied_artifact_search = search_with_path(filename, target_repo, target_path)
+        fail "Error: what the hell, could not find just-copied package #{filename} under #{target_repo}/#{target_path}" if copied_artifact_search.empty?
+        copied_artifact = copied_artifact_search.first
+        properties = { 'deb.component' => target_debian_component }
+        copied_artifact.properties(properties)
+      end
+     end
+
     # When we cut a new PE branch, we need to copy the pe components into <pe_version>/{repos,feature,release}/<platform>
     # @param manifest [File] JSON file containing information about what packages to download and the corresponding md5sums
     # @param target_path [String] path on artifactory to copy components to, e.g. <pe_version>/release
@@ -603,21 +641,8 @@ module Pkg
             filename = info["filename"] || name
             raise "Error: what the hell, could not find package #{filename} with md5sum #{info["md5"]}"
           end
-          begin
-            filename = info["filename"] || File.basename(artifact.download_uri)
-            artifact_target_path = "#{artifact.repo}/#{target_path}/#{dist}/#{filename}"
-            puts "Copying #{artifact.download_uri} to #{artifact_target_path}"
-            artifact.copy(artifact_target_path)
-          rescue Artifactory::Error::HTTPError
-            STDERR.puts "Could not copy #{artifact_target_path}. Source and destination are the same. Skipping..."
-          end
-          if File.extname(filename) == '.deb'
-            copied_artifact_search = Artifactory::Resource::Artifact.pattern_search(repo: 'debian_enterprise__local', pattern: "#{target_path}/*/#{filename}")
-            fail "Error: what the hell, could not find just-copied package #{filename} under debian_enterprise__local/#{target_path}" if copied_artifact_search.nil?
-            copied_artifact = copied_artifact_search.first
-            properties = { 'deb.component' => Pkg::Paths.debian_component_from_path(target_path) }
-            copied_artifact.properties(properties)
-          end
+          filename = info["filename"] || File.basename(artifact.download_uri)
+          copy_artifact(artifact, artifact.repo, "#{target_path}/#{dist}/#{filename}")
         end
       end
     end

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -600,7 +600,7 @@ module Pkg
         packages.each do |name, info|
           artifact = Artifactory::Resource::Artifact.checksum_search(md5: "#{info["md5"]}", repos: ["rpm_enterprise__local", "debian_enterprise__local"]).first
           if artifact.nil?
-            filename = info["filename"] || info["name"]
+            filename = info["filename"] || name
             raise "Error: what the hell, could not find package #{filename} with md5sum #{info["md5"]}"
           end
           begin

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -305,8 +305,17 @@ module Pkg::Paths
 
   def debian_component_from_path(path)
     matches = path.match(/(\d+\.\d+)\/(\w+)/)
+    # substitute '.' and '/' since those aren't valid characters for debian components
+    regex_for_substitution = /[\.\/]/
     fail "Error: Could not determine Debian Component from path #{path}" if matches.nil?
-    return matches[1] if matches[2] == 'repos'
-    return matches[0]
+    base_component = matches[1]
+    component_qualifier = matches[2]
+    full_component = "#{base_component}/#{component_qualifier}"
+    unless regex_for_substitution.nil?
+      base_component.gsub!(regex_for_substitution, '_')
+      full_component.gsub!(regex_for_substitution, '_')
+    end
+    return base_component if component_qualifier == 'repos'
+    return full_component
   end
 end

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -304,8 +304,8 @@ module Pkg::Paths
   end
 
   def debian_component_from_path(path)
-    matches = path.match(/(\d+\.\d+)\/(\w+)/)
     # substitute '.' and '/' since those aren't valid characters for debian components
+    matches = path.match(/([\d+\.\d+|master])\/(\w+)/)
     regex_for_substitution = /[\.\/]/
     fail "Error: Could not determine Debian Component from path #{path}" if matches.nil?
     base_component = matches[1]


### PR DESCRIPTION
This builds on #1039 and adds logic so that the compose jobs can be set to be self-healing (if they find packages but they aren't in the correct subdir on artifactory, copy it be in the correct subdir).

Mostly, when working on https://github.com/puppetlabs/enterprise-dist/pull/3657 I was updating repos with all the missing packages and that was tedious and felt like something that was automatable. 

Need to do changelog first, but wanted to validate that we were good with this sort of change before hand
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
