### PR TITLE
(RE-13629) Do not use exact file match when downloading final PE tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
  - (PA-3356) add puppet 7 nightly gem rake task
 
+### Fixed
+ - (RE-13629) Do not use exact file match when downloading final PE tarballs
+
 ## [0.99.67] - 2020-07-20
 ### Added
 - (PA-3212) Add support for Fedora 32.

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -502,7 +502,7 @@ module Pkg
     # @param local_path [String] local path to download tarballs to
     def download_final_pe_tarballs(pe_version, repo, remote_path, local_path)
       check_authorization
-      artifacts = Artifactory::Resource::Artifact.search(name: pe_version, repos: repo)
+      artifacts = Artifactory::Resource::Artifact.search(name: pe_version, repos: repo, exact_match: false)
       artifacts.each do |artifact|
         next unless artifact.download_uri.include? remote_path
         next if artifact.download_uri.include? "-rc"


### PR DESCRIPTION


Please add all notable changes to the "Unreleased" section of the CHANGELOG.
