### PR TITLE
Revert "Revert "Merge pull request #1045 from sarameisburger/remove-p…

### DIFF
--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -47,26 +47,7 @@ module Pkg
         },
       },
 
-      'cumulus' => {
-        '2.2' => {
-          codename: 'cumulus',
-          architectures: ['amd64'],
-          source_architecture: 'source',
-          package_format: 'deb',
-          source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
-      },
-
       'debian' => {
-        '7' => {
-          codename: 'wheezy',
-          architectures: ['amd64', 'i386'],
-          source_architecture: 'source',
-          package_format: 'deb',
-          source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
         '8' => {
           codename: 'jessie',
           architectures: ['amd64', 'i386', 'powerpc'],
@@ -137,78 +118,6 @@ module Pkg
       },
 
       'fedora' => {
-        'f25' => {
-          architectures: ['x86_64', 'i386'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        'f26' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        'f27' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        'f28' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        '25' => {
-          architectures: ['x86_64', 'i386'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        '26' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        '27' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        '28' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        '29' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
         '30' => {
           architectures: ['x86_64'],
           source_architecture: 'SRPMS',
@@ -228,26 +137,6 @@ module Pkg
       },
 
       'osx' => {
-        '10.10' => {
-          architectures: ['x86_64'],
-          package_format: 'dmg',
-          repo: false,
-        },
-        '10.11' => {
-          architectures: ['x86_64'],
-          package_format: 'dmg',
-          repo: false,
-        },
-        '10.12' => {
-          architectures: ['x86_64'],
-          package_format: 'dmg',
-          repo: false,
-        },
-        '10.13' => {
-          architectures: ['x86_64'],
-          package_format: 'dmg',
-          repo: false,
-        },
         '10.14' => {
           architectures: ['x86_64'],
           package_format: 'dmg',

--- a/spec/lib/packaging/artifactory_spec.rb
+++ b/spec/lib/packaging/artifactory_spec.rb
@@ -41,10 +41,10 @@ describe 'artifactory.rb' do
         :repo_config => '',
         :additional_artifacts => ["./eos/4/PC1/i386/puppet-agent-extras-5.3.1.34.gf65f9ef-1.eos4.i386.swix"],
       },
-      'osx-10.12-x86_64' => {
-        :artifact => "./apple/10.12/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.12.dmg",
+      'osx-10.15-x86_64' => {
+        :artifact => "./apple/10.15/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg",
         :repo_config => '',
-        :additional_artifacts => ["./apple/10.12/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.12.dmg"],
+        :additional_artifacts => ["./apple/10.15/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.15.dmg"],
       },
       'solaris-10-sparc' => {
         :artifact => "./solaris/10/PC1/puppet-agent-5.3.1.34.gf65f9ef-1.sparc.pkg.gz",
@@ -77,7 +77,7 @@ describe 'artifactory.rb' do
       :package_name => 'path/to/a/buster/package/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb',
       :all_package_names => ['puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb', 'puppetdb-termini_5.3.1.34.gf65f9ef-1buster_all.deb']
     },
-'windows-2012-x86' => {
+    'windows-2012-x86' => {
       :toplevel_repo => 'generic',
       :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/windows-x86",
       :package_name => 'path/to/a/windows/package/puppet-agent-5.3.1.34-x86.msi',
@@ -95,11 +95,11 @@ describe 'artifactory.rb' do
       :package_name => 'path/to/an/eos/4/package/puppet-agent-5.3.1.34.gf65f9ef-1.eos4.i386.swix',
       :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.eos4.i386.swix', 'puppet-agent-extras-5.3.1.34.gf65f9ef-1.eos4.i386.swix']
     },
-    'osx-10.12-x86_64' => {
+    'osx-10.15-x86_64' => {
       :toplevel_repo => 'generic',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/osx-10.12-x86_64",
-      :package_name => 'path/to/an/osx/10.12/package/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.12.dmg',
-      :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.osx10.12.dmg', 'puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.12.dmg']
+      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/osx-10.15-x86_64",
+      :package_name => 'path/to/an/osx/10.15/package/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg',
+      :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg', 'puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.15.dmg']
     },
     'solaris-10-sparc' => {
       :toplevel_repo => 'generic',

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -203,22 +203,20 @@ describe "Pkg::Config" do
   describe "#platform_data" do
     platform_tags = [
       'eos-4-i386',
-      'osx-10.12-x86_64',
+      'osx-10.15-x86_64',
       'cisco-wrlinux-7-x86_64',
       'ubuntu-16.04-i386',
-      'cumulus-2.2-amd64',
-      'el-6-i386',
+      'el-6-x86_64',
       'el-7-ppc64le',
       'sles-12-x86_64',
     ]
 
     artifacts = \
       "./artifacts/eos/4/PC1/i386/puppet-agent-5.3.2-1.eos4.i386.swix\n" \
-      "./artifacts/apple/10.12/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.osx10.12.dmg\n" \
+      "./artifacts/apple/10.15/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.osx10.15.dmg\n" \
       "./artifacts/cisco-wrlinux/7/PC1/x86_64/puppet-agent-5.3.2-1.cisco_wrlinux7.x86_64.rpm\n" \
       "./artifacts/deb/xenial/PC1/puppet-agent_5.3.2-1xenial_i386.deb\n" \
-      "./artifacts/deb/cumulus/PC1/puppet-agent_5.3.2-1cumulus_amd64.deb\n" \
-      "./artifacts/el/6/PC1/i386/puppet-agent-5.3.2.658.gc79ef9a-1.el6.i386.rpm\n" \
+      "./artifacts/el/6/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.el6.x86_64.rpm\n" \
       "./artifacts/el/7/PC1/ppc64le/puppet-agent-5.3.2-1.el7.ppc64le.rpm\n" \
       "./artifacts/sles/12/PC1/x86_64/puppet-agent-5.3.2-1.sles12.x86_64.rpm"
 
@@ -226,7 +224,7 @@ describe "Pkg::Config" do
       "./artifacts/aix/6.1/PC1/ppc/puppet-agent-5.3.2-1.aix6.1.ppc.rpm"
 
     fedora_artifacts = \
-      "./artifacts/fedora/f25/PC1/x86_64/puppet-agent-5.3.2-1.fedoraf25.x86_64.rpm"
+      "./artifacts/fedora/31/PC1/x86_64/puppet-agent-5.3.2-1.fc31.x86_64.rpm"
 
     windows_artifacts = \
       "./artifacts/windows/puppet-agent-x64.msi\n" \
@@ -283,8 +281,8 @@ describe "Pkg::Config" do
     it "should not use 'f' in fedora platform tags" do
       allow(Pkg::Util::Net).to receive(:remote_ssh_cmd).and_return(fedora_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data).to include('fedora-25-x86_64')
-      expect(data).not_to include('fedora-f25-x86_64')
+      expect(data).to include('fedora-31-x86_64')
+      expect(data).not_to include('fedora-f31-x86_64')
     end
 
     it "should collect packages whose extname differ from package_format" do

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -25,17 +25,15 @@ describe 'Pkg::Paths' do
       'pkg/ubuntu-16.04-amd64/puppet-agent_4.99.0-1xenial_amd64.deb' => 'ubuntu-16.04-amd64',
       'pkg/windows-x64/puppet-agent-4.99.0-x64.msi' => 'windows-2012-x64',
       'artifacts/el/6/products/x86_64/pe-r10k-2.5.4.3-1.el6.x86_64.rpm' => 'el-6-x86_64',
-      'pkg/deb/trusty/pe-r10k_2.5.4.3-1trusty_amd64.deb' => 'ubuntu-14.04-amd64',
       'pkg/pe/rpm/el-6-i386/pe-puppetserver-2017.3.0.3-1.el6.noarch.rpm' => 'el-6-i386',
       'pkg/deb/trusty/pe-r10k_2.5.4.3-1trusty_amd64.deb' => 'ubuntu-14.04-amd64',
       'pkg/pe/deb/xenial/pe-puppetserver_2017.3.0.3-1puppet1_all.deb' => 'ubuntu-16.04-amd64',
       'pkg/pe/deb/xenial/super-trusty-package_1.0.0-1puppet1_all.deb' => 'ubuntu-16.04-amd64',
-      'artifacts/deb/wheezy/PC1/puppetdb_4.3.1-1puppetlabs1_all.deb' => 'debian-7-amd64',
+      'artifacts/deb/stretch/PC1/puppetdb_4.3.1-1puppetlabs1_all.deb' => 'debian-9-amd64',
       'pkg/el/7/PC1/x86_64/puppetdb-4.3.1-1.el7.noarch.rpm' => 'el-7-x86_64',
-      'pkg/apple/10.11/PC1/x86_64/puppet-agent-1.9.0-1.osx10.11.dmg' => 'osx-10.11-x86_64',
-      'artifacts/mac/10.11/PC1/x86_64/puppet-agent-1.9.0-1.osx10.11.dmg' => 'osx-10.11-x86_64',
+      'pkg/apple/10.14/PC1/x86_64/puppet-agent-1.9.0-1.osx10.14.dmg' => 'osx-10.14-x86_64',
+      'artifacts/mac/10.15/PC1/x86_64/puppet-agent-1.9.0-1.osx10.15.dmg' => 'osx-10.15-x86_64',
       'artifacts/eos/4/PC1/i386/puppet-agent-1.9.0-1.eos4.i386.swix' => 'eos-4-i386',
-      'pkg/deb/cumulus/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1cumulus_amd64.deb' => 'cumulus-2.2-amd64',
       'pkg/windows/puppet-agent-1.9.0-x86.msi' => 'windows-2012-x86',
       'artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz' => 'ubuntu-16.04-source',
       'http://saturn.puppetlabs.net/deb_repos/1234abcd/repos/apt/xenial' => 'ubuntu-16.04-amd64',
@@ -97,8 +95,8 @@ describe 'Pkg::Paths' do
       expect(Pkg::Paths.artifacts_path('el-7-x86_64')).to eq('artifacts/puppet5/el/7/x86_64')
     end
 
-    it 'should be correct for trusty' do
-      expect(Pkg::Paths.artifacts_path('ubuntu-14.04-amd64')).to eq('artifacts/trusty/puppet5')
+    it 'should be correct for bionic' do
+      expect(Pkg::Paths.artifacts_path('ubuntu-18.04-amd64')).to eq('artifacts/bionic/puppet5')
     end
 
     it 'should be correct for solaris 11' do
@@ -106,7 +104,7 @@ describe 'Pkg::Paths' do
     end
 
     it 'should be correct for osx' do
-      expect(Pkg::Paths.artifacts_path('osx-10.10-x86_64')).to eq('artifacts/mac/puppet5/10.10/x86_64')
+      expect(Pkg::Paths.artifacts_path('osx-10.15-x86_64')).to eq('artifacts/mac/puppet5/10.15/x86_64')
     end
 
     it 'should be correct for windows' do
@@ -251,7 +249,7 @@ describe 'Pkg::Paths' do
       expect(Pkg::Paths.remote_repo_base('ubuntu-18.04-amd64')).to eq('bar')
     end
     it 'returns nonfinal_yum_repo_path for nonfinal rpms' do
-      expect(Pkg::Paths.remote_repo_base('fedora-29-x86_64', true)).to eq('foo-nightly')
+      expect(Pkg::Paths.remote_repo_base('fedora-31-x86_64', true)).to eq('foo-nightly')
     end
     it 'returns nonfinal_apt_repo_path for nonfinal debs' do
       expect(Pkg::Paths.remote_repo_base('debian-9-amd64', true)).to eq('bar-nightly')
@@ -305,7 +303,7 @@ describe 'Pkg::Paths' do
       expect(Pkg::Paths.release_package_link_path('debian-9-i386', true)).to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-stretch.deb")
     end
     it 'returns nil for package formats that do not have release packages' do
-      expect(Pkg::Paths.release_package_link_path('osx-10.13-x86_64')).to eq(nil)
+      expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)
       expect(Pkg::Paths.release_package_link_path('windows-2012-x86')).to eq(nil)
     end
   end

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Pkg::Platforms' do
   describe '#by_package_format' do
     it 'should return an array of platforms that use a given format' do
-      deb_platforms = ['cumulus', 'debian', 'ubuntu']
+      deb_platforms = ['debian', 'ubuntu']
       rpm_platforms = ['aix', 'cisco-wrlinux', 'el', 'fedora', 'redhatfips', 'sles']
       expect(Pkg::Platforms.by_package_format('deb')).to match_array(deb_platforms)
       expect(Pkg::Platforms.by_package_format('rpm')).to match_array(rpm_platforms)
@@ -19,7 +19,7 @@ describe 'Pkg::Platforms' do
 
   describe '#supported_platforms' do
     it 'should return all supported platforms' do
-      platforms = ['aix', 'cisco-wrlinux', 'cumulus', 'debian', 'el', 'eos', 'fedora', 'osx', 'redhatfips', 'sles', 'solaris', 'ubuntu', 'windows', 'windowsfips']
+      platforms = ['aix', 'cisco-wrlinux', 'debian', 'el', 'eos', 'fedora', 'osx', 'redhatfips', 'sles', 'solaris', 'ubuntu', 'windows', 'windowsfips']
       expect(Pkg::Platforms.supported_platforms).to match_array(platforms)
     end
   end
@@ -36,7 +36,7 @@ describe 'Pkg::Platforms' do
 
   describe '#codenames' do
     it 'should return all codenames for a given platform' do
-      codenames = ['focal', 'bionic', 'buster', 'cosmic', 'cumulus', 'wheezy', 'jessie', 'stretch', 'trusty', 'xenial']
+      codenames = ['focal', 'bionic', 'buster', 'cosmic', 'jessie', 'stretch', 'trusty', 'xenial']
       expect(Pkg::Platforms.codenames).to match_array(codenames)
     end
   end
@@ -59,27 +59,27 @@ describe 'Pkg::Platforms' do
 
   describe '#arches_for_codename' do
     it 'should return an array of arches corresponding to a given codename' do
-      expect(Pkg::Platforms.arches_for_codename('trusty')).to match_array(['i386', 'amd64'])
+      expect(Pkg::Platforms.arches_for_codename('xenial')).to match_array(['amd64', 'i386', 'ppc64el'])
     end
 
     it 'should be able to include source archietectures' do
-      expect(Pkg::Platforms.arches_for_codename('trusty', true)).to match_array(['i386', 'amd64', 'source'])
+      expect(Pkg::Platforms.arches_for_codename('xenial', true)).to match_array(["amd64", "i386", "ppc64el", "source"])
     end
   end
 
   describe '#codename_to_tags' do
     it 'should return an array of platform tags corresponding to a given codename' do
-      expect(Pkg::Platforms.codename_to_tags('trusty')).to match_array(['ubuntu-14.04-i386', 'ubuntu-14.04-amd64'])
+      expect(Pkg::Platforms.codename_to_tags('xenial')).to match_array(['ubuntu-16.04-i386', 'ubuntu-16.04-amd64', "ubuntu-16.04-ppc64el"])
     end
   end
 
   describe '#arches_for_platform_version' do
     it 'should return an array of arches for a given platform and version' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '11')).to match_array(['i386', 'x86_64'])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '12')).to match_array(['x86_64', 'ppc64le'])
     end
 
     it 'should be able to include source architectures' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '11', true)).to match_array(['i386', 'x86_64', 'SRPMS'])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '12', true)).to match_array(["SRPMS", "ppc64le", "x86_64"])
     end
   end
 
@@ -98,12 +98,12 @@ describe 'Pkg::Platforms' do
 
   describe '#platform_lookup' do
     it 'should return a hash of platform info' do
-      expect(Pkg::Platforms.platform_lookup('osx-10.10-x86_64')).to be_instance_of(Hash)
+      expect(Pkg::Platforms.platform_lookup('osx-10.15-x86_64')).to be_instance_of(Hash)
     end
 
     it 'should include at least arch and package format keys' do
-      expect(Pkg::Platforms.platform_lookup('osx-10.10-x86_64').keys).to include(:architectures)
-      expect(Pkg::Platforms.platform_lookup('osx-10.10-x86_64').keys).to include(:package_format)
+      expect(Pkg::Platforms.platform_lookup('osx-10.15-x86_64').keys).to include(:architectures)
+      expect(Pkg::Platforms.platform_lookup('osx-10.15-x86_64').keys).to include(:package_format)
     end
   end
 
@@ -137,7 +137,7 @@ describe 'Pkg::Platforms' do
       'windows-2012' => ['windows', '2012', ''],
       'redhatfips-7-x86_64' => ['redhatfips', '7', 'x86_64'],
       'el-7-SRPMS' => ['el', '7', 'SRPMS'],
-      'ubuntu-14.04-source' => ['ubuntu', '14.04', 'source'],
+      'ubuntu-16.04-source' => ['ubuntu', '16.04', 'source'],
     }
 
     fail_cases = [

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -74,7 +74,6 @@ DOC
       ] }
       let(:v4_rpms) { [
         "#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm",
-        "#{rpm_directory}/sles/12/PC1/i386/puppet-agent-5.5.3-1.sles12.i386.rpm",
       ] }
       let(:rpms) { rpms_not_to_sign + v3_rpms + v4_rpms }
       let(:already_signed_rpms) { [

--- a/spec/lib/packaging/util/ship_spec.rb
+++ b/spec/lib/packaging/util/ship_spec.rb
@@ -43,25 +43,21 @@ describe '#Pkg::Util::Ship' do
   end
 
 local_pkgs = [
-  'pkg/deb/cumulus/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1cumulus_amd64.deb',
-  'pkg/deb/wheezy/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1wheezy_i386.deb',
+  'pkg/deb/stretch/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1stretch_i386.deb',
   'pkg/el/5/puppet5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.el5.x86_64.rpm',
   'pkg/sles/11/puppet5/i386/puppet-agent-1.4.1.2904.g8023dd1-1.sles11.i386.rpm',
   'pkg/sles/12/puppet5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.sles12.x86_64.rpm',
   'pkg/mac/10.15/puppet5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.osx10.15.dmg',
-  'pkg/mac/10.10/puppet5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.osx10.10.dmg',
   'pkg/eos/4/puppet5/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix',
   'pkg/eos/4/puppet5/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix.asc',
   'pkg/windows/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x86.msi',
 ]
 new_pkgs = [
-  'pkg/cumulus/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1cumulus_amd64.deb',
-  'pkg/wheezy/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1wheezy_i386.deb',
+  'pkg/stretch/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1stretch_i386.deb',
   'pkg/puppet5/el/5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.el5.x86_64.rpm',
   'pkg/puppet5/sles/11/i386/puppet-agent-1.4.1.2904.g8023dd1-1.sles11.i386.rpm',
   'pkg/puppet5/sles/12/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.sles12.x86_64.rpm',
   'pkg/mac/puppet5/10.15/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.osx10.15.dmg',
-  'pkg/mac/puppet5/10.10/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.osx10.10.dmg',
   'pkg/eos/puppet5/4/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix',
   'pkg/eos/puppet5/4/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix.asc',
   'pkg/windows/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x86.msi',


### PR DESCRIPTION
…latforms""

We previously had removed a handful of platforms but had to revert due to some unforeseen failures. This reverts that revert but also no longer removes eos-4/swix because it seems that we are still shipping that for 5.5.x http://builds.delivery.puppetlabs.net/puppet-agent/5.5.19/shipped/eos/4/puppet5/i386/?C=M&O=D

I used https://github.com/puppetlabs/ci-job-configs/blob/master/jenkii/platform/projects/puppet-agent.yaml#L74 to determine the platforms

This reverts commit cf49b4bf74ae3f7556a230e414c6ab76a8f56792.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
