### PR TITLE
(maint) allow projects to override the gpg_key

### DIFF
--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -77,6 +77,7 @@ module Pkg::Params
                   :gem_test_files,
                   :gemversion,
                   :gpg_key,
+                  :gpg_key_override,
                   :gpg_name,
                   :homepage,
                   :internal_gem_host,

--- a/lib/packaging/util/gpg.rb
+++ b/lib/packaging/util/gpg.rb
@@ -7,8 +7,10 @@ module Pkg::Util::Gpg
     # files that are generated with this repo use the default gpg key to
     # reflect that.
     def key
-      fail "You need to set `gpg_key` in your build defaults." unless Pkg::Config.gpg_key && !Pkg::Config.gpg_key.empty?
-      Pkg::Config.gpg_key
+      return Pkg::Config.gpg_key_override unless Pkg::Config.gpg_key_override.to_s.empty?
+      return Pkg::Config.gpg_key unless Pkg::Config.gpg_key.to_s.empty?
+
+      fail "You need to set `gpg_key` in your build defaults."
     end
 
     def keychain


### PR DESCRIPTION
This is the least-gross approach that I can think of to allow for
incremental update of the gpg_key in the various git repos.

Normally, setting precedence is (highest-to-lowest)
  Environment Variable
  build-data git repo
  local settings

(This seems backwards to me, btw)

This commit introduces a "gpg_key_override" setting, allowable in the
build_defaults.yaml that overrides the gpg_key setting in build-data
and the environment.

The big downside of this approach would be the needed cleaning of
gpg_key_override once everything is migrated.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.