### PR TITLE
(RE-12065)(RE-12069) Remove s390x for sles and el

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -103,7 +103,7 @@ module Pkg
           repo: true,
         },
         '6' => {
-          architectures: ['x86_64', 'i386', 's390x'],
+          architectures: ['x86_64', 'i386'],
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
@@ -111,7 +111,7 @@ module Pkg
           repo: true,
         },
         '7' => {
-          architectures: ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+          architectures: ['x86_64', 'ppc64le', 'aarch64'],
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
@@ -273,7 +273,7 @@ module Pkg
 
       'sles' => {
         '11' => {
-          architectures: ['x86_64', 'i386', 's390x'],
+          architectures: ['x86_64', 'i386'],
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
@@ -281,7 +281,7 @@ module Pkg
           repo: true,
         },
         '12' => {
-          architectures: ['x86_64', 's390x', 'ppc64le'],
+          architectures: ['x86_64', 'ppc64le'],
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -207,7 +207,7 @@ describe "Pkg::Config" do
       'cisco-wrlinux-7-x86_64',
       'ubuntu-16.04-i386',
       'cumulus-2.2-amd64',
-      'el-6-s390x',
+      'el-6-i386',
       'el-7-ppc64le',
       'sles-12-x86_64',
     ]
@@ -218,7 +218,7 @@ describe "Pkg::Config" do
       "./artifacts/cisco-wrlinux/7/PC1/x86_64/puppet-agent-5.3.2-1.cisco_wrlinux7.x86_64.rpm\n" \
       "./artifacts/deb/xenial/PC1/puppet-agent_5.3.2-1xenial_i386.deb\n" \
       "./artifacts/deb/cumulus/PC1/puppet-agent_5.3.2-1cumulus_amd64.deb\n" \
-      "./artifacts/el/6/PC1/s390x/puppet-agent-5.3.2.658.gc79ef9a-1.el6.s390x.rpm\n" \
+      "./artifacts/el/6/PC1/i386/puppet-agent-5.3.2.658.gc79ef9a-1.el6.i386.rpm\n" \
       "./artifacts/el/7/PC1/ppc64le/puppet-agent-5.3.2-1.el7.ppc64le.rpm\n" \
       "./artifacts/sles/12/PC1/x86_64/puppet-agent-5.3.2-1.sles12.x86_64.rpm"
 

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -75,11 +75,11 @@ describe 'Pkg::Platforms' do
 
   describe '#arches_for_platform_version' do
     it 'should return an array of arches for a given platform and version' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '11')).to match_array(['i386', 'x86_64', 's390x'])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '11')).to match_array(['i386', 'x86_64'])
     end
 
     it 'should be able to include source architectures' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '11', true)).to match_array(['i386', 'x86_64', 's390x', 'SRPMS'])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '11', true)).to match_array(['i386', 'x86_64', 'SRPMS'])
     end
   end
 

--- a/spec/lib/packaging/retrieve_spec.rb
+++ b/spec/lib/packaging/retrieve_spec.rb
@@ -12,7 +12,7 @@ describe 'Pkg::Retrieve' do
     'aix-6.1-power' => {:artifact => './aix/6.1/PC1/ppc/puppet-agent-5.3.2.155.gb25e649-1.aix6.1.ppc.rpm'},
     'el-7-x86_64' => {:artifact => './el/7/PC1/x86_64/puppet-agent-5.3.2.155.gb25e649-1.el7.x86_64.rpm'},
     'osx-10.11-x86_64' => {:artifact => './apple/10.11/PC1/x86_64/puppet-agent-5.3.2.155.gb25e649-1.osx10.11.dmg'},
-    'sles-11-s390x' => {:artifact => './sles/11/PC1/s390x/puppet-agent-5.3.2.155.gb25e649-1.sles11.s390x.rpm'},
+    'sles-11-i386' => {:artifact => './sles/11/PC1/i386/puppet-agent-5.3.2.155.gb25e649-1.sles11.i386.rpm'},
     'solaris-10-sparc' => {:artifact => './solaris/10/PC1/puppet-agent-5.3.2.155.gb25e649-1.sparc.pkg.gz'},
     'ubuntu-16.04-amd64' => {:artifact => './deb/xenial/PC1/puppet-agent_5.3.2.155.gb25e649-1xenial_amd64.deb'},
     'windows-2012-x64' => {:artifact => './windows/puppet-agent-x64.msi'},

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -74,7 +74,7 @@ DOC
       ] }
       let(:v4_rpms) { [
         "#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm",
-        "#{rpm_directory}/sles/12/PC1/s390x/puppet-agent-5.5.3-1.sles12.s390x.rpm",
+        "#{rpm_directory}/sles/12/PC1/i386/puppet-agent-5.5.3-1.sles12.i386.rpm",
       ] }
       let(:rpms) { rpms_not_to_sign + v3_rpms + v4_rpms }
       let(:already_signed_rpms) { [


### PR DESCRIPTION
update spec tests accordingly - I swapped s390x for i386 in the tests, if that's a bad idea I can change it or just remove it altogether

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
