### PR TITLE
Add new apt pathing for puppet7

### DIFF
--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -319,7 +319,11 @@ module Pkg::Paths
 
     # For repos prior to puppet7, the puppet version was part of the repository
     # For example: /opt/repository/apt/pool/bionic/puppet6/p/puppet-agent
-    return File.join(remote_repo_path, 'pool', code_name, repo_name, project[0], project)
+    if %w(puppet puppet5 puppet6 puppet-nightly puppet5-nightly puppet6-nightly).include? repo_name
+      return File.join(remote_repo_path, 'pool', code_name, repo_name, project[0], project)
+    end
+
+    raise "Error: Cannot determine apt_package_base_path for repo: \"#{repo_name}\"."
   end
 
   def release_package_link_path(platform_tag, nonfinal = false)

--- a/lib/packaging/util/git.rb
+++ b/lib/packaging/util/git.rb
@@ -6,7 +6,7 @@ module Pkg::Util::Git
     # Git utility to create a new git commit
     def commit_file(file, message = 'changes')
       fail_unless_repo
-      puts 'Commiting changes:'
+      puts 'Committing changes:'
       puts
       diff, = Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} diff HEAD #{file}")
       puts diff

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -105,12 +105,22 @@ module Pkg::Util::Ship
   end
 
   def ship_rpms(local_staging_directory, remote_path, opts = {})
-    ship_pkgs(["#{local_staging_directory}/**/*.rpm", "#{local_staging_directory}/**/*.srpm"], Pkg::Config.yum_staging_server, remote_path, opts)
+    things_to_ship = [
+      "#{local_staging_directory}/**/*.rpm",
+      "#{local_staging_directory}/**/*.srpm"
+    ]
+    ship_pkgs(things_to_ship, Pkg::Config.yum_staging_server, remote_path, opts)
   end
 
   def ship_debs(local_staging_directory, remote_path, opts = {})
-    ship_pkgs(["#{local_staging_directory}/**/*.debian.tar.gz", "#{local_staging_directory}/**/*.orig.tar.gz" "#{local_staging_directory}/**/*.dsc", "#{local_staging_directory}/**/*.deb", "#{local_staging_directory}/**/*.changes"], Pkg::Config.apt_signing_server, remote_path, opts)
-
+    things_to_ship = [
+      "#{local_staging_directory}/**/*.debian.tar.gz",
+      "#{local_staging_directory}/**/*.orig.tar.gz",
+      "#{local_staging_directory}/**/*.dsc",
+      "#{local_staging_directory}/**/*.deb",
+      "#{local_staging_directory}/**/*.changes"
+    ]
+    ship_pkgs(things_to_ship, Pkg::Config.apt_signing_server, remote_path, opts)
   end
 
   def ship_svr4(local_staging_directory, remote_path, opts = {})
@@ -122,12 +132,17 @@ module Pkg::Util::Ship
   end
 
   def ship_dmg(local_staging_directory, remote_path, opts = {})
-    packages_have_shipped = ship_pkgs(["#{local_staging_directory}/**/*.dmg"], Pkg::Config.dmg_staging_server, remote_path, opts)
+    packages_have_shipped = ship_pkgs(["#{local_staging_directory}/**/*.dmg"],
+                                      Pkg::Config.dmg_staging_server, remote_path, opts)
 
     if packages_have_shipped
       Pkg::Platforms.platform_tags_for_package_format('dmg').each do |platform_tag|
         # Create the latest symlink for the current supported repo
-        Pkg::Util::Net.remote_create_latest_symlink(Pkg::Config.project, Pkg::Paths.artifacts_path(platform_tag, remote_path, opts[:nonfinal]), 'dmg')
+        Pkg::Util::Net.remote_create_latest_symlink(
+          Pkg::Config.project,
+          Pkg::Paths.artifacts_path(platform_tag, remote_path, opts[:nonfinal]),
+          'dmg'
+        )
       end
     end
   end

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -3,42 +3,37 @@ require 'spec_helper'
 describe 'Pkg::Paths' do
   describe '#arch_from_artifact_path' do
     arch_transformations = {
-      ['artifacts/aix/6.1/PC1/ppc/puppet-agent-5.1.0.79.g782e03c-1.aix6.1.ppc.rpm', 'aix', '6.1'] => 'power',
-      ['pkg/el-7-x86_64/puppet-agent-4.99.0-1.el7.x86_64.rpm', 'el', '7'] => 'x86_64',
-      ['artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz', 'ubuntu', '16.04'] => 'source',
-      ['http://saturn.puppetlabs.net/deb_repos/1234abcd/repos/apt/xenial', 'ubuntu', '16.04'] => 'amd64',
+      ['artifacts/aix/6.1/puppet6/ppc/puppet-agent-6.9.0-1.aix6.1.ppc.rpm', 'aix', '6.1'] => 'power',
+      ['pkg/el-8-x86_64/puppet-agent-6.9.0-1.el8.x86_64.rpm', 'el', '8'] => 'x86_64',
+      ['artifacts/fedora/32/puppet6/x86_64/puppet-agent-6.9.0-1.fc30.x86_64.rpm', 'fedora', '32'] => 'x86_64',
       ['pkg/ubuntu-16.04-amd64/puppet-agent_4.99.0-1xenial_amd64.deb', 'ubuntu', '16.04'] => 'amd64',
+
+      ['artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz', 'ubuntu', '16.04'] => 'source',
       ['artifacts/deb/jessie/PC1/puppetserver_5.0.1.master.orig.tar.gz', 'debian', '8'] => 'source',
       ['artifacts/el/6/PC1/SRPMS/puppetserver-5.0.1.master-0.1SNAPSHOT.2017.08.18T0951.el6.src.rpm', 'el', '6'] => 'SRPMS'
     }
     arch_transformations.each do |path_array, arch|
       it "should correctly return #{arch} for #{path_array[0]}" do
-        expect(Pkg::Paths.arch_from_artifact_path(path_array[1], path_array[2], path_array[0])).to eq(arch)
+        expect(Pkg::Paths.arch_from_artifact_path(path_array[1], path_array[2], path_array[0]))
+          .to eq(arch)
       end
     end
   end
 
   describe '#tag_from_artifact_path' do
     path_tranformations = {
-      'artifacts/aix/6.1/PC1/ppc/puppet-agent-5.1.0.79.g782e03c-1.aix6.1.ppc.rpm' => 'aix-6.1-power',
-      'pkg/el-7-x86_64/puppet-agent-4.99.0-1.el7.x86_64.rpm' => 'el-7-x86_64',
-      'pkg/ubuntu-16.04-amd64/puppet-agent_4.99.0-1xenial_amd64.deb' => 'ubuntu-16.04-amd64',
-      'pkg/windows-x64/puppet-agent-4.99.0-x64.msi' => 'windows-2012-x64',
+      'artifacts/aix/6.1/puppet6/ppc/puppet-agent-6.9.0-1.aix6.1.ppc.rpm' => 'aix-6.1-power',
+      'pkg/el-7-x86_64/puppet-agent-5.5.22-1.el8.x86_64.rpm' => 'el-7-x86_64',
+      'pkg/ubuntu-20.04-amd64/puppet-agent_5.5.22-1xenial_amd64.deb' => 'ubuntu-20.04-amd64',
+      'pkg/windows/puppet-agent-5.5.22-x86.msi' => 'windows-2012-x86',
       'artifacts/el/6/products/x86_64/pe-r10k-2.5.4.3-1.el6.x86_64.rpm' => 'el-6-x86_64',
       'pkg/pe/rpm/el-6-i386/pe-puppetserver-2017.3.0.3-1.el6.noarch.rpm' => 'el-6-i386',
-      'pkg/deb/trusty/pe-r10k_2.5.4.3-1trusty_amd64.deb' => 'ubuntu-14.04-amd64',
-      'pkg/pe/deb/xenial/pe-puppetserver_2017.3.0.3-1puppet1_all.deb' => 'ubuntu-16.04-amd64',
-      'pkg/pe/deb/xenial/super-trusty-package_1.0.0-1puppet1_all.deb' => 'ubuntu-16.04-amd64',
-      'artifacts/deb/stretch/PC1/puppetdb_4.3.1-1puppetlabs1_all.deb' => 'debian-9-amd64',
-      'pkg/el/7/PC1/x86_64/puppetdb-4.3.1-1.el7.noarch.rpm' => 'el-7-x86_64',
-      'pkg/apple/10.14/PC1/x86_64/puppet-agent-1.9.0-1.osx10.14.dmg' => 'osx-10.14-x86_64',
-      'artifacts/mac/10.15/PC1/x86_64/puppet-agent-1.9.0-1.osx10.15.dmg' => 'osx-10.15-x86_64',
-      'artifacts/eos/4/PC1/i386/puppet-agent-1.9.0-1.eos4.i386.swix' => 'eos-4-i386',
+      'pkg/deb/bionic/pe-r10k_3.5.2.0-1bionic_amd64.deb' => 'ubuntu-18.04-amd64',
+      'pkg/deb/buster/pe-r10k_3.5.2.0-1buster_amd64.deb' => 'debian-10-amd64',
+      'pkg/pe/deb/bionic/pe-puppetserver_2019.8.2.32-1bionic_all.deb' => 'ubuntu-18.04-amd64',
+      'artifacts/deb/focal/puppet6/puppetdb_6.13.0-1focal_all.deb' => 'ubuntu-20.04-amd64',
+      'pkg/apple/10.15/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg' => 'osx-10.15-x86_64',
       'pkg/windows/puppet-agent-1.9.0-x86.msi' => 'windows-2012-x86',
-      'artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz' => 'ubuntu-16.04-source',
-      'http://saturn.puppetlabs.net/deb_repos/1234abcd/repos/apt/xenial' => 'ubuntu-16.04-amd64',
-      'http://builds.puppetlabs.lan/puppet-agent/0ce4e6a0448366e01537323bbab77f834d7035c7/repos/el/6/PC1/x86_64/' => 'el-6-x86_64',
-      'http://builds.puppetlabs.lan/puppet-agent/0ce4e6a0448366e01537323bbab77f834d7035c7/repos/el/6/PC1/x86_64/' => 'el-6-x86_64',
       'pkg/pe/rpm/el-6-i386/pe-puppetserver-2017.3.0.3-1.el6.src.rpm' => 'el-6-SRPMS',
       'pkg/pe/deb/xenial/pe-puppetserver_2017.3.0.3-1puppet1.orig.tar.gz' => 'ubuntu-16.04-source',
       'pkg/puppet-agent-5.1.0.79.g782e03c.gem' => nil,
@@ -63,10 +58,14 @@ describe 'Pkg::Paths' do
   end
 
   describe '#repo_name' do
+    it 'should return repo_name for final version' do
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
+      expect(Pkg::Paths.repo_name).to eq('puppet6')
+    end
 
     it 'should return repo_name for final version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
-      expect(Pkg::Paths.repo_name).to eq('puppet5')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
+      expect(Pkg::Paths.repo_name).to eq('puppet7')
     end
 
     it 'should be empty string if repo_name is not set for final version' do
@@ -75,56 +74,84 @@ describe 'Pkg::Paths' do
     end
 
     it 'should return nonfinal_repo_name for non-final version' do
-      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet5-nightly')
-      expect(Pkg::Paths.repo_name(true)).to eq('puppet5-nightly')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet6-nightly')
+      expect(Pkg::Paths.repo_name(true)).to eq('puppet6-nightly')
     end
 
     it 'should fail if nonfinal_repo_name is not set for non-final version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
       expect { Pkg::Paths.repo_name(true) }.to raise_error
     end
   end
 
   describe '#artifacts_path' do
-    before :each do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+    context 'all puppet versions' do
+      before :each do
+        allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
+      end
+
+      it 'should work on all current platforms' do
+        Pkg::Platforms.platform_tags.each do |tag|
+          expect { Pkg::Paths.artifacts_path(tag) }.not_to raise_error
+        end
+      end
     end
 
-    it 'should be correct for el7' do
-      expect(Pkg::Paths.artifacts_path('el-7-x86_64')).to eq('artifacts/puppet5/el/7/x86_64')
+    context 'for puppet 6 and prior' do
+      before :each do
+        allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
+      end
+
+      it 'should be correct for el7' do
+        expect(Pkg::Paths.artifacts_path('el-7-x86_64'))
+          .to eq('artifacts/puppet6/el/7/x86_64')
+      end
+
+      it 'should be correct for bionic' do
+        expect(Pkg::Paths.artifacts_path('ubuntu-18.04-amd64'))
+          .to eq('artifacts/bionic/puppet6')
+      end
+
+      it 'should be correct for solaris 11' do
+        expect(Pkg::Paths.artifacts_path('solaris-11-sparc'))
+          .to eq('artifacts/solaris/puppet6/11')
+      end
+
+      it 'should be correct for osx' do
+        expect(Pkg::Paths.artifacts_path('osx-10.15-x86_64'))
+          .to eq('artifacts/mac/puppet6/10.15/x86_64')
+      end
+
+      it 'should be correct for windows' do
+        expect(Pkg::Paths.artifacts_path('windows-2012-x64'))
+          .to eq('artifacts/windows/puppet6')
+      end
     end
 
-    it 'should be correct for bionic' do
-      expect(Pkg::Paths.artifacts_path('ubuntu-18.04-amd64')).to eq('artifacts/bionic/puppet5')
-    end
+    context 'after puppet 7 apt changes' do
+      before :each do
+        allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
+      end
 
-    it 'should be correct for solaris 11' do
-      expect(Pkg::Paths.artifacts_path('solaris-11-sparc')).to eq('artifacts/solaris/puppet5/11')
-    end
-
-    it 'should be correct for osx' do
-      expect(Pkg::Paths.artifacts_path('osx-10.15-x86_64')).to eq('artifacts/mac/puppet5/10.15/x86_64')
-    end
-
-    it 'should be correct for windows' do
-      expect(Pkg::Paths.artifacts_path('windows-2012-x64')).to eq('artifacts/windows/puppet5')
-    end
-
-    it 'should work on all current platforms' do
-      Pkg::Platforms.platform_tags.each do |tag|
-        expect { Pkg::Paths.artifacts_path(tag) }.not_to raise_error
+      it 'should be correct for bionic' do
+        expect(Pkg::Paths.artifacts_path('ubuntu-18.04-amd64'))
+          .to eq('artifacts/puppet7/bionic')
+      end
+      it 'should be correct for focal' do
+        expect(Pkg::Paths.artifacts_path('ubuntu-20.04-amd64'))
+          .to eq('artifacts/puppet7/focal')
       end
     end
   end
 
   describe '#repo_path' do
     before :each do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
     end
 
     it 'should be correct' do
-      expect(Pkg::Paths.repo_path('el-7-x86_64')).to eq('repos/puppet5/el/7/x86_64')
+      expect(Pkg::Paths.repo_path('el-7-x86_64')).to eq('repos/puppet6/el/7/x86_64')
     end
 
     it 'should work on all current platforms' do
@@ -135,8 +162,16 @@ describe 'Pkg::Paths' do
   end
 
   describe '#repo_config_path' do
-    it 'should be correct' do
-      expect(Pkg::Paths.repo_config_path('el-7-x86_64')).to eq('repo_configs/rpm/*el-7-x86_64*.repo')
+    it 'should construct rpm/deb-specific repo configs' do
+      expect(Pkg::Paths.repo_config_path('el-7-x86_64'))
+        .to eq('repo_configs/rpm/*el-7-x86_64*.repo')
+      expect(Pkg::Paths.repo_config_path('ubuntu-18.04-amd64'))
+        .to eq('repo_configs/deb/*bionic*.list')
+    end
+
+    it 'should raise a RuntimeError with unfamilar repo configs' do
+      expect { Pkg::Paths.repo_config_path('bogus') }
+        .to raise_error(/Could not verify that 'bogus' is a valid tag/)
     end
 
     it 'should work on all current platforms' do
@@ -148,15 +183,15 @@ describe 'Pkg::Paths' do
 
   describe '#apt_repo_name' do
     it 'should return `Pkg::Config.repo_name` if set' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
-      allow(Pkg::Config).to receive(:apt_repo_name).and_return('PC1')
-      expect(Pkg::Paths.apt_repo_name).to eq('puppet5')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
+      allow(Pkg::Config).to receive(:apt_repo_name).and_return('stuff')
+      expect(Pkg::Paths.apt_repo_name).to eq('puppet6')
     end
 
     it 'should return `Pkg::Config.apt_repo_name` if `Pkg::Config.repo_name` is not set' do
       allow(Pkg::Config).to receive(:repo_name).and_return(nil)
-      allow(Pkg::Config).to receive(:apt_repo_name).and_return('PC1')
-      expect(Pkg::Paths.apt_repo_name).to eq('PC1')
+      allow(Pkg::Config).to receive(:apt_repo_name).and_return('puppet6')
+      expect(Pkg::Paths.apt_repo_name).to eq('puppet6')
     end
 
     it 'should return \'main\' if nothing is set' do
@@ -164,14 +199,15 @@ describe 'Pkg::Paths' do
       allow(Pkg::Config).to receive(:apt_repo_name).and_return(nil)
       expect(Pkg::Paths.apt_repo_name).to eq('main')
     end
+
     it 'should return nonfinal_repo_name for nonfinal version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
-      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet5-nightly')
-      expect(Pkg::Paths.apt_repo_name(true)).to eq('puppet5-nightly')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet7-nightly')
+      expect(Pkg::Paths.apt_repo_name(true)).to eq('puppet7-nightly')
     end
 
     it 'should fail if nonfinal_repo_name is not set for non-final version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
       expect { Pkg::Paths.apt_repo_name(true) }.to raise_error
     end
@@ -179,15 +215,15 @@ describe 'Pkg::Paths' do
 
   describe '#yum_repo_name' do
     it 'should return `Pkg::Config.repo_name` if set' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
-      allow(Pkg::Config).to receive(:yum_repo_name).and_return('PC1')
-      expect(Pkg::Paths.yum_repo_name).to eq('puppet5')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
+      allow(Pkg::Config).to receive(:yum_repo_name).and_return('stuff')
+      expect(Pkg::Paths.yum_repo_name).to eq('puppet6')
     end
 
     it 'should return `Pkg::Config.yum_repo_name` if `Pkg::Config.repo_name` is not set' do
       allow(Pkg::Config).to receive(:repo_name).and_return(nil)
-      allow(Pkg::Config).to receive(:yum_repo_name).and_return('PC1')
-      expect(Pkg::Paths.yum_repo_name).to eq('PC1')
+      allow(Pkg::Config).to receive(:yum_repo_name).and_return('puppet7')
+      expect(Pkg::Paths.yum_repo_name).to eq('puppet7')
     end
 
     it 'should return \'products\' if nothing is set' do
@@ -197,40 +233,50 @@ describe 'Pkg::Paths' do
     end
 
     it 'should return nonfinal_repo_name for nonfinal version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
-      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet5-nightly')
-      expect(Pkg::Paths.yum_repo_name(true)).to eq('puppet5-nightly')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet7-nightly')
+      expect(Pkg::Paths.yum_repo_name(true)).to eq('puppet7-nightly')
     end
 
     it 'should fail if nonfinal_repo_name is not set for non-final version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
       expect { Pkg::Paths.yum_repo_name(true) }.to raise_error
     end
   end
 
   describe '#remote_repo_base' do
+    fake_yum_repo_path = '/fake/yum'
+    fake_yum_nightly_repo_path = '/fake/yum-nightly'
+    fake_apt_repo_path = '/fake/apt'
+    fake_apt_nightly_repo_path = '/fake/apt-nightly'
+
     before :each do
-      allow(Pkg::Config).to receive(:yum_repo_path).and_return('foo')
-      allow(Pkg::Config).to receive(:apt_repo_path).and_return('bar')
+      allow(Pkg::Config).to receive(:yum_repo_path).and_return(fake_yum_repo_path)
+      allow(Pkg::Config).to receive(:apt_repo_path).and_return(fake_apt_repo_path)
       allow(Pkg::Config).to receive(:dmg_path).and_return('/opt/downloads/mac')
-      allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return('foo-nightly')
-      allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return('bar-nightly')
+      allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return(fake_yum_nightly_repo_path)
+      allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return(fake_apt_nightly_repo_path)
     end
     it 'returns yum_repo_path for rpms' do
-      expect(Pkg::Paths.remote_repo_base('el-7-x86_64')).to eq('foo')
+      expect(Pkg::Paths.remote_repo_base('el-7-x86_64'))
+        .to eq(fake_yum_repo_path)
     end
     it 'returns apt_repo_path for debs' do
-      expect(Pkg::Paths.remote_repo_base('ubuntu-18.04-amd64')).to eq('bar')
+      expect(Pkg::Paths.remote_repo_base('ubuntu-18.04-amd64'))
+        .to eq(fake_apt_repo_path)
     end
     it 'returns nonfinal_yum_repo_path for nonfinal rpms' do
-      expect(Pkg::Paths.remote_repo_base('fedora-31-x86_64', nonfinal: true)).to eq('foo-nightly')
+      expect(Pkg::Paths.remote_repo_base('fedora-31-x86_64', nonfinal: true))
+        .to eq(fake_yum_nightly_repo_path)
     end
     it 'returns nonfinal_apt_repo_path for nonfinal debs' do
-      expect(Pkg::Paths.remote_repo_base('debian-9-amd64', nonfinal: true)).to eq('bar-nightly')
+      expect(Pkg::Paths.remote_repo_base('debian-9-amd64', nonfinal: true))
+        .to eq(fake_apt_nightly_repo_path)
     end
     it 'fails if neither tag nor package_format is provided' do
-      expect { Pkg::Paths.remote_repo_base }.to raise_error(/Pkg::Paths.remote_repo_base must have/)
+      expect { Pkg::Paths.remote_repo_base }
+        .to raise_error(/Pkg::Paths.remote_repo_base must have/)
     end
 
     it 'returns /opt/downloads if the path is /opt/downloads/<something>' do
@@ -238,56 +284,127 @@ describe 'Pkg::Paths' do
     end
 
     it 'fails for all other package formats' do
-      expect { Pkg::Paths.remote_repo_base('solaris-11-i386') }.to raise_error(/Can't determine remote repo base path/)
+      expect { Pkg::Paths.remote_repo_base('solaris-11-i386') }
+        .to raise_error(/Can't determine remote repo base path/)
     end
   end
 
   describe '#apt_package_base_path' do
     it 'fails for non-debian platforms' do
-      expect { Pkg::Paths.apt_package_base_path('el-7-x86_64', 'puppet6', 'puppet-agent') }.to raise_error(/Can't determine path for non-debian platform/)
+      expect { Pkg::Paths.apt_package_base_path('el-7-x86_64', 'puppet6', 'puppet-agent') }
+        .to raise_error(/Can't determine path for non-debian platform/)
     end
-    it 'returns the approprate apt repo path' do
-      allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository/apt')
-      expect(Pkg::Paths.apt_package_base_path('ubuntu-18.04-amd64', 'puppet6', 'puppet-agent')).to eq('/opt/repository/apt/pool/bionic/puppet6/p/puppet-agent')
-      expect(Pkg::Paths.apt_package_base_path('debian-9-amd64', 'puppet6', 'razor-server')).to eq('/opt/repository/apt/pool/stretch/puppet6/r/razor-server')
+
+    context 'for puppet 6 and prior' do
+      it 'returns the approprate apt repo path' do
+        allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository/apt')
+        expect(Pkg::Paths.apt_package_base_path('ubuntu-18.04-amd64', 'puppet6', 'puppet-agent'))
+          .to eq('/opt/repository/apt/pool/bionic/puppet6/p/puppet-agent')
+        expect(Pkg::Paths.apt_package_base_path('debian-9-amd64', 'puppet6', 'bolt-server'))
+          .to eq('/opt/repository/apt/pool/stretch/puppet6/b/bolt-server')
+
+
+      end
+      it 'returns the appropriate nonfinal repo path' do
+        allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository-nightlies/apt')
+        expect(Pkg::Paths.apt_package_base_path('ubuntu-18.04-amd64', 'puppet6-nightly',
+                                                'puppet-agent', true))
+          .to eq('/opt/repository-nightlies/apt/pool/bionic/puppet6-nightly/p/puppet-agent')
+        expect(Pkg::Paths.apt_package_base_path('debian-10-amd64', 'puppet6-nightly',
+                                                'pdk', true))
+          .to eq('/opt/repository-nightlies/apt/pool/buster/puppet6-nightly/p/pdk')
+      end
     end
-    it 'returns the appropriate nonfinal repo path' do
-      allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository-nightlies/apt')
-      expect(Pkg::Paths.apt_package_base_path('ubuntu-18.04-amd64', 'puppet6-nightly', 'puppet-agent', true)).to eq('/opt/repository-nightlies/apt/pool/bionic/puppet6-nightly/p/puppet-agent')
-      expect(Pkg::Paths.apt_package_base_path('debian-9-amd64', 'puppet6-nightly', 'razor-server', true)).to eq('/opt/repository-nightlies/apt/pool/stretch/puppet6-nightly/r/razor-server')
+
+    context 'for puppet 7 and after' do
+      it 'returns the approprate apt repo path' do
+        allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository/apt')
+        expect(Pkg::Paths.apt_package_base_path('ubuntu-18.04-amd64', 'puppet7', 'puppet-agent'))
+          .to eq('/opt/repository/apt/puppet7/pool/bionic/p/puppet-agent')
+        expect(Pkg::Paths.apt_package_base_path('ubuntu-20.04-amd64', 'puppet7', 'puppet-agent'))
+          .to eq('/opt/repository/apt/puppet7/pool/focal/p/puppet-agent')
+      end
+      it 'returns the appropriate nonfinal repo path' do
+        allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository-nightlies/apt')
+        expect(Pkg::Paths.apt_package_base_path('debian-10-amd64', 'puppet7-nightly', 'pdk', true))
+          .to eq('/opt/repository-nightlies/apt/puppet7-nightly/pool/buster/p/pdk')
+      end
     end
   end
 
   describe '#release_package_link_path' do
-    repo_name = 'puppet6'
-    nonfinal_repo_name = 'puppet6-nightly'
-    yum_repo_path = '/opt/repository/yum'
-    apt_repo_path = '/opt/repository/apt'
-    nonfinal_yum_repo_path = '/opt/repository-nightlies/yum'
-    nonfinal_apt_repo_path = '/opt/repository-nightlies/apt'
-    before :each do
-      allow(Pkg::Config).to receive(:repo_name).and_return(repo_name)
-      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nonfinal_repo_name)
-      allow(Pkg::Config).to receive(:yum_repo_path).and_return(yum_repo_path)
-      allow(Pkg::Config).to receive(:apt_repo_path).and_return(apt_repo_path)
-      allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return(nonfinal_yum_repo_path)
-      allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return(nonfinal_apt_repo_path)
+    context 'for puppet 6' do
+      repo_name = 'puppet6'
+      nonfinal_repo_name = 'puppet6-nightly'
+      yum_repo_path = '/opt/repository/yum'
+      apt_repo_path = '/opt/repository/apt'
+      nonfinal_yum_repo_path = '/opt/repository-nightlies/yum'
+      nonfinal_apt_repo_path = '/opt/repository-nightlies/apt'
+      before :each do
+        allow(Pkg::Config).to receive(:repo_name).and_return(repo_name)
+        allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nonfinal_repo_name)
+        allow(Pkg::Config).to receive(:yum_repo_path).and_return(yum_repo_path)
+        allow(Pkg::Config).to receive(:apt_repo_path).and_return(apt_repo_path)
+        allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return(nonfinal_yum_repo_path)
+        allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return(nonfinal_apt_repo_path)
+      end
+      it 'returns the appropriate link path for rpm release packages' do
+        expect(Pkg::Paths.release_package_link_path('sles-12-ppc64le'))
+          .to eq("#{yum_repo_path}/#{repo_name}-release-sles-12.noarch.rpm")
+      end
+      it 'returns the appropriate link path for deb release packages' do
+        expect(Pkg::Paths.release_package_link_path('ubuntu-16.04-amd64'))
+          .to eq("#{apt_repo_path}/#{repo_name}-release-xenial.deb")
+      end
+      it 'returns the appropriate link path for nonfinal rpm release packages' do
+        expect(Pkg::Paths.release_package_link_path('el-7-x86_64', true))
+          .to eq("#{nonfinal_yum_repo_path}/#{nonfinal_repo_name}-release-el-7.noarch.rpm")
+      end
+      it 'returns the appropriate link path for nonfinal deb release packages' do
+        expect(Pkg::Paths.release_package_link_path('debian-9-i386', true))
+          .to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-stretch.deb")
+      end
+      it 'returns nil for package formats that do not have release packages' do
+        expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)
+        expect(Pkg::Paths.release_package_link_path('windows-2012-x86')).to eq(nil)
+      end
     end
-    it 'returns the appropriate link path for rpm release packages' do
-      expect(Pkg::Paths.release_package_link_path('sles-12-ppc64le')).to eq("#{yum_repo_path}/#{repo_name}-release-sles-12.noarch.rpm")
-    end
-    it 'returns the appropriate link path for deb release packages' do
-      expect(Pkg::Paths.release_package_link_path('ubuntu-16.04-amd64')).to eq("#{apt_repo_path}/#{repo_name}-release-xenial.deb")
-    end
-    it 'returns the appropriate link path for nonfinal rpm release packages' do
-      expect(Pkg::Paths.release_package_link_path('el-7-x86_64', true)).to eq("#{nonfinal_yum_repo_path}/#{nonfinal_repo_name}-release-el-7.noarch.rpm")
-    end
-    it 'returns the appropriate link path for nonfinal deb release packages' do
-      expect(Pkg::Paths.release_package_link_path('debian-9-i386', true)).to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-stretch.deb")
-    end
-    it 'returns nil for package formats that do not have release packages' do
-      expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)
-      expect(Pkg::Paths.release_package_link_path('windows-2012-x86')).to eq(nil)
+
+    context 'for puppet 7' do
+      repo_name = 'puppet7'
+      nonfinal_repo_name = 'puppet7-nightly'
+      yum_repo_path = '/opt/repository/yum'
+      apt_repo_path = '/opt/repository/apt'
+      nonfinal_yum_repo_path = '/opt/repository-nightlies/yum'
+      nonfinal_apt_repo_path = '/opt/repository-nightlies/apt'
+      before :each do
+        allow(Pkg::Config).to receive(:repo_name).and_return(repo_name)
+        allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nonfinal_repo_name)
+        allow(Pkg::Config).to receive(:yum_repo_path).and_return(yum_repo_path)
+        allow(Pkg::Config).to receive(:apt_repo_path).and_return(apt_repo_path)
+        allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return(nonfinal_yum_repo_path)
+        allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return(nonfinal_apt_repo_path)
+      end
+      it 'returns the appropriate link path for rpm release packages' do
+        expect(Pkg::Paths.release_package_link_path('sles-12-ppc64le'))
+          .to eq("#{yum_repo_path}/#{repo_name}-release-sles-12.noarch.rpm")
+      end
+      it 'returns the appropriate link path for deb release packages' do
+        expect(Pkg::Paths.release_package_link_path('ubuntu-20.04-amd64'))
+          .to eq("#{apt_repo_path}/#{repo_name}-release-focal.deb")
+      end
+      it 'returns the appropriate link path for nonfinal rpm release packages' do
+        expect(Pkg::Paths.release_package_link_path('el-8-x86_64', true))
+          .to eq("#{nonfinal_yum_repo_path}/#{nonfinal_repo_name}-release-el-8.noarch.rpm")
+      end
+      it 'returns the appropriate link path for nonfinal deb release packages' do
+        expect(Pkg::Paths.release_package_link_path('debian-10-i386', true))
+          .to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-buster.deb")
+      end
+      it 'returns nil for package formats that do not have release packages' do
+        expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)
+        expect(Pkg::Paths.release_package_link_path('windows-2012-x86')).to eq(nil)
+      end
     end
   end
 end

--- a/spec/lib/packaging/util/ship_spec.rb
+++ b/spec/lib/packaging/util/ship_spec.rb
@@ -2,88 +2,106 @@ require 'spec_helper'
 
 describe '#Pkg::Util::Ship' do
   describe '#collect_packages' do
-    msi_pkgs = [
-      'pkg/windows/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x86.msi',
-      'pkg/windows/puppet5/puppet-agent-x86.msi',
-      'pkg/windowsfips/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x64.msi',
-      'pkg/windowsfips/puppet5/puppet-agent-x64.msi'
+    msi_packages = [
+      'pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi',
+      'pkg/windows/puppet6/puppet-agent-6.19.0-x86.msi',
+      'pkg/windowsfips/puppet6/puppet-agent-6.19.0-x64.msi'
     ]
-    swix_pkgs = [
-      'pkg/eos/puppet5/4/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix',
-      'pkg/eos/puppet5/4/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix.asc',
+    solaris_packages = [
+      'pkg/solaris/10/puppet6/puppet-agent-6.9.0-1.sparc.pkg.gz',
+      'pkg/solaris/10/puppet6/puppet-agent-6.9.0-1.sparc.pkg.gz.asc'
     ]
 
     it 'returns an array of packages found on the filesystem' do
-      allow(Dir).to receive(:glob).with('pkg/**/*.swix*').and_return(swix_pkgs)
-      expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.swix*'])).to eq(swix_pkgs)
+      allow(Dir).to receive(:glob).with('pkg/**/*.sparc*').and_return(solaris_packages)
+      expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.sparc*'])).to eq(solaris_packages)
     end
 
-    describe 'define excludes' do
+    context 'excluding packages' do
       before :each do
-        allow(Dir).to receive(:glob).with('pkg/**/*.msi').and_return(msi_pkgs)
+        allow(Dir).to receive(:glob).with('pkg/**/*.msi').and_return(msi_packages)
       end
       it 'correctly excludes any packages that match a passed excludes argument' do
-        expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'], ['puppet-agent-x(86|64).msi'])).not_to include('pkg/windows/puppet5/puppet-agent-x86.msi')
+        expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'], ['puppet-agent-x(86|64).msi']))
+          .not_to include('pkg/windows/puppet5/puppet-agent-x86.msi')
+        expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'], ['puppet-agent-x(86|64).msi']))
+          .not_to include('pkg/windows/puppet5/puppet-agent-x64.msi')
       end
       it 'correctly includes packages that do not match a passed excluded argument' do
-        expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'], ['puppet-agent-x(86|64).msi'])).to \
-          match_array(
-            [
-              'pkg/windows/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x86.msi',
-              'pkg/windowsfips/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x64.msi',
-            ]
-          )
+        expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'],
+                                                ['bogus-puppet-agent-x(86|64).msi']))
+          .to match_array(msi_packages)
       end
     end
 
-    it 'fails when it cannot find any packages at all' do
+    it 'returns an empty array when it cannot find any packages' do
       allow(Dir).to receive(:glob).with('pkg/**/*.html').and_return([])
       expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.html'])).to be_empty
     end
   end
 
-local_pkgs = [
-  'pkg/deb/stretch/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1stretch_i386.deb',
-  'pkg/el/5/puppet5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.el5.x86_64.rpm',
-  'pkg/sles/11/puppet5/i386/puppet-agent-1.4.1.2904.g8023dd1-1.sles11.i386.rpm',
-  'pkg/sles/12/puppet5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.sles12.x86_64.rpm',
-  'pkg/mac/10.15/puppet5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.osx10.15.dmg',
-  'pkg/eos/4/puppet5/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix',
-  'pkg/eos/4/puppet5/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix.asc',
-  'pkg/windows/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x86.msi',
-]
-new_pkgs = [
-  'pkg/stretch/puppet5/puppet-agent_1.4.1.2904.g8023dd1-1stretch_i386.deb',
-  'pkg/puppet5/el/5/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.el5.x86_64.rpm',
-  'pkg/puppet5/sles/11/i386/puppet-agent-1.4.1.2904.g8023dd1-1.sles11.i386.rpm',
-  'pkg/puppet5/sles/12/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.sles12.x86_64.rpm',
-  'pkg/mac/puppet5/10.15/x86_64/puppet-agent-1.4.1.2904.g8023dd1-1.osx10.15.dmg',
-  'pkg/eos/puppet5/4/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix',
-  'pkg/eos/puppet5/4/i386/puppet-agent-1.4.1.2904.g8023dd1-1.eos4.i386.swix.asc',
-  'pkg/windows/puppet5/puppet-agent-1.4.1.2904.g8023dd1-x86.msi',
-]
+  # Sample data for #reorganize_packages and #ship_pkgs specs
+  retrieved_packages = [
+    'pkg/deb/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb',
+    'pkg/el/7/puppet6/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm',
+    'pkg/el/7/puppet6/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm',
+    'pkg/el/7/puppet6/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm',
+    'pkg/sles/12/puppet6/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm',
+    'pkg/sles/12/puppet6/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm',
+    'pkg/sles/15/puppet6/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm',
+    'pkg/apple/10.14/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg',
+    'pkg/apple/10.15/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg',
+    'pkg/fedora/32/puppet6/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm',
+    'pkg/windows/puppet-agent-6.19.0-x64.msi',
+    'pkg/windows/puppet-agent-6.19.0-x86.msi',
+    'pkg/windowsfips/puppet-agent-6.19.0-x64.msi'
+  ]
+
+  # After reorganization, the packages should look like this.
+  # Beware apple->mac transforms.
+  expected_reorganized_packages = [
+    'pkg/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb',
+    'pkg/puppet6/el/7/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm',
+    'pkg/puppet6/el/7/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm',
+    'pkg/puppet6/el/7/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm',
+    'pkg/puppet6/sles/12/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm',
+    'pkg/puppet6/sles/12/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm',
+    'pkg/puppet6/sles/15/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm',
+    'pkg/mac/puppet6/10.14/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg',
+    'pkg/mac/puppet6/10.15/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg',
+    'pkg/puppet6/fedora/32/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm',
+    'pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi',
+    'pkg/windows/puppet6/puppet-agent-6.19.0-x86.msi',
+    'pkg/windowsfips/puppet6/puppet-agent-6.19.0-x64.msi'
+  ]
 
   describe '#reorganize_packages' do
-    tmpdir = Dir.mktmpdir
+    # This is a sampling of packages found on builds.delivery.puppetlabs.net in
+    # '/opt/jenkins-builds/puppet-agent/<version>/artifacts'
+    # pl:jenkins:retrieve replaces 'artifacts' with 'pkg', so we pick up the
+    # action from that point by pretending that we've scanned the directory and
+    # made this list:
+
+    scratch_directory = Dir.mktmpdir
 
     before :each do
-      allow(Pkg::Config).to receive(:repo_name).and_return('puppet5')
-      expect(FileUtils).to receive(:cp).at_least(:once)
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
+      expect(FileUtils).to receive(:cp).at_least(:once).and_return(true)
     end
 
-    it 'makes a temporary directory' do
-      expect(FileUtils).to receive(:mkdir_p).at_least(:once)
-      Pkg::Util::Ship.reorganize_packages(local_pkgs, tmpdir)
-    end
+    original_packages = retrieved_packages
 
     it 'leaves the old packages in place' do
-      orig = local_pkgs
-      Pkg::Util::Ship.reorganize_packages(local_pkgs, tmpdir)
-      expect(local_pkgs).to eq(orig)
+      reorganized_packages = Pkg::Util::Ship
+                               .reorganize_packages(retrieved_packages, scratch_directory)
+
+      expect(retrieved_packages).to eq(original_packages)
     end
 
-    it 'returns a list of packages that do not have the temp dir in the path' do
-      expect(Pkg::Util::Ship.reorganize_packages(local_pkgs, tmpdir)).to eq(new_pkgs)
+    it 'returns a list of properly reorganized packages' do
+      reorganized_packages = Pkg::Util::Ship
+                               .reorganize_packages(retrieved_packages, scratch_directory)
+      expect(reorganized_packages).to eq(expected_reorganized_packages)
     end
   end
 
@@ -92,38 +110,84 @@ new_pkgs = [
     test_remote_path = '/opt/repository/yum'
 
     it 'ships the packages to the staging server' do
-      allow(Pkg::Util::Ship).to receive(:collect_packages).and_return(local_pkgs)
-      allow(Pkg::Util::Ship).to receive(:reorganize_packages).and_return(new_pkgs)
+      allow(Pkg::Util::Ship)
+        .to receive(:collect_packages)
+              .and_return(retrieved_packages)
+      allow(Pkg::Util::Ship)
+        .to receive(:reorganize_packages)
+              .and_return(expected_reorganized_packages)
       allow(Pkg::Util).to receive(:ask_yes_or_no).and_return(true)
       # All of these expects must be called in the same block in order for the
       # tests to work without actually shipping anything
-      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(test_staging_server, /#{test_remote_path}/).exactly(local_pkgs.count).times
-      expect(Pkg::Util::Net).to receive(:rsync_to).with(anything, test_staging_server, /#{test_remote_path}/, anything).exactly(local_pkgs.count).times
-      expect(Pkg::Util::Net).to receive(:remote_set_ownership).with(test_staging_server, 'root', 'release', anything).exactly(local_pkgs.count).times
-      expect(Pkg::Util::Net).to receive(:remote_set_permissions).with(test_staging_server, '775', anything).exactly(local_pkgs.count).times
-      expect(Pkg::Util::Net).to receive(:remote_set_permissions).with(test_staging_server, '0664', anything).exactly(local_pkgs.count).times
-      expect(Pkg::Util::Net).to receive(:remote_set_immutable).with(test_staging_server, anything).exactly(local_pkgs.count).times
-      expect(Pkg::Util::Ship.ship_pkgs(['pkg/**/*.rpm'], test_staging_server, test_remote_path)).to eq(true)
+      expect(Pkg::Util::Net)
+        .to receive(:remote_ssh_cmd)
+              .with(test_staging_server, /#{test_remote_path}/)
+              .exactly(retrieved_packages.count).times
+      expect(Pkg::Util::Net)
+        .to receive(:rsync_to)
+              .with(anything, test_staging_server, /#{test_remote_path}/, anything)
+              .exactly(retrieved_packages.count).times
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_ownership)
+              .with(test_staging_server, 'root', 'release', anything)
+              .exactly(retrieved_packages.count).times
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_permissions)
+              .with(test_staging_server, '775', anything)
+              .exactly(retrieved_packages.count).times
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_permissions)
+              .with(test_staging_server, '0664', anything)
+              .exactly(retrieved_packages.count).times
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_immutable)
+              .with(test_staging_server, anything)
+              .exactly(retrieved_packages.count).times
+      expect(Pkg::Util::Ship.ship_pkgs(['pkg/**/*.rpm'], test_staging_server, test_remote_path))
+        .to eq(true)
     end
 
     it 'ships packages containing the string `pkg` to the right place' do
-      allow(Pkg::Util::Ship).to receive(:collect_packages).and_return(['pkg/el/5/puppet5/x86_64/my-super-sweet-pkg-1.0.0-1.el5.x86_64.rpm' ])
-      allow(Pkg::Util::Ship).to receive(:reorganize_packages).and_return(['pkg/puppet5/el/5/x86_64/my-super-sweet-pkg-1.0.0-1.el5.x86_64.rpm'])
+      retrieved_package =   'pkg/el/7/puppet6/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm'
+      reorganized_package = 'pkg/puppet6/el/7/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm'
+      package_basename = File.basename(reorganized_package)
+      repository_base_path = '/opt/repository/yum/puppet6/el/7/x86_64'
+
+      allow(Pkg::Util::Ship).to receive(:collect_packages).and_return([retrieved_package])
+      allow(Pkg::Util::Ship).to receive(:reorganize_packages).and_return([reorganized_package])
       allow(Pkg::Util).to receive(:ask_yes_or_no).and_return(true)
       allow(Dir).to receive(:mktmpdir).and_return('/tmp/test')
+
       # All of these expects must be called in the same block in order for the
       # tests to work without actually shipping anything
-      expect(Pkg::Util::Net).to receive(:remote_ssh_cmd).with(test_staging_server, /#{test_remote_path}/)
-      expect(Pkg::Util::Net).to receive(:rsync_to).with(anything, test_staging_server, /#{test_remote_path}/, anything)
-      expect(Pkg::Util::Net).to receive(:remote_set_ownership).with(test_staging_server, 'root', 'release', ['/opt/repository/yum/puppet5/el/5/x86_64', '/opt/repository/yum/puppet5/el/5/x86_64/my-super-sweet-pkg-1.0.0-1.el5.x86_64.rpm'])
-      expect(Pkg::Util::Net).to receive(:remote_set_permissions).with(test_staging_server, '775', anything)
-      expect(Pkg::Util::Net).to receive(:remote_set_permissions).with(test_staging_server, '0664', anything)
-      expect(Pkg::Util::Net).to receive(:remote_set_immutable).with(test_staging_server, anything)
-      expect(Pkg::Util::Ship.ship_pkgs(['pkg/**/*.rpm'], test_staging_server, test_remote_path, excludes: ['puppet-agent'])).to eq(true)
+      expect(Pkg::Util::Net)
+        .to receive(:remote_ssh_cmd)
+              .with(test_staging_server, /#{test_remote_path}/)
+      expect(Pkg::Util::Net)
+        .to receive(:rsync_to)
+              .with(anything, test_staging_server, /#{test_remote_path}/, anything)
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_ownership)
+              .with(test_staging_server, 'root', 'release',
+                    [repository_base_path, "#{repository_base_path}/#{package_basename}"])
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_permissions)
+              .with(test_staging_server, '775', anything)
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_permissions)
+              .with(test_staging_server, '0664', anything)
+      expect(Pkg::Util::Net)
+        .to receive(:remote_set_immutable)
+              .with(test_staging_server, anything)
+      expect(Pkg::Util::Ship.ship_pkgs(['pkg/**/*.rpm'], test_staging_server,
+                                       test_remote_path, excludes: ['puppet-agent']))
+        .to eq(true)
     end
 
     it 'returns false if there are no packages to ship' do
-      expect(Pkg::Util::Ship.ship_pkgs(['pkg/**/*.msi'], test_staging_server, test_remote_path)).to eq(false)
+      expect(Pkg::Util::Ship.ship_pkgs(['pkg/**/*.msi'],
+                                       test_staging_server, test_remote_path))
+        .to eq(false)
     end
   end
 end

--- a/spec/lib/packaging/util/ship_spec.rb
+++ b/spec/lib/packaging/util/ship_spec.rb
@@ -2,14 +2,16 @@ require 'spec_helper'
 
 describe '#Pkg::Util::Ship' do
   describe '#collect_packages' do
-    msi_packages = [
-      'pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi',
-      'pkg/windows/puppet6/puppet-agent-6.19.0-x86.msi',
-      'pkg/windowsfips/puppet6/puppet-agent-6.19.0-x64.msi'
+    msi_packages = %w[
+      pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi
+      pkg/windows/puppet6/puppet-agent-6.19.0-x86.msi
+      pkg/windowsfips/puppet6/puppet-agent-6.19.0-x64.msi
+      pkg/windows/puppet6/puppet-agent-x86.msi
+      pkg/windowsfips/puppet6/puppet-agent-x64.msi
     ]
-    solaris_packages = [
-      'pkg/solaris/10/puppet6/puppet-agent-6.9.0-1.sparc.pkg.gz',
-      'pkg/solaris/10/puppet6/puppet-agent-6.9.0-1.sparc.pkg.gz.asc'
+    solaris_packages = %w[
+      pkg/solaris/10/puppet6/puppet-agent-6.9.0-1.sparc.pkg.gz
+      pkg/solaris/10/puppet6/puppet-agent-6.9.0-1.sparc.pkg.gz.asc
     ]
 
     it 'returns an array of packages found on the filesystem' do
@@ -23,9 +25,9 @@ describe '#Pkg::Util::Ship' do
       end
       it 'correctly excludes any packages that match a passed excludes argument' do
         expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'], ['puppet-agent-x(86|64).msi']))
-          .not_to include('pkg/windows/puppet5/puppet-agent-x86.msi')
+          .not_to include('pkg/windows/puppet6/puppet-agent-x86.msi')
         expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'], ['puppet-agent-x(86|64).msi']))
-          .not_to include('pkg/windows/puppet5/puppet-agent-x64.msi')
+          .not_to include('pkg/windows/puppet6/puppet-agent-x64.msi')
       end
       it 'correctly includes packages that do not match a passed excluded argument' do
         expect(Pkg::Util::Ship.collect_packages(['pkg/**/*.msi'],
@@ -41,38 +43,42 @@ describe '#Pkg::Util::Ship' do
   end
 
   # Sample data for #reorganize_packages and #ship_pkgs specs
-  retrieved_packages = [
-    'pkg/deb/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb',
-    'pkg/el/7/puppet6/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm',
-    'pkg/el/7/puppet6/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm',
-    'pkg/el/7/puppet6/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm',
-    'pkg/sles/12/puppet6/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm',
-    'pkg/sles/12/puppet6/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm',
-    'pkg/sles/15/puppet6/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm',
-    'pkg/apple/10.14/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg',
-    'pkg/apple/10.15/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg',
-    'pkg/fedora/32/puppet6/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm',
-    'pkg/windows/puppet-agent-6.19.0-x64.msi',
-    'pkg/windows/puppet-agent-6.19.0-x86.msi',
-    'pkg/windowsfips/puppet-agent-6.19.0-x64.msi'
+  retrieved_packages = %w[
+    pkg/deb/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb
+    pkg/el/7/puppet6/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm
+    pkg/el/7/puppet6/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm
+    pkg/el/7/puppet6/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm
+    pkg/sles/12/puppet6/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm
+    pkg/sles/12/puppet6/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm
+    pkg/sles/15/puppet6/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm
+    pkg/apple/10.14/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg
+    pkg/apple/10.15/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg
+    pkg/fedora/32/puppet6/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
+    pkg/windows/puppet-agent-6.19.0-x64.msi
+    pkg/windows/puppet-agent-6.19.0-x86.msi
+    pkg/windowsfips/puppet-agent-6.19.0-x64.msi
+    pkg/windows/puppet6/puppet-agent-x86.msi
+    pkg/windowsfips/puppet6/puppet-agent-x64.msi
   ]
 
   # After reorganization, the packages should look like this.
   # Beware apple->mac transforms.
-  expected_reorganized_packages = [
-    'pkg/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb',
-    'pkg/puppet6/el/7/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm',
-    'pkg/puppet6/el/7/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm',
-    'pkg/puppet6/el/7/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm',
-    'pkg/puppet6/sles/12/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm',
-    'pkg/puppet6/sles/12/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm',
-    'pkg/puppet6/sles/15/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm',
-    'pkg/mac/puppet6/10.14/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg',
-    'pkg/mac/puppet6/10.15/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg',
-    'pkg/puppet6/fedora/32/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm',
-    'pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi',
-    'pkg/windows/puppet6/puppet-agent-6.19.0-x86.msi',
-    'pkg/windowsfips/puppet6/puppet-agent-6.19.0-x64.msi'
+  expected_reorganized_packages = %w[
+    pkg/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb
+    pkg/puppet6/el/7/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm
+    pkg/puppet6/el/7/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm
+    pkg/puppet6/el/7/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm
+    pkg/puppet6/sles/12/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm
+    pkg/puppet6/sles/12/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm
+    pkg/puppet6/sles/15/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm
+    pkg/mac/puppet6/10.14/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg
+    pkg/mac/puppet6/10.15/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg
+    pkg/puppet6/fedora/32/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
+    pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi
+    pkg/windows/puppet6/puppet-agent-6.19.0-x86.msi
+    pkg/windowsfips/puppet6/puppet-agent-6.19.0-x64.msi
+    pkg/windows/puppet6/puppet-agent-x86.msi
+    pkg/windowsfips/puppet6/puppet-agent-x64.msi
   ]
 
   describe '#reorganize_packages' do


### PR DESCRIPTION
Update specs to puppet 6 pathing; prepratory work for puppet 7.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.