### PR TITLE
(maint) Add back osx 10.13 + update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.99.65] - 2020-06-22
+### Fixed
+- Add 0SX 10.13 platform back, it is not EOL for all projects.
+
 ## [0.99.64] - 2020-06-18
 ### Fixed
 - Do not use exact match when searching for final PE tarballs.

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -137,6 +137,11 @@ module Pkg
       },
 
       'osx' => {
+        '10.13' => {
+          architectures: ['x86_64'],
+          package_format: 'dmg',
+          repo: false,
+        },
         '10.14' => {
           architectures: ['x86_64'],
           package_format: 'dmg',


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
