### PR TITLE
(PA-3358) Revert puppet 7 nightly gem rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+ - (PA-3358) Removed puppet 7 nightly gem rake task
 
 ## [0.99.75] - 2020-12-08
 ### Added

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -150,20 +150,10 @@ namespace :package do
     Pkg::Config.gemversion = Pkg::Util::Version.extended_dot_version
     package_gem
   end
-
-  # PA-3356: temporary task to ship puppet 7 nightly gem
-  # TODO: PA-3358 - remove when puppet 7 is officialy out
-  task :puppet_7_nightly_gem => ["clean"] do
-    Pkg::Config.gemversion = Pkg::Util::Version.extended_dot_version.gsub(/6\.\d+\.\d+/, '7.0.0')
-    package_gem
-  end
 end
 
 # An alias task to simplify our remote logic in jenkins.rake
 namespace :pl do
   task :gem => "package:gem"
   task :nightly_gem => "package:nightly_gem"
-  # PA-3356: temporary task to ship puppet 7 nightly gem
-  # TODO: PA-3358 - remove when puppet 7 is officialy out
-  task :puppet_7_nightly_gem => "package:puppet_7_nightly_gem"
 end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -265,25 +265,6 @@ namespace :pl do
 
       Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.gem_host, command)
     end
-
-    # PA-3356: temporary task to link puppet 7 nightly gem
-    # TODO: PA-3358 - remove when puppet 7 is officialy out
-    desc "Remotely link puppet 7 nightly shipped gems to latest versions on #{Pkg::Config.gem_host}"
-    task link_puppet_7_nightly_shipped_gems_to_latest: 'pl:fetch' do
-      Pkg::Config.gemversion = Pkg::Util::Version.extended_dot_version.gsub(/6\.\d+\.\d+/, '7.0.0')
-
-      remote_path = Pkg::Config.nonfinal_gem_path
-      gems = FileList['pkg/*.gem'].map! { |path| path.gsub!('pkg/', '') }
-      command = %(cd #{remote_path}; )
-
-      command += gems.map! do |gem_name|
-        %(sudo ln -sf #{gem_name} #{gem_name.gsub(Pkg::Config.gemversion, 'latest')})
-      end.join(';')
-
-      command += %(; sync)
-
-      Pkg::Util::Net.remote_ssh_cmd(Pkg::Config.gem_host, command)
-    end
   end
 
   desc "Ship mocked rpms to #{Pkg::Config.yum_staging_server}"


### PR DESCRIPTION
This reverts commit 86b796baee3e8a86851a822f045b8070c6cc7a25.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
