### PR TITLE
(RE-9687) Set `deb.architecture` to 'all' for noarch packages shipped to artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (RE-9687) Set `deb.architecture` correctly in artifactory for noarch packages.
 
 ## [0.99.59] - 2020-03-11
 ### Added

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -235,7 +235,7 @@ module Pkg
     #
     #   Currently we are including everything that would be included in the yaml
     #   file that is generated at package build time.
-    def deploy_properties(platform_tag)
+    def deploy_properties(platform_tag, file_name)
       data = platform_specific_data(platform_tag)
 
       # TODO This method should be returning the entire contents of the yaml
@@ -246,10 +246,15 @@ module Pkg
       #properties_hash = Pkg::Config.config_to_hash
       properties_hash = {}
       if data[:package_format] == 'deb'
+        architecture = data[:architecture]
+        # set arch correctly for noarch packages
+        if file_name =~ /_all\.deb$/
+          architecture = 'all'
+        end
         properties_hash.merge!({
           'deb.distribution' => data[:codename],
           'deb.component' => data[:repo_subdirectories],
-          'deb.architecture' => data[:architecture],
+          'deb.architecture' => architecture,
         })
       end
       properties_hash
@@ -282,7 +287,7 @@ module Pkg
       artifact.upload(
         data[:repo_name],
         File.join(data[:alternate_subdirectories], File.basename(package)),
-        deploy_properties(platform_tag),
+        deploy_properties(platform_tag, File.basename(package)),
         headers
       )
     rescue

--- a/spec/lib/packaging/artifactory_spec.rb
+++ b/spec/lib/packaging/artifactory_spec.rb
@@ -21,6 +21,11 @@ describe 'artifactory.rb' do
         :repo_config => "../repo_configs/deb/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-xenial.list",
         :additional_artifacts => ["./deb/xenial/PC1/puppet-agent-extras_5.3.1.34.gf65f9ef-1xenial_amd64.deb"],
       },
+      'debian-10-amd64' => {
+        :artifact => "./deb/buster/PC1/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb",
+        :repo_config => "../repo_configs/deb/pl-puppetdb-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-buster.list",
+        :additional_artifacts => ["./deb/buster/PC1/puppetdb-termini_5.3.1.34.gf65f9ef-1buster_all.deb"],
+      },
       'windows-2012-x86' => {
         :artifact => "./windows/puppet-agent-5.3.1.34-x86.msi",
         :repo_config => '',
@@ -64,7 +69,15 @@ describe 'artifactory.rb' do
       :package_name => 'path/to/a/xenial/package/puppet-agent_5.3.1.34.gf65f9ef-1xenial_amd64.deb',
       :all_package_names => ['puppet-agent_5.3.1.34.gf65f9ef-1xenial_amd64.deb', 'puppet-agent-extras_5.3.1.34.gf65f9ef-1xenial_amd64.deb']
     },
-    'windows-2012-x86' => {
+    'debian-10-amd64' => {
+      :toplevel_repo => 'debian__local',
+      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/debian-10",
+      :codename => 'buster',
+      :arch => 'all',
+      :package_name => 'path/to/a/buster/package/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb',
+      :all_package_names => ['puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb', 'puppetdb-termini_5.3.1.34.gf65f9ef-1buster_all.deb']
+    },
+'windows-2012-x86' => {
       :toplevel_repo => 'generic',
       :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/windows-x86",
       :package_name => 'path/to/a/windows/package/puppet-agent-5.3.1.34-x86.msi',
@@ -186,12 +199,13 @@ describe 'artifactory.rb' do
     describe '#deploy_properties' do
       it "returns the correct contents for the deploy properties for #{platform_tag}" do
         if platform_tag_data[:codename]
-          expect(artifact.deploy_properties(platform_tag)).to include({
+          expect(artifact.deploy_properties(platform_tag, File.basename(platform_tag_data[:package_name]))).to include({
             'deb.distribution' => platform_tag_data[:codename],
-            'deb.component' => platform_tag_data[:repo_subdirectories]
+            'deb.component' => platform_tag_data[:repo_subdirectories],
+            'deb.architecture' => platform_tag_data[:arch]
           })
         else
-          expect(artifact.deploy_properties(platform_tag)).not_to include({
+          expect(artifact.deploy_properties(platform_tag, File.basename(platform_tag_data[:package_name]))).not_to include({
             'deb.component' => platform_tag_data[:repo_subdirectories]
           })
         end


### PR DESCRIPTION


Please add all notable changes to the "Unreleased" section of the CHANGELOG.
