### PR TITLE
(maint) make curl less noisy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- Added the --silent flag to curl when fetching gem JSON data from rubygems.org.
+  The live download progress/throughput information is noisy and not really helpful
+  when packaging is running in a batch mode.
 
 ## [0.99.71] - 2020-10-02
 ### Fixed
@@ -33,7 +37,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [0.99.66] - 2020-07-02
 ### Added
-- (RE-13303) Moved rolling repo link creation from the ship tasks 
+- (RE-13303) Moved rolling repo link creation from the ship tasks
   to separate rake tasks - `pl:remote:create_repo_links` and
   `pl:remote:create_nightly_repo_links`
 - Update `Pkg::Paths::remote_repo_base` to support dmg, msi, and swix packaging

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -17,7 +17,8 @@ module Pkg::Gem
     end
 
     def shipped_to_rubygems?(gem_name, gem_version, gem_platform)
-      gem_data = JSON.parse(`curl https://rubygems.org/api/v1/versions/#{gem_name}.json`)
+      rubygems_url = "https://rubygems.org/api/v1/versions/#{gem_name}.json"
+      gem_data = JSON.parse(%x[curl --silent #{rubygems_url}])
       gem = gem_data.select { |data| data['number'] == gem_version && data['platform'] == gem_platform }
       return !gem.empty?
     rescue => e

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -16,7 +16,7 @@ module Pkg::Gem
 
     def shipped_to_rubygems?(gem_name, gem_version, gem_platform)
       rubygems_url = "https://rubygems.org/api/v1/versions/#{gem_name}.json"
-      gem_data = JSON.parse(%x[curl --silent #{rubygems_url}])
+      gem_data = JSON.parse(%x(curl --silent #{rubygems_url}))
       gem = gem_data.select do |data|
         data['number'] == gem_version && data['platform'] == gem_platform
       end

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -1,9 +1,6 @@
 require 'json'
 module Pkg::Gem
   class << self
-    # This is preserved because I don't want to update the deprecated code path
-    # yet; I'm not entirely sure I've fixed everything that might attempt
-    # to call this method so this is now a wrapper for a wrapper.
     def ship(file)
       rsync_to_downloads(file)
       ship_to_rubygems(file)
@@ -13,18 +10,21 @@ module Pkg::Gem
     # checksums, or other glob-able artifacts to an external download server.
     def rsync_to_downloads(file)
       Pkg::Util.deprecate('Pkg::Gem.rsync_to_downloads', 'Pkg::Util::Ship.ship_pkgs')
-      Pkg::Util::Ship.ship_pkgs(["#{file}*"], Pkg::Config.gem_host, Pkg::Config.gem_path, platform_independent: true)
+      Pkg::Util::Ship.ship_pkgs(["#{file}*"], Pkg::Config.gem_host,
+                                Pkg::Config.gem_path, platform_independent: true)
     end
 
     def shipped_to_rubygems?(gem_name, gem_version, gem_platform)
       rubygems_url = "https://rubygems.org/api/v1/versions/#{gem_name}.json"
       gem_data = JSON.parse(%x[curl --silent #{rubygems_url}])
-      gem = gem_data.select { |data| data['number'] == gem_version && data['platform'] == gem_platform }
+      gem = gem_data.select do |data|
+        data['number'] == gem_version && data['platform'] == gem_platform
+      end
       return !gem.empty?
     rescue => e
-      puts "Uh oh, something went wrong searching for gem '#{gem_name}':"
+      puts "Something went wrong searching for gem '#{gem_name}':"
       puts e
-      puts "Perhaps you're shipping gem '#{gem_name}' for the first time? Congrats!"
+      puts "Perhaps you're shipping '#{gem_name}' for the first time?"
       return false
     end
 
@@ -41,7 +41,7 @@ module Pkg::Gem
       gem_platform ||= 'ruby'
 
       if shipped_to_rubygems?(Pkg::Config.gem_name, Pkg::Config.gemversion, gem_platform)
-        puts "#{file} has already been shipped to rubygems, skipping . . ."
+        puts "#{file} has already been shipped to rubygems, skipping."
         return
       end
       Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
@@ -61,7 +61,10 @@ module Pkg::Gem
 
     def ship_to_internal_mirror(file)
       internal_mirror_api_key_name = 'artifactory_api_key'
-      ship_to_rubygems(file, { :host => Pkg::Config.internal_gem_host, :key => internal_mirror_api_key_name })
+      ship_to_rubygems(file, {
+                         host: Pkg::Config.internal_gem_host,
+                         key: internal_mirror_api_key_name
+                       })
     end
   end
 end


### PR DESCRIPTION
When curl is fetching <gem>.json from rubygems, it prints download
information that is unhelpful during batch jobs. This turns that off
by adding '--silent' to the curl call.

There's also, in a seperate commit, some code formatting and output
message cleanups.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.