### PR TITLE
(maint) create_link tasks were in the wrong place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Fixed
  - `puppet-tools` repository was missed in the apt path updates.
+ - `create_link` tasks were initially created under the wrong namespace, these
+    have been moved to under the `pl` namespace.
 
 ### Changed
  - (PA-3358) Removed puppet 7 nightly gem rake task

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -444,6 +444,16 @@ namespace :pl do
     end
   end
 
+  desc 'Create the rolling repo links'
+  task create_repo_links: 'pl:fetch' do
+    Pkg::Util::Ship.create_rolling_repo_links
+  end
+
+  desc 'Create rolling repo links for nightlies'
+  task create_nightly_repo_links: 'pl:fetch' do
+    Pkg::Util::Ship.create_rolling_repo_links(true)
+  end
+
   desc 'Test out the ship requirements'
   task ship_check: 'pl:fetch' do
     errs = []
@@ -517,15 +527,6 @@ namespace :pl do
       end
     end
 
-    desc 'Create the rolling repo links'
-    task create_repo_links: 'pl:fetch' do
-      Pkg::Util::Ship.create_rolling_repo_links
-    end
-
-    desc 'Create rolling repo links for nightlies'
-    task create_nightly_repo_links: 'pl:fetch' do
-      Pkg::Util::Ship.create_rolling_repo_links(true)
-    end
   end
 
   # It is odd to namespace this ship task under :jenkins, but this task is


### PR DESCRIPTION
They were part of another method and not actually callable. Now part of
the `pl:` namespace.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
