### PR TITLE
(RE-11821) Add config validation after pl:fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Added
 - (PA-3531) Add support for RedHat 8 ppc64le
+- (RE-11821) Create a configuration-validation hook after a pl:fetch
 
 ### Fixed
- - `puppet-tools` and `puppet-nightly` repositories were missed in the apt path updates.
- - `create_link` tasks were initially created under the wrong namespace, these
-    have been moved to under the `pl` namespace.
+- `puppet-tools` and `puppet-nightly` repositories were missed in the apt path updates.
+- `create_link` tasks were initially created under the wrong namespace, these
+   have been moved to under the `pl` namespace.
 
 ### Changed
  - (PA-3358) Removed puppet 7 nightly gem rake task

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -393,6 +393,9 @@ module Pkg
       ##
       #   Ask for validation of BUILD_PARAMS
       #
+      #   Issued as warnings initially but the intent is to turn this into
+      #   a failure.
+      #
       def perform_validations
         error_count = 0
         Pkg::Params::VALIDATIONS.each do |v|
@@ -400,16 +403,15 @@ module Pkg
           variable_value = self.instance_variable_get("@#{v[:var]}")
           validations = v[:validations]
           validations.each do |validation|
-            result = Pkg::ConfigValidations.send(validation, variable_value)
-            if (result == false)
-              puts "ERROR: variable \"#{variable_name}\" failed validation \"#{validation}\""
+            unless Pkg::ConfigValidations.send(validation, variable_value)
+              warn "Warning: variable \"#{variable_name}\" failed validation \"#{validation}\""
               error_count += 1
             end
           end
         end
 
         if error_count != 0
-          fail "ERROR: #{error_count} validation failure(s)."
+          warn "Warning: #{error_count} validation failure(s)."
         end
       end
 

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -6,6 +6,7 @@ module Pkg
   #
   class Config
     require 'packaging/config/params.rb'
+    require 'packaging/config/validations.rb'
     require 'yaml'
 
     class << self
@@ -386,6 +387,29 @@ module Pkg
           if self.instance_variable_get("@#{v[:var]}")
             warn v[:message]
           end
+        end
+      end
+
+      ##
+      #   Ask for validation of BUILD_PARAMS
+      #
+      def perform_validations
+        error_count = 0
+        Pkg::Params::VALIDATIONS.each do |v|
+          variable_name = v[:var]
+          variable_value = self.instance_variable_get("@#{v[:var]}")
+          validations = v[:validations]
+          validations.each do |validation|
+            result = Pkg::ConfigValidations.send(validation, variable_value)
+            if (result == false)
+              puts "ERROR: variable \"#{variable_name}\" failed validation \"#{validation}\""
+              error_count += 1
+            end
+          end
+        end
+
+        if error_count != 0
+          fail "ERROR: #{error_count} validation failure(s)."
         end
       end
 

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -363,6 +363,7 @@ module Pkg::Params
                     { :oldvar => :yum_host,               :newvar => :tar_host },
                  ]
 
+
   # These are variables that we have deprecated. If they are encountered in a
   # project's config, we issue deprecations for them.
   #
@@ -373,4 +374,14 @@ module Pkg::Params
                   { :var => :gpg_name, :message => "
     DEPRECATED, 29-Jul-2014: 'gpg_name' has been replaced with 'gpg_key'.
                    Please update this field in your build_defaults.yaml" }]
+
+  # Provide an open-ended template for validating BUILD_PARAMS.
+  #
+  # Each validatation contains the variable name as ':var' and a list of validations it
+  # must pass from the Pkg::Params::Validations class.
+  #
+  VALIDATIONS = [
+    { :var => :project, :validations => [:not_empty?] }
+  ]
+
 end

--- a/lib/packaging/config/validations.rb
+++ b/lib/packaging/config/validations.rb
@@ -1,0 +1,13 @@
+module Pkg
+  class ConfigValidations
+
+    class << self
+
+      # As a validation, this one is kindof lame but is intended as a seed pattern for possibly
+      # more robust ones.
+      def not_empty?(value)
+        value.to_s.empty? ? false : true
+      end
+    end
+  end
+end

--- a/tasks/config.rake
+++ b/tasks/config.rake
@@ -6,6 +6,11 @@ namespace :config do
     end
   end
 
+  desc "validate Pkg::Config values for this repo"
+  task :validate do
+    Pkg::Config.perform_validations
+  end
+
   task :print_hosts => 'pl:fetch' do
     Pkg::Util.filter_configs('host').each do |key, value|
       puts "#{key}: #{value}"


### PR DESCRIPTION
Introduce a hook that allows for data validation after a pl:fetch.

Create an initial simple validation per the suggestion in RE-11821
that checks if 'project' is non-empty.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.