### PR TITLE
(maint) Include `puppet-nightly` into the apt_package_base_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Fixed
- - `puppet-tools` repository was missed in the apt path updates.
+ - `puppet-tools` and `puppet-nightly` repositories were missed in the apt path updates.
 
 ### Changed
  - (PA-3358) Removed puppet 7 nightly gem rake task

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -322,7 +322,7 @@ module Pkg::Paths
     if %w(puppet7 puppet7-nightly
           puppet6 puppet6-nightly
           puppet5 puppet5-nightly
-          puppet
+          puppet  puppet-nightly
           puppet-tools).include? repo_name
       return File.join(remote_repo_path, 'pool', code_name, repo_name, project[0], project)
     end


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.