### PR TITLE
(maint) Add the ability to determine debian component from paths containing 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.99.70] - 2020-10-01
+### Added
+- Added ability to determine debian component for paths containing 'main'
+
 ## [0.99.69] - 2020-09-21
 ### Added
 - (PA-3386) Add support for Redhat 8 aarch64.
@@ -667,7 +671,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.69...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.70...HEAD
+[0.99.70]: https://github.com/puppetlabs/packaging/compare/0.99.69...0.99.70
 [0.99.69]: https://github.com/puppetlabs/packaging/compare/0.99.68...0.99.69
 [0.99.68]: https://github.com/puppetlabs/packaging/compare/0.99.67...0.99.68
 [0.99.67]: https://github.com/puppetlabs/packaging/compare/0.99.66...0.99.67

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -315,7 +315,7 @@ module Pkg::Paths
 
   def debian_component_from_path(path)
     # substitute '.' and '/' since those aren't valid characters for debian components
-    matches = path.match(/([\d+\.\d+|master])\/(\w+)/)
+    matches = path.match(/([\d+\.\d+|master|main])\/(\w+)/)
     regex_for_substitution = /[\.\/]/
     fail "Error: Could not determine Debian Component from path #{path}" if matches.nil?
     base_component = matches[1]


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
