### PR TITLE
(PA-3356) add puppet 7 nightly gem rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+ - (PA-3356) add puppet 7 nightly gem rake task
 
 ## [0.99.67] - 2020-07-20
 ### Added

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -150,10 +150,20 @@ namespace :package do
     Pkg::Config.gemversion = Pkg::Util::Version.extended_dot_version
     package_gem
   end
+
+  # PA-3356: temporary task to ship puppet 7 nightly gem
+  # TODO: PA-3358 - remove when puppet 7 is officialy out
+  task :puppet_7_nightly_gem => ["clean"] do
+    Pkg::Config.gemversion = Pkg::Util::Version.extended_dot_version.gsub(/6\.\d+\.\d+/, '7.0.0')
+    package_gem
+  end
 end
 
 # An alias task to simplify our remote logic in jenkins.rake
 namespace :pl do
   task :gem => "package:gem"
   task :nightly_gem => "package:nightly_gem"
+  # PA-3356: temporary task to ship puppet 7 nightly gem
+  # TODO: PA-3358 - remove when puppet 7 is officialy out
+  task :puppet_7_nightly_gem => "package:puppet_7_nightly_gem"
 end


### PR DESCRIPTION
```
~/Workspace/puppet branch:main                                                                                             
❯ git describe
6.17.0-126-gbd1d1a786f

Successfully built RubyGem
Name: puppet
Version: 7.0.0.126.gbd1d1a7
File: puppet-7.0.0.126.gbd1d1a7-x64-mingw32.gem
```
