### PR TITLE
(maint) Don't use exact_match search for PE final tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.99.64] - 2020-06-18
+### Fixed
+- Do not use exact match when searching for final PE tarballs.
+
 ## [0.99.63] - 2020-06-17
 ### Fixed
 - Artifactory::Util.slice wasn't properly scoped in the `pattern_search` method.
@@ -632,7 +636,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.63...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.64...HEAD
+[0.99.64]: https://github.com/puppetlabs/packaging/compare/0.99.63...0.99.64
 [0.99.63]: https://github.com/puppetlabs/packaging/compare/0.99.62...0.99.63
 [0.99.62]: https://github.com/puppetlabs/packaging/compare/0.99.61...0.99.62
 [0.99.61]: https://github.com/puppetlabs/packaging/compare/0.99.60...0.99.61

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -531,7 +531,7 @@ module Pkg
     # @param target_path [String] path copy tarballs to, assumes same repo
     def copy_final_pe_tarballs(pe_version, repo, remote_path, target_path)
       check_authorization
-      final_tarballs = Artifactory::Resource::Artifact.search(name: pe_version, repos: repo)
+      final_tarballs = Artifactory::Resource::Artifact.search(name: pe_version, repos: repo, exact_match: false)
       final_tarballs.each do |artifact|
         next unless artifact.download_uri.include? remote_path
         next if artifact.download_uri.include? "-rc"


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
