### PR TITLE
(PA-3497) accommodate arm64 debian packages for aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+- (PA-3497) accommodate arm64 debian packages for aarch64
 
 ## [0.99.74] - 2020-11-19
 ### Changed

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -16,9 +16,9 @@ module Pkg::Paths
     if source_formats.find { |fmt| path =~ /#{fmt}$/ }
       return Pkg::Platforms.get_attribute_for_platform_version(platform, version, :source_architecture)
     end
-    arches.find { |a| path.include?(a) } || arches[0]
+    arches.find { |a| path.include?(package_arch(platform, a)) } || arches[0]
   rescue
-    arches.find { |a| path.include?(a) } || arches[0]
+    arches.find { |a| path.include?(package_arch(platform, a)) } || arches[0]
   end
 
   # Given a path to an artifact, divine the appropriate platform tag associated
@@ -361,4 +361,15 @@ module Pkg::Paths
     return base_component if component_qualifier == 'repos'
     return full_component
   end
+
+  #for ubuntu-20.04-aarch64, debian package architecture is arm64
+  def package_arch(platform, arch)
+    if platform == 'ubuntu' && arch == 'aarch64'
+      return 'arm64'
+    end
+    arch
+  end
+
+  private :package_arch
+
 end

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -5,8 +5,10 @@ describe 'Pkg::Paths' do
     arch_transformations = {
       ['artifacts/aix/6.1/puppet6/ppc/puppet-agent-6.9.0-1.aix6.1.ppc.rpm', 'aix', '6.1'] => 'power',
       ['pkg/el-8-x86_64/puppet-agent-6.9.0-1.el8.x86_64.rpm', 'el', '8'] => 'x86_64',
+      ['pkg/el/8/puppet6/aarch64/puppet-agent-6.5.0.3094.g16b6fa6f-1.el8.aarch64.rpm', 'el', '8'] => 'aarch64',
       ['artifacts/fedora/32/puppet6/x86_64/puppet-agent-6.9.0-1.fc30.x86_64.rpm', 'fedora', '32'] => 'x86_64',
       ['pkg/ubuntu-16.04-amd64/puppet-agent_4.99.0-1xenial_amd64.deb', 'ubuntu', '16.04'] => 'amd64',
+      ['artifacts/deb/focal/puppet6/puppet-agent_6.5.0.3094.g16b6fa6f-1focal_arm64.deb', 'ubuntu', '20.04'] => 'aarch64',
 
       ['artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz', 'ubuntu', '16.04'] => 'source',
       ['artifacts/deb/jessie/PC1/puppetserver_5.0.1.master.orig.tar.gz', 'debian', '8'] => 'source',


### PR DESCRIPTION
tests are failing until https://github.com/puppetlabs/packaging/pull/1085 is merged