### PR TITLE
(maint) Add env var to override package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed
+- Allow `Pkg::Config.version` to be overridden with the `PACKAGING_PACKAGE_VERSION`
+  environment variable.
 - Added the --silent flag to curl when fetching gem JSON data from rubygems.org.
   The live download progress/throughput information is noisy and not really helpful
   when packaging is running in a batch mode.

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -298,6 +298,7 @@ module Pkg::Params
               { :var => :team,                    :envvar => :TEAM },
               { :var => :update_version_file,     :envvar => :NEW_STYLE_PACKAGE },
               { :var => :vanagon_project,         :envvar => :VANAGON_PROJECT, :type => :bool },
+              { :var => :version,                 :envvar => :PACKAGING_PACKAGE_VERSION },
               { :var => :yum_archive_path,        :envvar => :YUM_ARCHIVE_PATH },
               { :var => :yum_host,                :envvar => :YUM_HOST },
               { :var => :yum_repo_path,           :envvar => :YUM_REPO },


### PR DESCRIPTION
For puppet-agent 7.0.0 which is not yet released, we want packaging to use 7.0.0 as the version. Currently, it runs a `git describe` on the repo, which outputs a version similar to: `6.19.1-444`.

This commit makes `Pkg::Config.version` overridable with the `PACKAGING_PACKAGE_VERSION` environment variable.