### PR TITLE
(maint) Add puppet-tools as one of the supported apt repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+ - `puppet-tools` repository was missed in the apt path updates.
+
+### Changed
  - (PA-3358) Removed puppet 7 nightly gem rake task
 
 ## [0.99.75] - 2020-12-08

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -322,7 +322,8 @@ module Pkg::Paths
     if %w(puppet7 puppet7-nightly
           puppet6 puppet6-nightly
           puppet5 puppet5-nightly
-          puppet).include? repo_name
+          puppet
+          puppet-tools).include? repo_name
       return File.join(remote_repo_path, 'pool', code_name, repo_name, project[0], project)
     end
 

--- a/spec/lib/packaging/util/git_tag_spec.rb
+++ b/spec/lib/packaging/util/git_tag_spec.rb
@@ -17,7 +17,7 @@ describe "Pkg::Util::Git_tag" do
 
   context "branch?" do
     it "sets ref type as a branch when passed a branch" do
-      git_tag = Pkg::Util::Git_tag.new("git://github.com/puppetlabs/leatherman.git", "master")
+      git_tag = Pkg::Util::Git_tag.new("git://github.com/puppetlabs/leatherman.git", "main")
       expect(git_tag.branch?).to eq(true)
     end
   end


### PR DESCRIPTION
Also update `git_tag` test to pull a valid ref of leatherman