### PR TITLE
(RE-13386) Don't ship deb packages to a 'pool' subdirectory by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Removed
 - (RE-13273) Removed support of PC1 repos. They are obsolete
 
+### Changed
+- (RE-13386) In `Pkg::Artifactory` deb packages will no longer default to
+  shipping to the 'pool' subdirectory.
+
 ## [0.99.61] - 2020-04-01
 ### Fixed
 - Reverted removal of EOL platforms since it was causing breakage.
 
 ## [0.99.60] - 2020-04-01
 ### Added
-- Added parameters to ManageArtifactory#upload_file to allow for setting properties
+- Added parameters to `ManageArtifactory#upload_file` to allow for setting properties
   and headers after the upload, matching the parameters in Resource::Artifact#upload.
 - Added platform support for:
    * Ubuntu 20.04 'Focal'

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -111,7 +111,6 @@ module Pkg
     def location_for(platform_tag)
       toplevel_repo = DEFAULT_REPO_TYPE
       repo_subdirectories = File.join(@repo_base, @project, @project_version)
-      alternate_subdirectories = repo_subdirectories
 
       unless platform_tag == DEFAULT_REPO_TYPE
         format = Pkg::Platforms.package_format_for_tag(platform_tag)
@@ -122,20 +121,16 @@ module Pkg
       when 'rpm'
         toplevel_repo = 'rpm'
         repo_subdirectories = File.join(repo_subdirectories, "#{platform}-#{version}-#{architecture}")
-        alternate_subdirectories = repo_subdirectories
       when 'deb'
         toplevel_repo = 'debian__local'
         repo_subdirectories = File.join(repo_subdirectories, "#{platform}-#{version}")
-        alternate_subdirectories = repo_subdirectories
       when 'swix', 'dmg', 'svr4', 'ips'
         repo_subdirectories = File.join(repo_subdirectories, "#{platform}-#{version}-#{architecture}")
-        alternate_subdirectories = repo_subdirectories
       when 'msi'
         repo_subdirectories = File.join(repo_subdirectories, "#{platform}-#{architecture}")
-        alternate_subdirectories = repo_subdirectories
       end
 
-      [toplevel_repo, repo_subdirectories, alternate_subdirectories]
+      [toplevel_repo, repo_subdirectories]
     end
 
     # @param platform_tag [String] The platform tag specific to the information
@@ -150,8 +145,8 @@ module Pkg
         end
       end
 
-      repo_name, repo_subdirectories, alternate_subdirectories = location_for(platform_tag)
-      full_artifactory_path = File.join(repo_name, alternate_subdirectories)
+      repo_name, repo_subdirectories = location_for(platform_tag)
+      full_artifactory_path = File.join(repo_name, repo_subdirectories)
 
       {
         platform: platform,
@@ -161,7 +156,6 @@ module Pkg
         package_format: package_format,
         repo_name: repo_name,
         repo_subdirectories: repo_subdirectories,
-        alternate_subdirectories: alternate_subdirectories,
         full_artifactory_path: full_artifactory_path
       }
     end
@@ -286,7 +280,7 @@ module Pkg
       headers = { "X-Checksum-Md5" => artifact_md5 }
       artifact.upload(
         data[:repo_name],
-        File.join(data[:alternate_subdirectories], File.basename(package)),
+        File.join(data[:repo_subdirectories], File.basename(package)),
         deploy_properties(platform_tag, File.basename(package)),
         headers
       )

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -126,7 +126,7 @@ module Pkg
       when 'deb'
         toplevel_repo = 'debian__local'
         repo_subdirectories = File.join(repo_subdirectories, "#{platform}-#{version}")
-        alternate_subdirectories = File.join('pool', repo_subdirectories)
+        alternate_subdirectories = repo_subdirectories
       when 'swix', 'dmg', 'svr4', 'ips'
         repo_subdirectories = File.join(repo_subdirectories, "#{platform}-#{version}-#{architecture}")
         alternate_subdirectories = repo_subdirectories

--- a/spec/lib/packaging/artifactory_spec.rb
+++ b/spec/lib/packaging/artifactory_spec.rb
@@ -125,7 +125,6 @@ describe 'artifactory.rb' do
           expect(artifact.location_for(platform_tag)).to match_array([
             platform_tag_data[:toplevel_repo],
             platform_tag_data[:repo_subdirectories],
-            platform_tag_data[:repo_subdirectories]
           ])
         end
       else
@@ -133,7 +132,6 @@ describe 'artifactory.rb' do
           expect(artifact.location_for(platform_tag)).to match_array([
             platform_tag_data[:toplevel_repo],
             platform_tag_data[:repo_subdirectories],
-            platform_tag_data[:repo_subdirectories]
           ])
         end
       end
@@ -142,7 +140,6 @@ describe 'artifactory.rb' do
         expect(artifact.location_for('generic')).to match_array([
           'generic',
           File.join(default_repo_name, project, project_version),
-          File.join(default_repo_name, project, project_version)
         ])
       end
     end

--- a/spec/lib/packaging/artifactory_spec.rb
+++ b/spec/lib/packaging/artifactory_spec.rb
@@ -125,7 +125,7 @@ describe 'artifactory.rb' do
           expect(artifact.location_for(platform_tag)).to match_array([
             platform_tag_data[:toplevel_repo],
             platform_tag_data[:repo_subdirectories],
-            File.join('pool', platform_tag_data[:repo_subdirectories])
+            platform_tag_data[:repo_subdirectories]
           ])
         end
       else


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
