### PR TITLE
Update gem dependencies and cope with the Rubocop results

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - 'vendor/**/*'
 
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Enabled: true
 
 Lint/ElseLayout:
@@ -17,19 +17,12 @@ Lint/ElseLayout:
 Lint/UnreachableCode:
   Enabled: true
 
-Lint/UselessComparison:
-  Enabled: true
-
 # MAYBE useful - no return inside ensure block.
 Lint/EnsureReturn:
   Enabled: true
 
 # MAYBE useful - errors when rescue {} happens.
-Lint/HandleExceptions:
-  Enabled: false
-
-# MAYBE useful - catches while 1
-Lint/LiteralInCondition:
+Lint/SuppressedException:
   Enabled: false
 
 # MAYBE useful - but too many instances
@@ -40,81 +33,64 @@ Lint/ShadowingOuterLocalVariable:
 Lint/LiteralInInterpolation:
   Enabled: true
 
-
-# DISABLED really useless. Detects return as last statement.
 Style/RedundantReturn:
   Enabled: false
 
-# DISABLED since the instances do not seem to indicate any specific errors.
 Lint/AmbiguousOperator:
   Enabled: false
 
-# DISABLED since for all the checked, we are basically checking nil
 # TODO: Change the checking so that if the variable being assigned to has
 # a value ALREADY, then raise an error.
 Lint/AssignmentInCondition:
   Enabled: false
 
-# DISABLED - not useful
-Style/SpaceBeforeComment:
+Layout/SpaceBeforeComment:
   Enabled: false
 
-# DISABLED - not useful
 Style/HashSyntax:
   Enabled: false
 
 # USES: as shortcut for non nil&valid checking a = x() and a.empty?
-# DISABLED - not useful
 Style/AndOr:
   Enabled: false
 
-# DISABLED - not useful
 Style/RedundantSelf:
   Enabled: false
 
-# DISABLED - not useful
-Style/MethodLength:
+Metrics/MethodLength:
   Enabled: false
 
-# DISABLED - not useful
 Style/WhileUntilModifier:
   Enabled: false
 
-# DISABLED - the offender is just haskell envy
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-# DISABLED
-Lint/Eval:
-  Enabled: false
-# DISABLED
-Lint/BlockAlignment:
+Security/Eval:
   Enabled: false
 
-# DISABLED
-Lint/DefEndAlignment:
+Layout/BlockAlignment:
   Enabled: false
 
-# DISABLED
-Lint/EndAlignment:
+Layout/DefEndAlignment:
   Enabled: false
 
-# DISABLED
+Layout/EndAlignment:
+  Enabled: false
+
 Lint/DeprecatedClassMethods:
   Enabled: false
 
-# DISABLED
 Lint/Loop:
   Enabled: false
 
-# DISABLED
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
 
 Lint/RescueException:
   Enabled: false
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: false
 
 Lint/UnusedBlockArgument:
@@ -123,37 +99,25 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Enabled: false
 
-# DISABLED - TODO
 Lint/UselessAccessModifier:
   Enabled: false
 
-# DISABLED - TODO
 Lint/UselessAssignment:
   Enabled: false
 
-# DISABLED - TODO
 Lint/Void:
   Enabled: false
 
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: false
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 Style/Alias:
   Enabled: false
 
-Style/AlignArray:
-  Enabled: false
-
-Style/AlignHash:
-  Enabled: false
-
-Style/AlignParameters:
-  Enabled: false
-
-Style/BlockNesting:
+Metrics/BlockNesting:
   Enabled: false
 
 Style/AsciiComments:
@@ -162,22 +126,16 @@ Style/AsciiComments:
 Style/Attr:
   Enabled: false
 
-Style/Blocks:
-  Enabled: false
-
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 Style/CaseEquality:
   Enabled: false
 
-Style/CaseIndentation:
+Layout/CaseIndentation:
   Enabled: false
 
 Style/CharacterLiteral:
   Enabled: false
 
-Style/ClassAndModuleCamelCase:
+Naming/ClassAndModuleCamelCase:
   Enabled: false
 
 Style/ClassAndModuleChildren:
@@ -186,7 +144,7 @@ Style/ClassAndModuleChildren:
 Style/ClassCheck:
   Enabled: false
 
-Style/ClassLength:
+Metrics/ClassLength:
   Enabled: false
 
 Style/ClassMethods:
@@ -198,76 +156,58 @@ Style/ClassVars:
 Style/WhenThen:
   Enabled: false
 
-
-# DISABLED - not useful
 Style/WordArray:
   Enabled: false
 
-Style/UnneededPercentQ:
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
   Enabled: false
 
-Style/Tab:
-  Enabled: false
-
-Style/SpaceBeforeSemicolon:
+Layout/SpaceBeforeFirstArg:
   Enabled: true
 
-Style/TrailingBlankLines:
-  Enabled: false
-
-Style/SpaceInsideBlockBraces:
+Layout/SpaceAfterColon:
   Enabled: true
 
-Style/SpaceInsideBrackets:
+Layout/SpaceAfterComma:
   Enabled: true
 
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceAfterMethodName:
   Enabled: true
 
-Style/SpaceInsideParens:
+Layout/SpaceAfterNot:
   Enabled: true
 
-Style/LeadingCommentSpace:
-  Enabled: false
-
-Style/SingleSpaceBeforeFirstArg:
+Layout/SpaceAfterSemicolon:
   Enabled: true
 
-Style/SpaceAfterColon:
+Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
-Style/SpaceAfterComma:
+Layout/SpaceAroundOperators:
   Enabled: true
 
-Style/SpaceAfterControlKeyword:
+Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
-Style/SpaceAfterMethodName:
+Layout/SpaceBeforeComma:
   Enabled: true
-
-Style/SpaceAfterNot:
-  Enabled: true
-
-Style/SpaceAfterSemicolon:
-  Enabled: true
-
-Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
-
-Style/SpaceAroundOperators:
-  Enabled: true
-
-Style/SpaceBeforeBlockBraces:
-  Enabled: true
-
-Style/SpaceBeforeComma:
-  Enabled: true
-
 
 Style/CollectionMethods:
   Enabled: false
 
-Style/CommentIndentation:
+Layout/CommentIndentation:
   Enabled: false
 
 Style/ColonMethodCall:
@@ -276,10 +216,10 @@ Style/ColonMethodCall:
 Style/CommentAnnotation:
   Enabled: false
 
-Style/CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Enabled: false
 
-Style/ConstantName:
+Naming/ConstantName:
   Enabled: false
 
 Style/Documentation:
@@ -288,50 +228,40 @@ Style/Documentation:
 Style/DefWithParentheses:
   Enabled: false
 
-Style/DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Enabled: false
 
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
-# DISABLED - used for converting to bool
 Style/DoubleNegation:
   Enabled: false
 
 Style/EachWithObject:
   Enabled: false
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Style/IndentArray:
-  Enabled: false
-
-Style/IndentHash:
-  Enabled: false
-
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   Enabled: true
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: true
 
-Style/EmptyLines:
+Layout/EmptyLines:
   Enabled: false
 
-Style/EmptyLinesAroundAccessModifier:
-  Enabled: false
-
-Style/EmptyLinesAroundBody:
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
 
 Style/EmptyLiteral:
   Enabled: false
 
-Style/LineLength:
+Layout/LineLength:
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:
@@ -340,13 +270,10 @@ Style/MethodDefParentheses:
 Style/LineEndConcatenation:
   Enabled: false
 
-Style/TrailingWhitespace:
+Layout/TrailingWhitespace:
   Enabled: true
 
 Style/StringLiterals:
-  Enabled: false
-
-Style/TrailingComma:
   Enabled: false
 
 Style/GlobalVars:
@@ -387,13 +314,13 @@ Style/UnlessElse:
   Enabled: true
 
 # This pushes preference for shell commands as backticks instead of %x
-Style/UnneededPercentX:
+Style/RedundantPercentQ:
   Enabled: false
 
 Style/VariableInterpolation:
   Enabled: true
 
-Style/VariableName:
+Naming/VariableName:
   Enabled: true
 
 Style/WhileUntilDo:
@@ -402,7 +329,7 @@ Style/WhileUntilDo:
 Style/EvenOdd:
   Enabled: true
 
-Style/FileName:
+Naming/FileName:
   Enabled: true
 
 Style/For:
@@ -411,7 +338,7 @@ Style/For:
 Style/Lambda:
   Enabled: false
 
-Style/MethodName:
+Naming/MethodName:
   Enabled: false
 
 Style/MultilineTernaryOperator:
@@ -447,7 +374,7 @@ Style/NumericLiterals:
 Style/OneLineConditional:
   Enabled: true
 
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Enabled: true
 
 Style/ParenthesesAroundCondition:
@@ -459,7 +386,7 @@ Style/PercentLiteralDelimiters:
 Style/PerlBackrefs:
   Enabled: false
 
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 Style/RedundantException:
@@ -467,7 +394,6 @@ Style/RedundantException:
 
 Style/SelfAssignment:
   Enabled: true
-
 
 Style/Proc:
   Enabled: true
@@ -487,13 +413,10 @@ Style/RegexpLiteral:
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
-Style/ParameterLists:
+Metrics/ParameterLists:
   Enabled: true
 
 Lint/RequireParentheses:
-  Enabled: true
-
-Lint/SpaceBeforeFirstArg:
   Enabled: true
 
 Style/ModuleFunction:
@@ -507,3 +430,62 @@ Style/IfWithSemicolon:
 
 Style/Encoding:
   Enabled: false
+
+Gemspec/DateAssignment:
+  Enabled: true
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+Lint/AmbiguousAssignment:
+  Enabled: true
+Lint/DeprecatedConstants:
+  Enabled: true
+Lint/DuplicateBranch:
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+Lint/EmptyBlock:
+  Enabled: true
+Lint/EmptyClass:
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+Lint/NumberedParameterAssignment:
+  Enabled: true
+Lint/OrAssignmentToConstant:
+  Enabled: true
+Lint/RedundantDirGlobSort:
+  Enabled: true
+Lint/SymbolConversion:
+  Enabled: true
+Lint/ToEnumArguments:
+  Enabled: true
+Lint/TripleQuotes:
+  Enabled: true
+Lint/UnexpectedBlockArity:
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+Style/ArgumentsForwarding:
+  Enabled: true
+Style/CollectionCompact:
+  Enabled: true
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
+Style/EndlessMethod:
+  Enabled: true
+Style/HashConversion:
+  Enabled: true
+Style/HashExcept:
+  Enabled: true
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+Style/NegatedIfElseCondition:
+  Enabled: true
+Style/NilLambda:
+  Enabled: true
+Style/RedundantArgument:
+  Enabled: true
+Style/SwapValues:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,181 +1,62 @@
+---
+
 AllCops:
   Include:
-    - 'lib/**/*.rb'
-    - 'tasks/**/*'
+  - lib/**/*.rb
+  - tasks/**/*
   Exclude:
-    - '**/*.erb'
-    - 'spec/**/*'
-    - 'vendor/**/*'
+  - "**/*.erb"
+  - spec/**/*
+  - vendor/**/*
+  SuggestExtensions: false
 
-
-Layout/ConditionPosition:
+Gemspec/DateAssignment:
   Enabled: true
 
-Lint/ElseLayout:
-  Enabled: true
-
-Lint/UnreachableCode:
-  Enabled: true
-
-# MAYBE useful - no return inside ensure block.
-Lint/EnsureReturn:
-  Enabled: true
-
-# MAYBE useful - errors when rescue {} happens.
-Lint/SuppressedException:
-  Enabled: false
-
-# MAYBE useful - but too many instances
-Lint/ShadowingOuterLocalVariable:
-  Enabled: false
-
-# Can catch complicated strings.
-Lint/LiteralInInterpolation:
-  Enabled: true
-
-Style/RedundantReturn:
-  Enabled: false
-
-Lint/AmbiguousOperator:
-  Enabled: false
-
-# TODO: Change the checking so that if the variable being assigned to has
-# a value ALREADY, then raise an error.
-Lint/AssignmentInCondition:
-  Enabled: false
-
-Layout/SpaceBeforeComment:
-  Enabled: false
-
-Style/HashSyntax:
-  Enabled: false
-
-# USES: as shortcut for non nil&valid checking a = x() and a.empty?
-Style/AndOr:
-  Enabled: false
-
-Style/RedundantSelf:
-  Enabled: false
-
-Metrics/MethodLength:
-  Enabled: false
-
-Style/WhileUntilModifier:
-  Enabled: false
-
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
-Security/Eval:
+Layout/AccessModifierIndentation:
   Enabled: false
 
 Layout/BlockAlignment:
   Enabled: false
 
+Layout/CaseIndentation:
+  Enabled: false
+
+Layout/CommentIndentation:
+  Enabled: false
+
+Layout/ConditionPosition:
+  Enabled: true
+
 Layout/DefEndAlignment:
+  Enabled: false
+
+Layout/DotPosition:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/EmptyLines:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
 
 Layout/EndAlignment:
   Enabled: false
 
-Lint/DeprecatedClassMethods:
-  Enabled: false
-
-Lint/Loop:
-  Enabled: false
-
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
-
-Lint/RescueException:
-  Enabled: false
-
-Lint/RedundantStringCoercion:
-  Enabled: false
-
-Lint/UnusedBlockArgument:
-  Enabled: false
-
-Lint/UnusedMethodArgument:
-  Enabled: false
-
-Lint/UselessAccessModifier:
-  Enabled: false
-
-Lint/UselessAssignment:
-  Enabled: false
-
-Lint/Void:
-  Enabled: false
-
-Layout/AccessModifierIndentation:
-  Enabled: false
-
-Naming/AccessorMethodName:
-  Enabled: false
-
-Style/Alias:
-  Enabled: false
-
-Metrics/BlockNesting:
-  Enabled: false
-
-Style/AsciiComments:
-  Enabled: false
-
-Style/Attr:
-  Enabled: false
-
-Style/CaseEquality:
-  Enabled: false
-
-Layout/CaseIndentation:
-  Enabled: false
-
-Style/CharacterLiteral:
-  Enabled: false
-
-Naming/ClassAndModuleCamelCase:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-Style/ClassCheck:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Style/ClassMethods:
-  Enabled: false
-
-Style/ClassVars:
-  Enabled: false
-
-Style/WhenThen:
-  Enabled: false
-
-Style/WordArray:
-  Enabled: false
-
-Layout/SpaceBeforeSemicolon:
+Layout/IndentationConsistency:
   Enabled: true
 
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
-Layout/SpaceInsideParens:
+Layout/IndentationWidth:
   Enabled: true
 
 Layout/LeadingCommentSpace:
   Enabled: false
 
-Layout/SpaceBeforeFirstArg:
-  Enabled: true
+Layout/LineLength:
+  Enabled: false
 
 Layout/SpaceAfterColon:
   Enabled: true
@@ -201,37 +82,268 @@ Layout/SpaceAroundOperators:
 Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+
 Layout/SpaceBeforeComma:
   Enabled: true
 
-Style/CollectionMethods:
+Layout/SpaceBeforeComment:
   Enabled: false
 
-Layout/CommentIndentation:
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Lint/AmbiguousAssignment:
+  Enabled: true
+
+Lint/AmbiguousOperator:
   Enabled: false
 
-Style/ColonMethodCall:
+Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-Style/CommentAnnotation:
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
+Lint/Debugger:
+  Enabled: false
+
+Lint/DeprecatedClassMethods:
+  Enabled: false
+
+Lint/DeprecatedConstants:
+  Enabled: true
+
+Lint/DuplicateBranch:
+  Enabled: true
+
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyBlock:
+  Enabled: true
+
+Lint/EmptyClass:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Enabled: false
+
+Lint/MissingCopEnableDirective:
+  Enabled: false
+
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+
+Lint/NumberedParameterAssignment:
+  Enabled: true
+
+Lint/OrAssignmentToConstant:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RedundantDirGlobSort:
+  Enabled: true
+
+Lint/RedundantStringCoercion:
+  Enabled: false
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: false
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+Lint/SuppressedException:
+  Enabled: false
+
+Lint/SymbolConversion:
+  Enabled: true
+
+Lint/ToEnumArguments:
+  Enabled: true
+
+Lint/TripleQuotes:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnexpectedBlockArity:
+  Enabled: true
+
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UselessAccessModifier:
+  Enabled: false
+
+Lint/UselessAssignment:
+  Enabled: false
+
+Lint/Void:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
   Enabled: false
 
 Metrics/CyclomaticComplexity:
   Enabled: false
 
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: true
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: false
+
 Naming/ConstantName:
   Enabled: false
 
-Style/Documentation:
+Naming/FileName:
+  Enabled: true
+
+Naming/MethodName:
+  Enabled: false
+
+Naming/MethodParameterName:
+  Enabled: false
+
+Naming/PredicateName:
+  Enabled: false
+
+Naming/VariableName:
+  Enabled: true
+
+Security/Eval:
+  Enabled: false
+
+Security/Open:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
+Style/AndOr:
+  Enabled: false
+
+Style/ArgumentsForwarding:
+  Enabled: true
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Attr:
+  Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/CharacterLiteral:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ClassMethods:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Style/CollectionCompact:
+  Enabled: true
+
+Style/CollectionMethods:
+  Enabled: false
+
+Style/ColonMethodCall:
+  Enabled: false
+
+Style/CommandLiteral:
+  Enabled: false
+
+Style/CommentAnnotation:
   Enabled: false
 
 Style/DefWithParentheses:
   Enabled: false
 
-Style/PreferredHashMethods:
-  Enabled: false
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
 
-Layout/DotPosition:
+Style/Documentation:
   Enabled: false
 
 Style/DoubleNegation:
@@ -240,40 +352,28 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Enabled: false
 
-Layout/EmptyLineBetweenDefs:
-  Enabled: false
-
-Layout/IndentationConsistency:
-  Enabled: true
-
-Layout/IndentationWidth:
-  Enabled: true
-
-Layout/EmptyLines:
-  Enabled: false
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: false
-
 Style/EmptyLiteral:
   Enabled: false
 
-Layout/LineLength:
+Style/Encoding:
   Enabled: false
 
-Style/MethodCallWithoutArgsParentheses:
+Style/EndlessMethod:
   Enabled: true
 
-Style/MethodDefParentheses:
+Style/EvenOdd:
   Enabled: true
 
-Style/LineEndConcatenation:
+Style/For:
+  Enabled: true
+
+Style/FormatString:
+  Enabled: true
+
+Style/FormatStringToken:
   Enabled: false
 
-Layout/TrailingWhitespace:
-  Enabled: true
-
-Style/StringLiterals:
+Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/GlobalVars:
@@ -282,85 +382,71 @@ Style/GlobalVars:
 Style/GuardClause:
   Enabled: false
 
+Style/HashConversion:
+  Enabled: true
+
+Style/HashExcept:
+  Enabled: true
+
+Style/HashSyntax:
+  Enabled: false
+
 Style/IfUnlessModifier:
   Enabled: false
 
-Style/MultilineIfThen:
+Style/IfWithBooleanLiteralBranches:
   Enabled: true
 
-Style/NegatedIf:
-  Enabled: true
-
-Style/NegatedWhile:
-  Enabled: true
-
-Style/Next:
-  Enabled: false
-
-Style/SingleLineBlockParams:
-  Enabled: false
-
-Style/SingleLineMethods:
-  Enabled: false
-
-Style/SpecialGlobalVars:
-  Enabled: false
-
-
-Style/TrivialAccessors:
-  Enabled: false
-
-Style/UnlessElse:
-  Enabled: true
-
-# This pushes preference for shell commands as backticks instead of %x
-Style/RedundantPercentQ:
-  Enabled: false
-
-Style/VariableInterpolation:
-  Enabled: true
-
-Naming/VariableName:
-  Enabled: true
-
-Style/WhileUntilDo:
-  Enabled: true
-
-Style/EvenOdd:
-  Enabled: true
-
-Naming/FileName:
-  Enabled: true
-
-Style/For:
+Style/IfWithSemicolon:
   Enabled: true
 
 Style/Lambda:
   Enabled: false
 
-Naming/MethodName:
+Style/LineEndConcatenation:
   Enabled: false
 
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: true
+
+Style/MultilineIfThen:
+  Enabled: true
+
 Style/MultilineTernaryOperator:
+  Enabled: true
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NegatedIf:
+  Enabled: true
+
+Style/NegatedIfElseCondition:
+  Enabled: true
+
+Style/NegatedWhile:
   Enabled: true
 
 Style/NestedTernaryOperator:
   Enabled: true
 
+Style/Next:
+  Enabled: false
+
 Style/NilComparison:
   Enabled: true
 
-Style/FormatString:
+Style/NilLambda:
   Enabled: true
-
-Style/MultilineBlockChain:
-  Enabled: true
-
-Style/Semicolon:
-  Enabled: true
-
-Style/SignalException:
-  Enabled: false
 
 Style/NonNilCheck:
   Enabled: true
@@ -374,8 +460,8 @@ Style/NumericLiterals:
 Style/OneLineConditional:
   Enabled: true
 
-Naming/BinaryOperatorParameterName:
-  Enabled: true
+Style/OptionalBooleanParameter:
+  Enabled: false
 
 Style/ParenthesesAroundCondition:
   Enabled: true
@@ -386,14 +472,8 @@ Style/PercentLiteralDelimiters:
 Style/PerlBackrefs:
   Enabled: false
 
-Naming/PredicateName:
+Style/PreferredHashMethods:
   Enabled: false
-
-Style/RedundantException:
-  Enabled: true
-
-Style/SelfAssignment:
-  Enabled: true
 
 Style/Proc:
   Enabled: true
@@ -401,91 +481,71 @@ Style/Proc:
 Style/RaiseArgs:
   Enabled: true
 
+Style/RedundantArgument:
+  Enabled: true
+
 Style/RedundantBegin:
   Enabled: true
 
-Style/RescueModifier:
+Style/RedundantException:
   Enabled: true
+
+Style/RedundantPercentQ:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: false
+
+Style/RedundantSelf:
+  Enabled: false
 
 Style/RegexpLiteral:
   Enabled: false
 
-Lint/UnderscorePrefixedVariableName:
+Style/RescueModifier:
   Enabled: true
 
-Metrics/ParameterLists:
+Style/SelfAssignment:
   Enabled: true
 
-Lint/RequireParentheses:
+Style/Semicolon:
   Enabled: true
 
-Style/ModuleFunction:
+Style/SignalException:
   Enabled: false
 
-Lint/Debugger:
+Style/SingleLineBlockParams:
   Enabled: false
 
-Style/IfWithSemicolon:
-  Enabled: true
-
-Style/Encoding:
+Style/SingleLineMethods:
   Enabled: false
 
-Gemspec/DateAssignment:
-  Enabled: true
-Layout/SpaceBeforeBrackets:
-  Enabled: true
-Lint/AmbiguousAssignment:
-  Enabled: true
-Lint/DeprecatedConstants:
-  Enabled: true
-Lint/DuplicateBranch:
-  Enabled: true
-Lint/DuplicateRegexpCharacterClassElement:
-  Enabled: true
-Lint/EmptyBlock:
-  Enabled: true
-Lint/EmptyClass:
-  Enabled: true
-Lint/LambdaWithoutLiteralBlock:
-  Enabled: true
-Lint/NoReturnInBeginEndBlocks:
-  Enabled: true
-Lint/NumberedParameterAssignment:
-  Enabled: true
-Lint/OrAssignmentToConstant:
-  Enabled: true
-Lint/RedundantDirGlobSort:
-  Enabled: true
-Lint/SymbolConversion:
-  Enabled: true
-Lint/ToEnumArguments:
-  Enabled: true
-Lint/TripleQuotes:
-  Enabled: true
-Lint/UnexpectedBlockArity:
-  Enabled: true
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: true
-Style/ArgumentsForwarding:
-  Enabled: true
-Style/CollectionCompact:
-  Enabled: true
-Style/DocumentDynamicEvalDefinition:
-  Enabled: true
-Style/EndlessMethod:
-  Enabled: true
-Style/HashConversion:
-  Enabled: true
-Style/HashExcept:
-  Enabled: true
-Style/IfWithBooleanLiteralBranches:
-  Enabled: true
-Style/NegatedIfElseCondition:
-  Enabled: true
-Style/NilLambda:
-  Enabled: true
-Style/RedundantArgument:
-  Enabled: true
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
 Style/SwapValues:
   Enabled: true
+
+Style/TrivialAccessors:
+  Enabled: false
+
+Style/UnlessElse:
+  Enabled: true
+
+Style/VariableInterpolation:
+  Enabled: true
+
+Style/WhenThen:
+  Enabled: false
+
+Style/WhileUntilDo:
+  Enabled: true
+
+Style/WhileUntilModifier:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- Refresh gem dependencies with recent versions
+- Remove deprecated spec usage.
 
-## [0.99.76] - 2021-03-21
+## [0.99.76] - 2021-03-01
 ### Added
 - (PA-3531) Add support for RedHat 8 ppc64le
 - (RE-11821) Create a configuration-validation hook after a pl:fetch

--- a/lib/packaging.rb
+++ b/lib/packaging.rb
@@ -1,6 +1,5 @@
 module Pkg
-
-  LIBDIR = File.expand_path(File.dirname(__FILE__))
+  LIBDIR = __dir__
 
   $:.unshift(LIBDIR) unless
     $:.include?(File.dirname(__FILE__)) || $:.include?(LIBDIR)

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -3,193 +3,192 @@ require "packaging/platforms"
 # These are all of the parameters known to our packaging system.
 # They are ingested by the config class as class instance variables
 module Pkg::Params
-  BUILD_PARAMS = [:allow_dirty_tree,
-                  :answer_override,
-                  :apt_archive_path,
-                  :apt_archive_repo_command,
-                  :apt_host,
-                  :apt_releases,
-                  :apt_repo_command,
-                  :apt_repo_name,
-                  :apt_repo_path,
-                  :apt_repo_staging_path,
-                  :apt_repo_url,
-                  :apt_signing_server,
-                  :apt_staging_server,
-                  :author,
-                  :benchmark,
-                  :build_data_repo,
-                  :build_date,
-                  :build_defaults,
-                  :build_dmg,
-                  :build_doc,
-                  :build_gem,
-                  :build_ips,
-                  :build_msi,
-                  :build_pe,
-                  :build_tar,
-                  :builder_data_file,
-                  :builds_server,
-                  :bundle_platforms,
-                  :certificate_pem,
-                  :cows,
-                  :db_table,
-                  :deb_build_host,
-                  :deb_build_mirrors,
-                  :deb_targets,
-                  :debug,
-                  :debversion,
-                  :default_cow,
-                  :default_mock,
-                  :dev_build,
-                  :description,
-                  :distribution_server,
-                  :dmg_host,
-                  :dmg_path,
-                  :dmg_staging_server,
-                  :downloads_archive_path,
-                  :email,
-                  :files,
-                  :final_mocks,
-                  :foss_only,
-                  :foss_platforms,
-                  :freight_archive_path,
-                  :freight_conf,
-                  :gem_default_executables,
-                  :gem_dependencies,
-                  :gem_description,
-                  :gem_devel_dependencies,
-                  :gem_development_dependencies,
-                  :gem_excludes,
-                  :gem_executables,
-                  :gem_files,
-                  :gem_forge_project,
-                  :gem_host,
-                  :gem_name,
-                  :gem_path,
-                  :gem_platform_dependencies,
-                  :gem_rdoc_options,
-                  :gem_require_path,
-                  :gem_required_ruby_version,
-                  :gem_required_rubygems_version,
-                  :gem_runtime_dependencies,
-                  :gem_summary,
-                  :gem_test_files,
-                  :gemversion,
-                  :gpg_key,
-                  :gpg_name,
-                  :homepage,
-                  :internal_gem_host,
-                  :ips_build_host,
-                  :ips_host,
-                  :ips_inter_cert,
-                  :ips_package_host,
-                  :ips_path,
-                  :ips_repo,
-                  :ips_root_cert,
-                  :ips_signing_cert,
-                  :ips_signing_key,
-                  :ips_signing_server,
-                  :ips_signing_ssh_key,
-                  :ips_store,
-                  :jenkins_build_host,
-                  :jenkins_packaging_job,
-                  :jenkins_repo_path,
-                  :metrics,
-                  :metrics_url,
-                  :msi_host,
-                  :msi_name,
-                  :msi_path,
-                  :msi_signing_cert,
-                  :msi_signing_cert_pw,
-                  :msi_signing_server,
-                  :msi_signing_ssh_key,
-                  :msi_staging_server,
-                  :name,
-                  :nonfinal_apt_repo_command,
-                  :nonfinal_apt_repo_path,
-                  :nonfinal_apt_repo_staging_path,
-                  :nonfinal_dmg_path,
-                  :nonfinal_gem_path,
-                  :nonfinal_ips_path,
-                  :nonfinal_msi_path,
-                  :nonfinal_p5p_path,
-                  :nonfinal_repo_name,
-                  :nonfinal_repo_link_target,
-                  :nonfinal_svr4_path,
-                  :nonfinal_swix_path,
-                  :nonfinal_yum_repo_path,
-                  :notify,
-                  :nuget_host,
-                  :nuget_repo_path,
-                  :origversion,
-                  :osx_build_host,
-                  :osx_signing_cert,
-                  :osx_signing_keychain,
-                  :osx_signing_keychain_pw,
-                  :osx_signing_server,
-                  :osx_signing_ssh_key,
-                  :p5p_host,
-                  :p5p_path,
-                  :packager,
-                  :packaging_repo,
-                  :packaging_root,
-                  :packaging_url,
-                  :pbuild_conf,
-                  :pe_feature_branch,
-                  :pe_release_branch,
-                  :pe_name,
-                  :pe_platforms,
-                  :pe_version,
-                  :pg_major_version,
-                  :platform_repos,
-                  :pre_tar_task,
-                  :pre_tasks,
-                  :privatekey_pem,
-                  :project,
-                  :project_root,
-                  :random_mockroot,
-                  :rc_mocks,
-                  :redis_hostname,
-                  :ref,
-                  :release,
-                  :repo_link_target,
-                  :repo_name,
-                  :rpm_build_host,
-                  :rpm_targets,
-                  :rpmrelease,
-                  :rpmversion,
-                  :rsync_servers,
-                  :s3_ship,
-                  :short_ref,
-                  :sign_tar,
-                  :signing_server,
-                  :staging_server,
-                  :summary,
-                  :svr4_host,
-                  :svr4_path,
-                  :swix_host,
-                  :swix_path,
-                  :swix_staging_server,
-                  :tar_excludes,
-                  :tar_host,
-                  :tar_staging_server,
-                  :tarball_path,
-                  :task,
-                  :team,
-                  :templates,
-                  :update_version_file,
-                  :vanagon_project,
-                  :version,
-                  :version_file,
-                  :version_strategy,
-                  :yum_archive_path,
-                  :yum_host,
-                  :yum_repo_command,
-                  :yum_repo_name,
-                  :yum_repo_path,
-                  :yum_staging_server,
-                 ]
+  BUILD_PARAMS = %i[allow_dirty_tree
+                    answer_override
+                    apt_archive_path
+                    apt_archive_repo_command
+                    apt_host
+                    apt_releases
+                    apt_repo_command
+                    apt_repo_name
+                    apt_repo_path
+                    apt_repo_staging_path
+                    apt_repo_url
+                    apt_signing_server
+                    apt_staging_server
+                    author
+                    benchmark
+                    build_data_repo
+                    build_date
+                    build_defaults
+                    build_dmg
+                    build_doc
+                    build_gem
+                    build_ips
+                    build_msi
+                    build_pe
+                    build_tar
+                    builder_data_file
+                    builds_server
+                    bundle_platforms
+                    certificate_pem
+                    cows
+                    db_table
+                    deb_build_host
+                    deb_build_mirrors
+                    deb_targets
+                    debug
+                    debversion
+                    default_cow
+                    default_mock
+                    dev_build
+                    description
+                    distribution_server
+                    dmg_host
+                    dmg_path
+                    dmg_staging_server
+                    downloads_archive_path
+                    email
+                    files
+                    final_mocks
+                    foss_only
+                    foss_platforms
+                    freight_archive_path
+                    freight_conf
+                    gem_default_executables
+                    gem_dependencies
+                    gem_description
+                    gem_devel_dependencies
+                    gem_development_dependencies
+                    gem_excludes
+                    gem_executables
+                    gem_files
+                    gem_forge_project
+                    gem_host
+                    gem_name
+                    gem_path
+                    gem_platform_dependencies
+                    gem_rdoc_options
+                    gem_require_path
+                    gem_required_ruby_version
+                    gem_required_rubygems_version
+                    gem_runtime_dependencies
+                    gem_summary
+                    gem_test_files
+                    gemversion
+                    gpg_key
+                    gpg_name
+                    homepage
+                    internal_gem_host
+                    ips_build_host
+                    ips_host
+                    ips_inter_cert
+                    ips_package_host
+                    ips_path
+                    ips_repo
+                    ips_root_cert
+                    ips_signing_cert
+                    ips_signing_key
+                    ips_signing_server
+                    ips_signing_ssh_key
+                    ips_store
+                    jenkins_build_host
+                    jenkins_packaging_job
+                    jenkins_repo_path
+                    metrics
+                    metrics_url
+                    msi_host
+                    msi_name
+                    msi_path
+                    msi_signing_cert
+                    msi_signing_cert_pw
+                    msi_signing_server
+                    msi_signing_ssh_key
+                    msi_staging_server
+                    name
+                    nonfinal_apt_repo_command
+                    nonfinal_apt_repo_path
+                    nonfinal_apt_repo_staging_path
+                    nonfinal_dmg_path
+                    nonfinal_gem_path
+                    nonfinal_ips_path
+                    nonfinal_msi_path
+                    nonfinal_p5p_path
+                    nonfinal_repo_name
+                    nonfinal_repo_link_target
+                    nonfinal_svr4_path
+                    nonfinal_swix_path
+                    nonfinal_yum_repo_path
+                    notify
+                    nuget_host
+                    nuget_repo_path
+                    origversion
+                    osx_build_host
+                    osx_signing_cert
+                    osx_signing_keychain
+                    osx_signing_keychain_pw
+                    osx_signing_server
+                    osx_signing_ssh_key
+                    p5p_host
+                    p5p_path
+                    packager
+                    packaging_repo
+                    packaging_root
+                    packaging_url
+                    pbuild_conf
+                    pe_feature_branch
+                    pe_release_branch
+                    pe_name
+                    pe_platforms
+                    pe_version
+                    pg_major_version
+                    platform_repos
+                    pre_tar_task
+                    pre_tasks
+                    privatekey_pem
+                    project
+                    project_root
+                    random_mockroot
+                    rc_mocks
+                    redis_hostname
+                    ref
+                    release
+                    repo_link_target
+                    repo_name
+                    rpm_build_host
+                    rpm_targets
+                    rpmrelease
+                    rpmversion
+                    rsync_servers
+                    s3_ship
+                    short_ref
+                    sign_tar
+                    signing_server
+                    staging_server
+                    summary
+                    svr4_host
+                    svr4_path
+                    swix_host
+                    swix_path
+                    swix_staging_server
+                    tar_excludes
+                    tar_host
+                    tar_staging_server
+                    tarball_path
+                    task
+                    team
+                    templates
+                    update_version_file
+                    vanagon_project
+                    version
+                    version_file
+                    version_strategy
+                    yum_archive_path
+                    yum_host
+                    yum_repo_command
+                    yum_repo_name
+                    yum_repo_path
+                    yum_staging_server]
 
   # Environment variable overrides for Pkg::Config parameters
   #
@@ -198,113 +197,113 @@ module Pkg::Params
   #           Note: :type is assumed :string if not present
   #
   ENV_VARS = [
-              { :var => :allow_dirty_tree,        :envvar => :ALLOW_DIRTY_TREE, :type => :bool },
-              { :var => :answer_override,         :envvar => :ANSWER_OVERRIDE },
-              { :var => :apt_archive_path,        :envvar => :APT_ARCHIVE_PATH },
-              { :var => :apt_archive_repo_command, :envvar => :APT_ARCHIVE_REPO_COMMAND },
-              { :var => :apt_host,                :envvar => :APT_HOST },
-              { :var => :apt_releases,            :envvar => :APT_RELEASES,    :type => :array },
-              { :var => :apt_repo_path,           :envvar => :APT_REPO },
-              { :var => :apt_repo_staging_path,   :envvar => :APT_REPO_STAGING_PATH },
-              { :var => :apt_signing_server,      :envvar => :APT_SIGNING_SERVER },
-              { :var => :apt_staging_server,      :envvar => :APT_STAGING_SERVER },
-              { :var => :build_data_repo,         :envvar => :BUILD_DATA_REPO },
-              { :var => :build_dmg,               :envvar => :DMG,             :type => :bool },
-              { :var => :build_doc,               :envvar => :DOC,             :type => :bool },
-              { :var => :build_gem,               :envvar => :GEM,             :type => :bool },
-              { :var => :build_ips,               :envvar => :IPS,             :type => :bool },
-              { :var => :build_msi,               :envvar => :MSI,             :type => :bool },
-              { :var => :build_pe,                :envvar => :PE_BUILD,        :type => :bool },
-              { :var => :build_tar,               :envvar => :TAR,             :type => :bool },
-              { :var => :certificate_pem,         :envvar => :CERT_PEM },
-              { :var => :cows,                    :envvar => :COW },
-              { :var => :debug,                   :envvar => :DEBUG,           :type => :bool },
-              { :var => :default_cow,             :envvar => :COW },
-              { :var => :default_mock,            :envvar => :MOCK },
-              { :var => :dev_build,               :envvar => :DEV_BUILD,       :type => :bool },
-              { :var => :dmg_host,                :envvar => :DMG_HOST },
-              { :var => :dmg_path,                :envvar => :DMG_PATH },
-              { :var => :dmg_staging_server,      :envvar => :DMG_STAGING_SERVER },
-              { :var => :downloads_archive_path,  :envvar => :DOWNLOADS_ARCHIVE_PATH },
-              { :var => :final_mocks,             :envvar => :MOCK },
-              { :var => :foss_only,               :envvar => :FOSS_ONLY,       :type => :bool },
-              { :var => :foss_platforms,          :envvar => :FOSS_PLATFORMS,  :type => :array },
-              { :var => :freight_archive_path,    :envvar => :FREIGHT_ARCHIVE_PATH },
-              { :var => :gem_host,                :envvar => :GEM_HOST },
-              { :var => :gpg_key,                 :envvar => :GPG_KEY },
-              { :var => :gpg_name,                :envvar => :GPG_NAME },
-              { :var => :ips_host,                :envvar => :IPS_HOST },
-              { :var => :ips_inter_cert,          :envvar => :IPS_INTER_CERT },
-              { :var => :ips_path,                :envvar => :IPS_PATH },
-              { :var => :ips_repo,                :envvar => :IPS_REPO },
-              { :var => :ips_root_cert,           :envvar => :IPS_ROOT_CERT },
-              { :var => :ips_signing_cert,        :envvar => :IPS_SIGNING_CERT },
-              { :var => :ips_signing_key,         :envvar => :IPS_SIGNING_KEY },
-              { :var => :ips_signing_server,      :envvar => :IPS_SIGNING_SERVER },
-              { :var => :ips_signing_ssh_key,     :envvar => :IPS_SIGNING_SSH_KEY },
-              { :var => :msi_host,                :envvar => :MSI_HOST },
-              { :var => :msi_path,                :envvar => :MSI_PATH },
-              { :var => :msi_signing_cert,        :envvar => :MSI_SIGNING_CERT },
-              { :var => :msi_signing_cert_pw,     :envvar => :MSI_SIGNING_CERT_PW },
-              { :var => :msi_signing_server,      :envvar => :MSI_SIGNING_SERVER },
-              { :var => :msi_signing_ssh_key,     :envvar => :MSI_SIGNING_SSH_KEY },
-              { :var => :msi_staging_server,      :envvar => :MSI_STAGING_SERVER },
-              { :var => :nonfinal_apt_repo_command, :envvar => :NONFINAL_APT_REPO_COMMAND },
-              { :var => :nonfinal_apt_repo_path,  :envvar => :NONFINAL_APT_REPO_PATH },
-              { :var => :nonfinal_apt_repo_staging_path, :envvar => :NONFINAL_APT_REPO_STAGING_PATH },
-              { :var => :nonfinal_dmg_path,       :envvar => :NONFINAL_DMG_PATH },
-              { :var => :nonfinal_gem_path,       :envvar => :NONFINAL_GEM_PATH },
-              { :var => :nonfinal_ips_path,       :envvar => :NONFINAL_IPS_PATH },
-              { :var => :nonfinal_msi_path,       :envvar => :NONFINAL_MSI_PATH },
-              { :var => :nonfinal_p5p_path,       :envvar => :NONFINAL_P5P_PATH },
-              { :var => :nonfinal_repo_link_target, :envvar => :NONFINAL_REPO_LINK_TARGET },
-              { :var => :nonfinal_repo_name,      :envvar => :NONFINAL_REPO_NAME },
-              { :var => :nonfinal_svr4_path,      :envvar => :NONFINAL_SVR4_PATH },
-              { :var => :nonfinal_swix_path,      :envvar => :NONFINAL_SWIX_PATH },
-              { :var => :nonfinal_yum_repo_path,  :envvar => :NONFINAL_YUM_REPO_PATH },
-              { :var => :notify,                  :envvar => :NOTIFY },
-              { :var => :nuget_host,              :envvar => :NUGET_HOST },
-              { :var => :nuget_repo_path,         :envvar => :NUGET_REPO },
-              { :var => :osx_signing_cert,        :envvar => :OSX_SIGNING_CERT },
-              { :var => :osx_signing_keychain,    :envvar => :OSX_SIGNING_KEYCHAIN },
-              { :var => :osx_signing_keychain_pw, :envvar => :OSX_SIGNING_KEYCHAIN_PW },
-              { :var => :osx_signing_server,      :envvar => :OSX_SIGNING_SERVER },
-              { :var => :osx_signing_ssh_key,     :envvar => :OSX_SIGNING_SSH_KEY },
-              { :var => :p5p_host,                :envvar => :P5P_HOST },
-              { :var => :p5p_path,                :envvar => :P5P_PATH },
-              { :var => :packager,                :envvar => :PACKAGER },
-              { :var => :pbuild_conf,             :envvar => :PBUILDCONF },
-              { :var => :pe_feature_branch,       :envvar => :PE_FEATURE_BRANCH },
-              { :var => :pe_version,              :envvar => :PE_VER },
-              { :var => :privatekey_pem,          :envvar => :PRIVATE_PEM },
-              { :var => :project,                 :envvar => :PROJECT_OVERRIDE },
-              { :var => :project_root,            :envvar => :PROJECT_ROOT },
-              { :var => :random_mockroot,         :envvar => :RANDOM_MOCKROOT, :type => :bool },
-              { :var => :rc_mocks,                :envvar => :MOCK },
-              { :var => :release,                 :envvar => :RELEASE },
-              { :var => :repo_name,               :envvar => :REPO_NAME },
-              { :var => :repo_link_target,        :envvar => :REPO_LINK_TARGET },
-              { :var => :s3_ship,                 :envvar => :S3_SHIP,         :type => :bool },
-              { :var => :sign_tar,                :envvar => :SIGN_TAR,        :type => :bool },
-              { :var => :signing_server,          :envvar => :SIGNING_SERVER },
-              { :var => :staging_server,          :envvar => :STAGING_SERVER },
-              { :var => :swix_host,               :envvar => :SWIX_HOST },
-              { :var => :swix_staging_server,     :envvar => :SWIX_STAGING_SERVER },
-              { :var => :svr4_host,               :envvar => :SVR4_HOST },
-              { :var => :svr4_path,               :envvar => :SVR4_PATH },
-              { :var => :swix_path,               :envvar => :SWIX_PATH },
-              { :var => :tar_host,                :envvar => :TAR_HOST },
-              { :var => :tar_staging_server,      :envvar => :TAR_STAGING_SERVER },
-              { :var => :team,                    :envvar => :TEAM },
-              { :var => :update_version_file,     :envvar => :NEW_STYLE_PACKAGE },
-              { :var => :vanagon_project,         :envvar => :VANAGON_PROJECT, :type => :bool },
-              { :var => :version,                 :envvar => :PACKAGING_PACKAGE_VERSION },
-              { :var => :yum_archive_path,        :envvar => :YUM_ARCHIVE_PATH },
-              { :var => :yum_host,                :envvar => :YUM_HOST },
-              { :var => :yum_repo_path,           :envvar => :YUM_REPO },
-              { :var => :yum_staging_server,      :envvar => :YUM_STAGING_SERVER },
-              { :var => :internal_gem_host,       :envvar => :INTERNAL_GEM_HOST },
-             ]
+    { :var => :allow_dirty_tree, :envvar => :ALLOW_DIRTY_TREE, :type => :bool },
+    { :var => :answer_override,         :envvar => :ANSWER_OVERRIDE },
+    { :var => :apt_archive_path,        :envvar => :APT_ARCHIVE_PATH },
+    { :var => :apt_archive_repo_command, :envvar => :APT_ARCHIVE_REPO_COMMAND },
+    { :var => :apt_host,                :envvar => :APT_HOST },
+    { :var => :apt_releases,            :envvar => :APT_RELEASES, :type => :array },
+    { :var => :apt_repo_path,           :envvar => :APT_REPO },
+    { :var => :apt_repo_staging_path,   :envvar => :APT_REPO_STAGING_PATH },
+    { :var => :apt_signing_server,      :envvar => :APT_SIGNING_SERVER },
+    { :var => :apt_staging_server,      :envvar => :APT_STAGING_SERVER },
+    { :var => :build_data_repo,         :envvar => :BUILD_DATA_REPO },
+    { :var => :build_dmg,               :envvar => :DMG,             :type => :bool },
+    { :var => :build_doc,               :envvar => :DOC,             :type => :bool },
+    { :var => :build_gem,               :envvar => :GEM,             :type => :bool },
+    { :var => :build_ips,               :envvar => :IPS,             :type => :bool },
+    { :var => :build_msi,               :envvar => :MSI,             :type => :bool },
+    { :var => :build_pe,                :envvar => :PE_BUILD,        :type => :bool },
+    { :var => :build_tar,               :envvar => :TAR,             :type => :bool },
+    { :var => :certificate_pem,         :envvar => :CERT_PEM },
+    { :var => :cows,                    :envvar => :COW },
+    { :var => :debug,                   :envvar => :DEBUG, :type => :bool },
+    { :var => :default_cow,             :envvar => :COW },
+    { :var => :default_mock,            :envvar => :MOCK },
+    { :var => :dev_build,               :envvar => :DEV_BUILD, :type => :bool },
+    { :var => :dmg_host,                :envvar => :DMG_HOST },
+    { :var => :dmg_path,                :envvar => :DMG_PATH },
+    { :var => :dmg_staging_server,      :envvar => :DMG_STAGING_SERVER },
+    { :var => :downloads_archive_path,  :envvar => :DOWNLOADS_ARCHIVE_PATH },
+    { :var => :final_mocks,             :envvar => :MOCK },
+    { :var => :foss_only,               :envvar => :FOSS_ONLY,       :type => :bool },
+    { :var => :foss_platforms,          :envvar => :FOSS_PLATFORMS,  :type => :array },
+    { :var => :freight_archive_path,    :envvar => :FREIGHT_ARCHIVE_PATH },
+    { :var => :gem_host,                :envvar => :GEM_HOST },
+    { :var => :gpg_key,                 :envvar => :GPG_KEY },
+    { :var => :gpg_name,                :envvar => :GPG_NAME },
+    { :var => :ips_host,                :envvar => :IPS_HOST },
+    { :var => :ips_inter_cert,          :envvar => :IPS_INTER_CERT },
+    { :var => :ips_path,                :envvar => :IPS_PATH },
+    { :var => :ips_repo,                :envvar => :IPS_REPO },
+    { :var => :ips_root_cert,           :envvar => :IPS_ROOT_CERT },
+    { :var => :ips_signing_cert,        :envvar => :IPS_SIGNING_CERT },
+    { :var => :ips_signing_key,         :envvar => :IPS_SIGNING_KEY },
+    { :var => :ips_signing_server,      :envvar => :IPS_SIGNING_SERVER },
+    { :var => :ips_signing_ssh_key,     :envvar => :IPS_SIGNING_SSH_KEY },
+    { :var => :msi_host,                :envvar => :MSI_HOST },
+    { :var => :msi_path,                :envvar => :MSI_PATH },
+    { :var => :msi_signing_cert,        :envvar => :MSI_SIGNING_CERT },
+    { :var => :msi_signing_cert_pw,     :envvar => :MSI_SIGNING_CERT_PW },
+    { :var => :msi_signing_server,      :envvar => :MSI_SIGNING_SERVER },
+    { :var => :msi_signing_ssh_key,     :envvar => :MSI_SIGNING_SSH_KEY },
+    { :var => :msi_staging_server,      :envvar => :MSI_STAGING_SERVER },
+    { :var => :nonfinal_apt_repo_command, :envvar => :NONFINAL_APT_REPO_COMMAND },
+    { :var => :nonfinal_apt_repo_path, :envvar => :NONFINAL_APT_REPO_PATH },
+    { :var => :nonfinal_apt_repo_staging_path, :envvar => :NONFINAL_APT_REPO_STAGING_PATH },
+    { :var => :nonfinal_dmg_path,       :envvar => :NONFINAL_DMG_PATH },
+    { :var => :nonfinal_gem_path,       :envvar => :NONFINAL_GEM_PATH },
+    { :var => :nonfinal_ips_path,       :envvar => :NONFINAL_IPS_PATH },
+    { :var => :nonfinal_msi_path,       :envvar => :NONFINAL_MSI_PATH },
+    { :var => :nonfinal_p5p_path,       :envvar => :NONFINAL_P5P_PATH },
+    { :var => :nonfinal_repo_link_target, :envvar => :NONFINAL_REPO_LINK_TARGET },
+    { :var => :nonfinal_repo_name,      :envvar => :NONFINAL_REPO_NAME },
+    { :var => :nonfinal_svr4_path,      :envvar => :NONFINAL_SVR4_PATH },
+    { :var => :nonfinal_swix_path,      :envvar => :NONFINAL_SWIX_PATH },
+    { :var => :nonfinal_yum_repo_path,  :envvar => :NONFINAL_YUM_REPO_PATH },
+    { :var => :notify,                  :envvar => :NOTIFY },
+    { :var => :nuget_host,              :envvar => :NUGET_HOST },
+    { :var => :nuget_repo_path,         :envvar => :NUGET_REPO },
+    { :var => :osx_signing_cert,        :envvar => :OSX_SIGNING_CERT },
+    { :var => :osx_signing_keychain,    :envvar => :OSX_SIGNING_KEYCHAIN },
+    { :var => :osx_signing_keychain_pw, :envvar => :OSX_SIGNING_KEYCHAIN_PW },
+    { :var => :osx_signing_server,      :envvar => :OSX_SIGNING_SERVER },
+    { :var => :osx_signing_ssh_key,     :envvar => :OSX_SIGNING_SSH_KEY },
+    { :var => :p5p_host,                :envvar => :P5P_HOST },
+    { :var => :p5p_path,                :envvar => :P5P_PATH },
+    { :var => :packager,                :envvar => :PACKAGER },
+    { :var => :pbuild_conf,             :envvar => :PBUILDCONF },
+    { :var => :pe_feature_branch,       :envvar => :PE_FEATURE_BRANCH },
+    { :var => :pe_version,              :envvar => :PE_VER },
+    { :var => :privatekey_pem,          :envvar => :PRIVATE_PEM },
+    { :var => :project,                 :envvar => :PROJECT_OVERRIDE },
+    { :var => :project_root,            :envvar => :PROJECT_ROOT },
+    { :var => :random_mockroot,         :envvar => :RANDOM_MOCKROOT, :type => :bool },
+    { :var => :rc_mocks,                :envvar => :MOCK },
+    { :var => :release,                 :envvar => :RELEASE },
+    { :var => :repo_name,               :envvar => :REPO_NAME },
+    { :var => :repo_link_target,        :envvar => :REPO_LINK_TARGET },
+    { :var => :s3_ship,                 :envvar => :S3_SHIP,         :type => :bool },
+    { :var => :sign_tar,                :envvar => :SIGN_TAR,        :type => :bool },
+    { :var => :signing_server,          :envvar => :SIGNING_SERVER },
+    { :var => :staging_server,          :envvar => :STAGING_SERVER },
+    { :var => :swix_host,               :envvar => :SWIX_HOST },
+    { :var => :swix_staging_server,     :envvar => :SWIX_STAGING_SERVER },
+    { :var => :svr4_host,               :envvar => :SVR4_HOST },
+    { :var => :svr4_path,               :envvar => :SVR4_PATH },
+    { :var => :swix_path,               :envvar => :SWIX_PATH },
+    { :var => :tar_host,                :envvar => :TAR_HOST },
+    { :var => :tar_staging_server,      :envvar => :TAR_STAGING_SERVER },
+    { :var => :team,                    :envvar => :TEAM },
+    { :var => :update_version_file,     :envvar => :NEW_STYLE_PACKAGE },
+    { :var => :vanagon_project,         :envvar => :VANAGON_PROJECT, :type => :bool },
+    { :var => :version,                 :envvar => :PACKAGING_PACKAGE_VERSION },
+    { :var => :yum_archive_path,        :envvar => :YUM_ARCHIVE_PATH },
+    { :var => :yum_host,                :envvar => :YUM_HOST },
+    { :var => :yum_repo_path,           :envvar => :YUM_REPO },
+    { :var => :yum_staging_server,      :envvar => :YUM_STAGING_SERVER },
+    { :var => :internal_gem_host,       :envvar => :INTERNAL_GEM_HOST }
+  ]
   # Default values that are supplied if the user does not supply them
   #
   # usage is the same as above
@@ -343,25 +342,25 @@ module Pkg::Params
   #
   REASSIGNMENTS = [
                     # These are fall-through values for shipping endpoints
-                    { :oldvar => :staging_server,         :newvar => :apt_staging_server },
-                    { :oldvar => :staging_server,         :newvar => :dmg_staging_server },
-                    { :oldvar => :staging_server,         :newvar => :swix_staging_server },
-                    { :oldvar => :staging_server,         :newvar => :tar_staging_server },
-                    { :oldvar => :staging_server,         :newvar => :yum_staging_server },
+    { :oldvar => :staging_server, :newvar => :apt_staging_server },
+    { :oldvar => :staging_server,         :newvar => :dmg_staging_server },
+    { :oldvar => :staging_server,         :newvar => :swix_staging_server },
+    { :oldvar => :staging_server,         :newvar => :tar_staging_server },
+    { :oldvar => :staging_server,         :newvar => :yum_staging_server },
                     # These are fall-through values for signing/repo endpoints
-                    { :oldvar => :yum_staging_server,     :newvar => :yum_host },
-                    { :oldvar => :apt_repo_staging_path,  :newvar => :apt_repo_path },
-                    { :oldvar => :apt_signing_server,     :newvar => :apt_host },
+    { :oldvar => :yum_staging_server,     :newvar => :yum_host },
+    { :oldvar => :apt_repo_staging_path,  :newvar => :apt_repo_path },
+    { :oldvar => :apt_signing_server,     :newvar => :apt_host },
                     # These are legitimately old values
-                    { :oldvar => :gem_devel_dependencies, :newvar => :gem_development_dependencies },
-                    { :oldvar => :gpg_name,               :newvar => :gpg_key },
-                    { :oldvar => :name,                   :newvar => :project },
-                    { :oldvar => :pe_name,                :newvar => :project },
-                    { :oldvar => :project,                :newvar => :gem_name },
-                    { :oldvar => :yum_host,               :newvar => :swix_host },
-                    { :oldvar => :yum_host,               :newvar => :dmg_host },
-                    { :oldvar => :yum_host,               :newvar => :tar_host },
-                 ]
+    { :oldvar => :gem_devel_dependencies, :newvar => :gem_development_dependencies },
+    { :oldvar => :gpg_name,               :newvar => :gpg_key },
+    { :oldvar => :name,                   :newvar => :project },
+    { :oldvar => :pe_name,                :newvar => :project },
+    { :oldvar => :project,                :newvar => :gem_name },
+    { :oldvar => :yum_host,               :newvar => :swix_host },
+    { :oldvar => :yum_host,               :newvar => :dmg_host },
+    { :oldvar => :yum_host,               :newvar => :tar_host }
+  ]
 
 
   # These are variables that we have deprecated. If they are encountered in a
@@ -383,5 +382,4 @@ module Pkg::Params
   VALIDATIONS = [
     { :var => :project, :validations => [:not_empty?] }
   ]
-
 end

--- a/lib/packaging/config/validations.rb
+++ b/lib/packaging/config/validations.rb
@@ -1,12 +1,10 @@
 module Pkg
   class ConfigValidations
-
     class << self
-
       # As a validation, this one is kindof lame but is intended as a seed pattern for possibly
       # more robust ones.
       def not_empty?(value)
-        value.to_s.empty? ? false : true
+        !value.to_s.empty?
       end
     end
   end

--- a/lib/packaging/deb.rb
+++ b/lib/packaging/deb.rb
@@ -8,6 +8,7 @@ module Pkg::Deb
       if elements.nil?
         fail "Didn't get a matching cow, e.g. 'base-squeeze-i386'"
       end
+
       dist = elements[1]
       arch = elements[2]
       if Pkg::Config.build_pe

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -2,9 +2,7 @@
 require 'fileutils'
 
 module Pkg::Deb::Repo
-
   class << self
-
     # This is the default set of arches we are using for our reprepro repos. We
     # take this list and combine it with the list of supported arches for each
     # given platform to ensure a complete set of architectures. We use this
@@ -43,7 +41,7 @@ module Pkg::Deb::Repo
       # First test if the directory even exists
       #
       begin
-        stdout, _, _ = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 1 --no-parent #{repo_base} 2>&1")
+        stdout, = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 1 --no-parent #{repo_base} 2>&1")
       rescue RuntimeError
         warn "No debian repos available for #{Pkg::Config.project} at #{Pkg::Config.ref}."
         return
@@ -61,8 +59,9 @@ module Pkg::Deb::Repo
       repo_urls.each do |url|
         # We want to skip the base_url, which wget returns as one of the results
         next if "#{url}/" == repo_base
+
         platform_tag = Pkg::Paths.tag_from_artifact_path(url)
-        platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
+        platform, version, = Pkg::Platforms.parse_platform_tag(platform_tag)
         codename = Pkg::Platforms.codename_for_platform_version(platform, version)
         repoconfig = ["# Packages for #{Pkg::Config.project} built from ref #{Pkg::Config.ref}",
                       "deb #{url} #{codename} #{reprepro_repo_name}"]
@@ -76,9 +75,9 @@ module Pkg::Deb::Repo
       wget = Pkg::Util::Tool.check_tool("wget")
       FileUtils.mkdir_p("pkg/#{target}")
       config_url = "#{base_url}/#{target}/deb/"
-      stdout, _, _ = Pkg::Util::Execution.capture3("#{wget} -r -np -nH --cut-dirs 3 -P pkg/#{target} --reject 'index*' #{config_url}")
+      stdout, = Pkg::Util::Execution.capture3("#{wget} -r -np -nH --cut-dirs 3 -P pkg/#{target} --reject 'index*' #{config_url}")
       stdout
-    rescue => e
+    rescue StandardError => e
       fail "Couldn't retrieve deb apt repo configs.\n#{e}"
     end
 
@@ -95,13 +94,13 @@ module Pkg::Deb::Repo
 
       artifact_paths.each do |path|
         platform_tag = Pkg::Paths.tag_from_artifact_path(path)
-        platform, version, _ = Pkg::Platforms. parse_platform_tag(platform_tag)
+        platform, version, = Pkg::Platforms.parse_platform_tag(platform_tag)
         codename = Pkg::Platforms.codename_for_platform_version(platform, version)
         arches = Pkg::Platforms.arches_for_codename(codename)
 
         cmd << "mkdir -p #{codename}/conf && "
         cmd << "pushd #{codename} ; "
-        cmd << %Q( [ -e 'conf/distributions' ] || echo "
+        cmd << %( [ -e 'conf/distributions' ] || echo "
 Origin: Puppet Labs
 Label: Puppet Labs
 Codename: #{codename}
@@ -139,7 +138,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; )
     end
 
     def ship_repo_configs(target = "repo_configs")
-      if (!File.exist?("pkg/#{target}/deb")) || Pkg::Util::File.empty_dir?("pkg/#{target}/deb")
+      if !File.exist?("pkg/#{target}/deb") || Pkg::Util::File.empty_dir?("pkg/#{target}/deb")
         warn "No repo configs have been generated! Try pl:deb_repo_configs."
         return
       end
@@ -166,6 +165,7 @@ Description: Apt repository for acceptance testing" >> conf/distributions ; )
 
       dists.each do |dist|
         next unless supported_codenames.include?(dist)
+
         arches = Pkg::Platforms.arches_for_codename(dist)
         Dir.chdir("#{target}/apt/#{dist}") do
           File.open("conf/distributions", "w") do |f|
@@ -178,7 +178,7 @@ Description: #{message} for #{dist}
 SignWith: #{Pkg::Config.gpg_key}"
           end
 
-          stdout, _, _ = Pkg::Util::Execution.capture3("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
+          stdout, = Pkg::Util::Execution.capture3("#{reprepro} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
           stdout
         end
       end
@@ -204,7 +204,7 @@ SignWith: #{Pkg::Config.gpg_key}"
       # You may think "rsync doesn't actually remove the sticky bit, let's
       # remove the Dugo-s from the chmod". However, that will make your rsyncs
       # fail due to permission errors.
-      options = %w(
+      options = %w[
         rsync
         --itemize-changes
         --hard-links
@@ -222,15 +222,15 @@ SignWith: #{Pkg::Config.gpg_key}"
         --no-group
         --exclude='dists/*-*'
         --exclude='pool/*-*'
-      )
+      ]
 
       options << '--dry-run' if dryrun
       options << path
-      if !destination.nil?
-        options << "#{destination}:#{dest_path.parent}"
-      else
-        options << "#{dest_path.parent}"
-      end
+      options << if destination.nil?
+                   dest_path.parent.to_s
+                 else
+                   "#{destination}:#{dest_path.parent}"
+                 end
       options.join("\s")
     end
 
@@ -259,6 +259,5 @@ SignWith: #{Pkg::Config.gpg_key}"
         Pkg::Util::Net.remote_execute(destination_server, cp_command)
       end
     end
-
   end
 end

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -21,7 +21,7 @@ module Pkg::Gem
         data['number'] == gem_version && data['platform'] == gem_platform
       end
       return !gem.empty?
-    rescue => e
+    rescue StandardError => e
       puts "Something went wrong searching for gem '#{gem_name}':"
       puts e
       puts "Perhaps you're shipping '#{gem_name}' for the first time?"
@@ -49,7 +49,7 @@ module Pkg::Gem
       gem_push_command << " --host #{options[:host]}" if options[:host]
       gem_push_command << " --key #{options[:key]}" if options[:key]
       Pkg::Util::Execution.capture3(gem_push_command)
-    rescue => e
+    rescue StandardError => e
       puts "###########################################"
       puts "#  Publishing to rubygems failed. Make sure your .gem/credentials"
       puts "#  file is set up and you are an owner of #{Pkg::Config.gem_name}"

--- a/lib/packaging/metrics.rb
+++ b/lib/packaging/metrics.rb
@@ -3,13 +3,13 @@ module Pkg::Metrics
 
   def update_release_metrics
     metrics_repo = 'release-metrics'
-    command = <<CMD
-git clone git@github.com:puppetlabs/#{metrics_repo}.git
-cd #{metrics_repo}
-bundle exec add-release --date #{Pkg::Util::Date.today} --project #{Pkg::Config.project} --version #{Pkg::Config.ref}
-cd ..
-rm -r #{metrics_repo}
-CMD
+    command = <<~CMD
+      git clone git@github.com:puppetlabs/#{metrics_repo}.git
+      cd #{metrics_repo}
+      bundle exec add-release --date #{Pkg::Util::Date.today} --project #{Pkg::Config.project} --version #{Pkg::Config.ref}
+      cd ..
+      rm -r #{metrics_repo}
+    CMD
     Pkg::Util::Execution.capture3(command, true)
   end
 end

--- a/lib/packaging/nuget.rb
+++ b/lib/packaging/nuget.rb
@@ -23,7 +23,7 @@ module Pkg::Nuget
       form_data = ["-H 'Authorization: Basic #{authentication}'", "-f"]
       packages.each do |pkg|
         puts "Working on package #{pkg}"
-        projname, version = File.basename(pkg).match(/^(.*)-([\d+\.]+)\.nupkg$/).captures
+        projname, version = File.basename(pkg).match(/^(.*)-([\d+.]+)\.nupkg$/).captures
         package_form_data = ["--upload-file #{pkg}"]
         package_path = "#{projname}/#{version}/#{File.basename(pkg)}"
         stdout = ''
@@ -32,6 +32,7 @@ module Pkg::Nuget
           stdout, retval = Pkg::Util::Net.curl_form_data("#{uri}/#{package_path}", form_data + package_form_data)
         end
         fail "The Package upload (curl) failed with error #{retval}" unless Pkg::Util::Execution.success?(retval)
+
         stdout
       end
     end

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -4,7 +4,6 @@ require 'set'
 # explicitly supports
 module Pkg
   module Platforms
-
     module_function
 
     DEBIAN_SOURCE_FORMATS = ['debian.tar.gz', 'orig.tar.gz', 'dsc', 'changes']
@@ -17,15 +16,15 @@ module Pkg
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
-          repo: false,
+          repo: false
         },
         '7.1' => {
           architectures: ['power'],
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
-          repo: false,
-        },
+          repo: false
+        }
       },
 
       'cisco-wrlinux' => {
@@ -35,7 +34,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
+          repo: true
         },
         '7' => {
           architectures: ['x86_64'],
@@ -43,8 +42,8 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
-        },
+          repo: true
+        }
       },
 
       'debian' => {
@@ -54,7 +53,7 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
+          repo: true
         },
         '9' => {
           codename: 'stretch',
@@ -62,7 +61,7 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
+          repo: true
         },
         '10' => {
           codename: 'buster',
@@ -70,8 +69,8 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
+          repo: true
+        }
       },
 
       'el' => {
@@ -81,7 +80,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v3',
-          repo: true,
+          repo: true
         },
         '6' => {
           architectures: ['x86_64', 'i386'],
@@ -89,7 +88,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
+          repo: true
         },
         '7' => {
           architectures: ['x86_64', 'ppc64le', 'aarch64'],
@@ -97,7 +96,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
+          repo: true
         },
         '8' => {
           architectures: ['x86_64', 'ppc64le', 'aarch64'],
@@ -105,7 +104,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
+          repo: true
         }
       },
 
@@ -113,8 +112,8 @@ module Pkg
         '4' => {
           architectures: ['i386'],
           package_format: 'swix',
-          repo: false,
-        },
+          repo: false
+        }
       },
 
       'fedora' => {
@@ -124,7 +123,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
+          repo: true
         },
         '31' => {
           architectures: ['x86_64'],
@@ -132,7 +131,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
+          repo: true
         },
         '32' => {
           architectures: ['x86_64'],
@@ -140,26 +139,26 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
-        },
+          repo: true
+        }
       },
 
       'osx' => {
         '10.13' => {
           architectures: ['x86_64'],
           package_format: 'dmg',
-          repo: false,
+          repo: false
         },
         '10.14' => {
           architectures: ['x86_64'],
           package_format: 'dmg',
-          repo: false,
+          repo: false
         },
         '10.15' => {
           architectures: ['x86_64'],
           package_format: 'dmg',
-          repo: false,
-        },
+          repo: false
+        }
       },
 
       'redhatfips' => {
@@ -169,7 +168,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v3',
-          repo: true,
+          repo: true
         }
       },
 
@@ -180,7 +179,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v3',
-          repo: true,
+          repo: true
         },
         '12' => {
           architectures: ['x86_64', 'ppc64le'],
@@ -188,7 +187,7 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
+          repo: true
         },
         '15' => {
           architectures: ['x86_64', 'ppc64le'],
@@ -196,21 +195,21 @@ module Pkg
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],
           signature_format: 'v4',
-          repo: true,
-        },
+          repo: true
+        }
       },
 
       'solaris' => {
         '10' => {
           architectures: ['i386', 'sparc'],
           package_format: 'svr4',
-          repo: false,
+          repo: false
         },
         '11' => {
           architectures: ['i386', 'sparc'],
           package_format: 'ips',
-          repo: false,
-        },
+          repo: false
+        }
       },
 
       'ubuntu' => {
@@ -220,7 +219,7 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
+          repo: true
         },
         '16.04' => {
           codename: 'xenial',
@@ -228,7 +227,7 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
+          repo: true
         },
         '18.04' => {
           codename: 'bionic',
@@ -236,7 +235,7 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
+          repo: true
         },
         '18.10' => {
           codename: 'cosmic',
@@ -244,7 +243,7 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
+          repo: true
         },
         '20.04' => {
           codename: 'focal',
@@ -252,24 +251,24 @@ module Pkg
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
+          repo: true
+        }
       },
 
       'windows' => {
         '2012' => {
           architectures: ['x86', 'x64'],
           package_format: 'msi',
-          repo: false,
+          repo: false
         }
       },
       'windowsfips' => {
         '2012' => {
           architectures: ['x64'],
           package_format: 'msi',
-          repo: false,
+          repo: false
         }
-      },
+      }
     }.freeze
 
     # @return [Array] An array of Strings, containing all of the supported
@@ -282,7 +281,7 @@ module Pkg
     #   versions for the given platform
     def versions_for_platform(platform)
       PLATFORM_INFO[platform].keys
-    rescue
+    rescue StandardError
       raise "No information found for '#{platform}'"
     end
 
@@ -324,7 +323,7 @@ module Pkg
       # AIX uses 'ppc' as its architecture in paths and file names
       architecture = 'ppc' if platform == 'aix'
       return [platform, version, architecture]
-    rescue
+    rescue StandardError
       raise "Could not verify that '#{platform_tag}' is a valid tag"
     end
 
@@ -333,7 +332,7 @@ module Pkg
     #   platform-version-arch
     # @return [Hash] The hash of data associated with the given platform version
     def platform_lookup(platform_tag)
-      platform, version, _ = parse_platform_tag(platform_tag)
+      platform, version, = parse_platform_tag(platform_tag)
       PLATFORM_INFO[platform][version]
     end
 
@@ -345,12 +344,14 @@ module Pkg
     def get_attribute(platform_tag, attribute_name)
       info = platform_lookup(platform_tag)
       raise "#{platform_tag} doesn't have information about #{attribute_name} available" unless info.key?(attribute_name)
+
       info[attribute_name]
     end
 
     def get_attribute_for_platform_version(platform, version, attribute_name)
       info = PLATFORM_INFO[platform][version]
       raise "#{platform_tag} doesn't have information about #{attribute_name} available" unless info.key?(attribute_name)
+
       info[attribute_name]
     end
 
@@ -443,7 +444,7 @@ module Pkg
       if include_source
         begin
           source_architecture = Array(get_attribute_for_platform_version(platform, version, :source_architecture))
-        rescue
+        rescue StandardError
         end
       end
       return (platform_architectures + source_architecture).flatten

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -1,7 +1,5 @@
 module Pkg::Repo
-
   class << self
-
     ##
     ## Construct a local_target based upon the versioning style
     ##
@@ -29,6 +27,7 @@ module Pkg::Repo
         if ENV['FAIL_ON_MISSING_TARGET'] == "true"
           raise "Error: missing packages under #{repo_location}"
         end
+
         warn "Warn: Skipping #{archive_name} because #{repo_location} has no files"
         return
       end
@@ -37,7 +36,7 @@ module Pkg::Repo
         puts "Info: Archiving #{repo_location} as #{archive_name}"
         target_tarball = File.join('repos', "#{archive_name}.tar.gz")
         tar_command = "#{tar} --owner=0 --group=0 --create --gzip --file #{target_tarball} #{repo_location}"
-        stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
+        stdout, = Pkg::Util::Execution.capture3(tar_command)
         return stdout
       end
     end
@@ -68,7 +67,7 @@ module Pkg::Repo
         end
 
         tar_command = "#{tar} --owner=0 --group=0 #{tar_action} --file #{all_repos_tarball_name} #{repo_tarball_path}"
-        stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
+        stdout, = Pkg::Util::Execution.capture3(tar_command)
         puts stdout
       end
     end
@@ -81,7 +80,7 @@ module Pkg::Repo
       gzip = Pkg::Util::Tool.check_tool('gzip')
 
       gzip_command = "#{gzip} --fast #{all_repos_tarball_name}"
-      stdout, _, _ = Pkg::Util::Execution.capture3(gzip_command)
+      stdout, = Pkg::Util::Execution.capture3(gzip_command)
       puts stdout
     end
 
@@ -110,13 +109,13 @@ module Pkg::Repo
       cmd = "[ -d #{artifact_directory} ] || exit 1 ; "
       cmd << "pushd #{artifact_directory} > /dev/null && "
       cmd << "find . -name '*.#{pkg_ext}' -print0 | xargs --no-run-if-empty -0 -I {} dirname {} "
-      stdout, _ = Pkg::Util::Net.remote_execute(
-                Pkg::Config.distribution_server,
-                cmd,
-                { capture_output: true }
-              )
+      stdout, = Pkg::Util::Net.remote_execute(
+        Pkg::Config.distribution_server,
+        cmd,
+        { capture_output: true }
+      )
       return stdout.split
-    rescue => e
+    rescue StandardError => e
       fail "Error: Could not retrieve directories that contain #{pkg_ext} packages in #{Pkg::Config.distribution_server}:#{artifact_directory}"
     end
 
@@ -125,7 +124,7 @@ module Pkg::Repo
       cmd << "pushd #{artifact_parent_directory} > /dev/null && "
       cmd << 'rsync --archive --verbose --one-file-system --ignore-existing artifacts/ repos/ '
       Pkg::Util::Net.remote_execute(Pkg::Config.distribution_server, cmd)
-    rescue => e
+    rescue StandardError => e
       fail "Error: Could not populate repos directory in #{Pkg::Config.distribution_server}:#{artifact_parent_directory}"
     end
 
@@ -135,7 +134,7 @@ module Pkg::Repo
 
     def update_repo(remote_host, command, options = {})
       fail_message = "Error: Missing required argument '%s', update your build_defaults?"
-      [:repo_name, :repo_path, :repo_host, :repo_url].each do |option|
+      %i[repo_name repo_path repo_host repo_url].each do |option|
         fail fail_message % option.to_s if argument_required?(option.to_s, command) && !options[option]
       end
 
@@ -149,7 +148,8 @@ module Pkg::Repo
       }
       Pkg::Util::Net.remote_execute(
         remote_host,
-        Pkg::Util::Misc.search_and_replace(command, whitelist))
+        Pkg::Util::Misc.search_and_replace(command, whitelist)
+      )
     end
   end
 end

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -48,6 +48,7 @@ module Pkg::Rpm::Repo
 
       artifact_paths.each do |path|
         next if path.include? 'aix'
+
         cmd << "if [ -d #{path}  ]; then "
         cmd << "pushd #{path} && "
         cmd << '$createrepo --checksum=sha --checkts --update --delta-workers=0 --database . && '
@@ -75,7 +76,7 @@ module Pkg::Rpm::Repo
       path = Pathname.new(origin_path)
       dest_path = Pathname.new(destination_path)
 
-      options = %w(
+      options = %w[
         rsync
         --recursive
         --links
@@ -91,16 +92,16 @@ module Pkg::Rpm::Repo
         --no-perms
         --no-owner
         --no-group
-      )
+      ]
 
       options << '--dry-run' if dryrun
       options << path
 
-      if destination
-        options << "#{destination}:#{dest_path.parent}"
-      else
-        options << "#{dest_path.parent}"
-      end
+      options << if destination
+                   "#{destination}:#{dest_path.parent}"
+                 else
+                   dest_path.parent.to_s
+                 end
 
       options.join("\s")
     end
@@ -117,9 +118,9 @@ module Pkg::Rpm::Repo
       FileUtils.mkdir_p("pkg/#{target}")
       config_url = "#{base_url}/#{target}/rpm/"
       begin
-        stdout, _, _ = Pkg::Util::Execution.capture3("#{wget} -r -np -nH --cut-dirs 3 -P pkg/#{target} --reject 'index*' #{config_url}")
+        stdout, = Pkg::Util::Execution.capture3("#{wget} -r -np -nH --cut-dirs 3 -P pkg/#{target} --reject 'index*' #{config_url}")
         stdout
-      rescue => e
+      rescue StandardError => e
         fail "Couldn't retrieve rpm yum repo configs.\n#{e}"
       end
     end
@@ -149,7 +150,7 @@ module Pkg::Rpm::Repo
       # repodata folders in them, and second that those same directories also
       # contain rpms
       #
-      stdout, _, _ = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 5 --no-parent #{repo_base} 2>&1")
+      stdout, = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 5 --no-parent #{repo_base} 2>&1")
       stdout = stdout.split.uniq.reject { |x| x =~ /\?|index/ }.select { |x| x =~ /http:.*repodata\/$/ }
 
       # RPMs will always exist at the same directory level as the repodata
@@ -157,7 +158,7 @@ module Pkg::Rpm::Repo
       #
       yum_repos = []
       stdout.map { |x| x.chomp('repodata/') }.each do |url|
-        output, _, _ = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 1 --no-parent #{url} 2>&1")
+        output, = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 1 --no-parent #{url} 2>&1")
         unless output.split.uniq.reject { |x| x =~ /\?|index/ }.select { |x| x =~ /http:.*\.rpm$/ }.empty?
           yum_repos << url
         end
@@ -204,7 +205,7 @@ module Pkg::Rpm::Repo
     end
 
     def create_local_repos(directory = "repos")
-      stdout, _, _ = Pkg::Util::Execution.capture3("bash -c '#{repo_creation_command(directory)}'")
+      stdout, = Pkg::Util::Execution.capture3("bash -c '#{repo_creation_command(directory)}'")
       stdout
     end
 

--- a/lib/packaging/sign/dmg.rb
+++ b/lib/packaging/sign/dmg.rb
@@ -4,11 +4,11 @@ module Pkg::Sign::Dmg
   def sign(target_dir = 'pkg')
     use_identity = "-i #{Pkg::Config.osx_signing_ssh_key}" unless Pkg::Config.osx_signing_ssh_key.nil?
 
-    if Pkg::Config.osx_signing_server =~ /@/
-      host_string = "#{Pkg::Config.osx_signing_server}"
-    else
-      host_string = "#{ENV['USER']}@#{Pkg::Config.osx_signing_server}"
-    end
+    host_string = if Pkg::Config.osx_signing_server =~ /@/
+                    Pkg::Config.osx_signing_server.to_s
+                  else
+                    "#{ENV['USER']}@#{Pkg::Config.osx_signing_server}"
+                  end
     ssh_host_string = "#{use_identity} #{host_string}"
     rsync_host_string = "-e 'ssh #{use_identity}' #{host_string}"
 
@@ -18,7 +18,7 @@ module Pkg::Sign::Dmg
     Pkg::Util::Net.remote_execute(ssh_host_string, "mkdir -p #{mount} #{signed}")
     dmgs = Dir.glob("#{target_dir}/apple/**/*.dmg")
     Pkg::Util::Net.rsync_to(dmgs.join(" "), rsync_host_string, work_dir)
-    Pkg::Util::Net.remote_execute(ssh_host_string, %Q[for dmg in #{dmgs.map { |d| File.basename(d, ".dmg") }.join(" ")}; do
+    Pkg::Util::Net.remote_execute(ssh_host_string, %[for dmg in #{dmgs.map { |d| File.basename(d, '.dmg') }.join(' ')}; do
       /usr/bin/hdiutil attach #{work_dir}/$dmg.dmg -mountpoint #{mount} -nobrowse -quiet ;
       /usr/bin/security -q unlock-keychain -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" ;
         for pkg in $(ls #{mount}/*.pkg | xargs -n 1 basename); do
@@ -33,7 +33,7 @@ module Pkg::Sign::Dmg
       /bin/rm #{work_dir}/$dmg.dmg ;
       /usr/bin/hdiutil create -volname $dmg -srcfolder #{signed}/ #{work_dir}/$dmg.dmg ;
       /bin/rm #{signed}/* ; done])
-    dmgs.each do | dmg |
+    dmgs.each do |dmg|
       Pkg::Util::Net.rsync_from("#{work_dir}/#{File.basename(dmg)}", rsync_host_string, File.dirname(dmg))
     end
     Pkg::Util::Net.remote_execute(ssh_host_string, "if [ -d '#{work_dir}' ]; then rm -rf '#{work_dir}'; fi")

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -44,6 +44,7 @@ module Pkg::Sign::Rpm
     # which bails out with non-0 exit codes. Instead, check that the output
     # looks more-or-less how we expect it to.
     fail "Something went wrong checking the signature of #{rpm}." unless signature_check_output.include? "Header"
+
     return signature_check_output.include? "key ID #{key}"
   end
 
@@ -70,7 +71,7 @@ module Pkg::Sign::Rpm
     v4_rpms = []
     rpms_to_sign.each do |rpm|
       platform_tag = Pkg::Paths.tag_from_artifact_path(rpm)
-      platform, version, _ = Pkg::Platforms.parse_platform_tag(platform_tag)
+      platform, version, = Pkg::Platforms.parse_platform_tag(platform_tag)
 
       # We don't sign AIX rpms
       next if platform_tag.include?('aix')
@@ -103,6 +104,7 @@ module Pkg::Sign::Rpm
     # Using the map of paths to basenames, we re-hardlink the rpms we deleted.
     all_rpms.each do |link_path, rpm_filename|
       next if File.exist? link_path
+
       FileUtils.mkdir_p(File.dirname(link_path))
       # Find paths where the signed rpm has the same basename, but different
       # full path, as the one we need to link.

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -22,7 +22,8 @@ module Pkg::Util
   require 'packaging/util/git_tags'
 
   def self.boolean_value(var)
-    return true if var == true || ( var.is_a?(String) && ( var.downcase == 'true' || var.downcase =~ /^y$|^yes$/))
+    return true if var == true || (var.is_a?(String) && (var.downcase == 'true' || var.downcase =~ /^y$|^yes$/))
+
     return false
   end
 
@@ -53,6 +54,7 @@ module Pkg::Util
   # @raise [RuntimeError] raises an exception if the variable is not set and is required
   def self.check_var(varname, var)
     fail "Requires #{varname} be set!" if var.nil?
+
     var
   end
 
@@ -86,13 +88,14 @@ module Pkg::Util
   end
 
   def self.ask_yes_or_no(force = false)
-    unless force
-      return Pkg::Util.boolean_value(Pkg::Config.answer_override) unless Pkg::Config.answer_override.nil?
+    if !force && !Pkg::Config.answer_override.nil?
+      return Pkg::Util.boolean_value(Pkg::Config.answer_override)
     end
 
     answer = Pkg::Util.get_input
     return true if answer =~ /^y$|^yes$/
     return false if answer =~ /^n$|^no$/
+
     puts "Nope, try something like yes or no or y or n, etc:"
     Pkg::Util.ask_yes_or_no
   end
@@ -110,6 +113,7 @@ module Pkg::Util
 
   def self.filter_configs(filter = nil)
     return Pkg::Config.instance_values.select { |key, _| key.match(/#{filter}/) } if filter
+
     Pkg::Config.instance_values
   end
 

--- a/lib/packaging/util/date.rb
+++ b/lib/packaging/util/date.rb
@@ -1,14 +1,13 @@
 # Utilities for managing/querying date/time
 
 module Pkg::Util::Date
-
   class << self
     def timestamp(separator = nil)
-      if s = separator
-        format = "%Y#{s}%m#{s}%d#{s}%H#{s}%M#{s}%S"
-      else
-        format = "%Y-%m-%d %H:%M:%S"
-      end
+      format = if s = separator
+                 "%Y#{s}%m#{s}%d#{s}%H#{s}%M#{s}%S"
+               else
+                 "%Y-%m-%d %H:%M:%S"
+               end
       Time.now.strftime(format)
     end
 

--- a/lib/packaging/util/execution.rb
+++ b/lib/packaging/util/execution.rb
@@ -1,9 +1,7 @@
 # Utility methods for handling system calls and interactions
 
 module Pkg::Util::Execution
-
   class << self
-
     # Alias to $?.success? that makes success? slightly easier to test and stub
     # If immediately run, $? will not be instanciated, so only call success? if
     # $? exists, otherwise return nil
@@ -71,9 +69,9 @@ module Pkg::Util::Execution
             blk.call
             success = true
             break
-          rescue => err
+          rescue StandardError => e
             puts "An error was encountered evaluating block. Retrying.."
-            exception = err.to_s + "\n" + err.backtrace.join("\n")
+            exception = "#{e.to_s}\n#{e.backtrace.join("\n")}"
           end
         end
       else

--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -2,7 +2,6 @@
 require 'fileutils'
 
 module Pkg::Util::File
-
   class << self
     def exist?(file)
       ::File.exist?(file)
@@ -15,7 +14,7 @@ module Pkg::Util::File
 
     def mktemp
       mktemp = Pkg::Util::Tool.find_tool('mktemp', :required => true)
-      stdout, _, _ = Pkg::Util::Execution.capture3("#{mktemp} -d -t pkgXXXXXX")
+      stdout, = Pkg::Util::Execution.capture3("#{mktemp} -d -t pkgXXXXXX")
       stdout.strip
     end
 
@@ -44,6 +43,7 @@ module Pkg::Util::File
       if !exists and args[:required]
         fail "Required file #{file} could not be found"
       end
+
       exists
     end
 
@@ -52,6 +52,7 @@ module Pkg::Util::File
       if !writable and args[:required]
         fail "File #{file} is not writable"
       end
+
       writable
     end
 
@@ -79,7 +80,7 @@ module Pkg::Util::File
         target_opts = "-C #{target}"
       end
       if file_exists?(source, :required => true)
-        stdout, _, _ = Pkg::Util::Execution.capture3(%Q(#{tar} #{options} #{target_opts} -xf #{source}))
+        stdout, = Pkg::Util::Execution.capture3(%(#{tar} #{options} #{target_opts} -xf #{source}))
         stdout
       end
     end
@@ -98,11 +99,11 @@ module Pkg::Util::File
       # FileList and eliminate many lines of code and comment.
       Dir.chdir(Pkg::Config.project_root) do
         file_patterns.each do |pattern|
-          if File.directory?(pattern) and !Pkg::Util::File.empty_dir?(pattern)
-            install << Dir[pattern + "/**/*"]
-          else
-            install << Dir[pattern]
-          end
+          install << if File.directory?(pattern) and !Pkg::Util::File.empty_dir?(pattern)
+                       Dir["#{pattern}/**/*"]
+                     else
+                       Dir[pattern]
+                     end
         end
         install.flatten!
 
@@ -122,4 +123,3 @@ module Pkg::Util::File
     end
   end
 end
-

--- a/lib/packaging/util/git.rb
+++ b/lib/packaging/util/git.rb
@@ -22,7 +22,6 @@ module Pkg::Util::Git
     end
 
     # Git utility to create a new git bundle
-    # rubocop:disable Metrics/AbcSize
     def bundle(treeish, appendix = Pkg::Util.rand_string, temp = Pkg::Util::File.mktemp)
       fail_unless_repo
       Pkg::Util::Execution.capture3("#{Pkg::Util::Tool::GIT} bundle create #{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}-#{appendix} #{treeish} --tags")
@@ -113,13 +112,12 @@ module Pkg::Util::Git
       end
     end
 
-    # rubocop:disable Style/GuardClause
     def fail_unless_repo
       unless repo?
         raise "Pkg::Config.project_root (#{Pkg::Config.project_root}) is not \
           a valid git repository"
       end
-    end
+end
 
     # Return the basename of the project repo
     def project_name

--- a/lib/packaging/util/git_tags.rb
+++ b/lib/packaging/util/git_tags.rb
@@ -1,6 +1,6 @@
 module Pkg::Util
   class Git_tag
-    attr_reader :address, :ref, :ref_name, :ref_type, :branch_name
+    attr_reader :address, :ref, :ref_name, :ref_type
 
     GIT = Pkg::Util::Tool::GIT
     DEVNULL = Pkg::Util::OS::DEVNULL
@@ -43,7 +43,7 @@ module Pkg::Util
     # Fetch the full ref using ls-remote, this should raise an error if it returns non-zero
     # because that means this ref doesn't exist in the repo
     def fetch_full_ref
-      stdout, _, _ = Pkg::Util::Execution.capture3("#{GIT} ls-remote --tags --heads --exit-code #{address} #{ref}")
+      stdout, = Pkg::Util::Execution.capture3("#{GIT} ls-remote --tags --heads --exit-code #{address} #{ref}")
       stdout.split.last
     rescue RuntimeError => e
       raise "ERROR : Not a ref or sha!\n#{e}"

--- a/lib/packaging/util/gpg.rb
+++ b/lib/packaging/util/gpg.rb
@@ -1,6 +1,5 @@
 module Pkg::Util::Gpg
   class << self
-
     # Please note that this method is not used in determining what key is used
     # to sign the debian repos. That is defined in the freight config that
     # lives on our internal repo staging host. The debian conf/distribution
@@ -8,6 +7,7 @@ module Pkg::Util::Gpg
     # reflect that.
     def key
       fail "You need to set `gpg_key` in your build defaults." unless Pkg::Config.gpg_key && !Pkg::Config.gpg_key.empty?
+
       Pkg::Config.gpg_key
     end
 
@@ -31,14 +31,14 @@ module Pkg::Util::Gpg
 
     def kill_keychain
       if keychain
-        stdout, _, _ = Pkg::Util::Execution.capture3("#{keychain} -k mine")
+        stdout, = Pkg::Util::Execution.capture3("#{keychain} -k mine")
         stdout
       end
     end
 
     def start_keychain
       if keychain
-        keychain_output, _, _ = Pkg::Util::Execution.capture3("#{keychain} -q --agents gpg --eval #{key}")
+        keychain_output, = Pkg::Util::Execution.capture3("#{keychain} -q --agents gpg --eval #{key}")
         keychain_output.chomp!
         new_env = keychain_output.match(/GPG_AGENT_INFO=([^;]*)/)
         ENV["GPG_AGENT_INFO"] = new_env[1]
@@ -56,7 +56,7 @@ module Pkg::Util::Gpg
           return true
         end
         use_tty = "--no-tty --use-agent" if ENV['RPM_GPG_AGENT']
-        stdout, _, _ = Pkg::Util::Execution.capture3("#{gpg} #{use_tty} --armor --detach-sign -u #{key} #{file}")
+        stdout, = Pkg::Util::Execution.capture3("#{gpg} #{use_tty} --armor --detach-sign -u #{key} #{file}")
         stdout
       else
         fail "No gpg available. Cannot sign #{file}."

--- a/lib/packaging/util/jenkins.rb
+++ b/lib/packaging/util/jenkins.rb
@@ -3,9 +3,7 @@ require 'net/http'
 require 'json'
 
 module Pkg::Util::Jenkins
-
   class << self
-
     # Use the curl to create a jenkins job from a valid XML
     # configuration file.
     # Returns the URL to the job
@@ -25,6 +23,7 @@ module Pkg::Util::Jenkins
       form_args = ["--silent", "--fail"]
       output, retval = Pkg::Util::Net.curl_form_data(job_url, form_args, :quiet => true)
       return output if retval.nil?
+
       return Pkg::Util::Execution.success?(retval)
     end
 
@@ -64,6 +63,7 @@ module Pkg::Util::Jenkins
       unless response.code == '200'
         raise "Unable to query #{uri}, please check that it is valid."
       end
+
       return JSON.parse(response.body)
     end
 
@@ -90,6 +90,5 @@ module Pkg::Util::Jenkins
 
       wait_for_build job_hash['lastBuild']['url']
     end
-
   end
 end

--- a/lib/packaging/util/misc.rb
+++ b/lib/packaging/util/misc.rb
@@ -32,6 +32,7 @@ module Pkg::Util::Misc
       unless data.is_a?(Hash)
         raise "Hash required. Got '#{data.class}' when parsing '#{file}'"
       end
+
       # We explicity return data here b/c the unless clause above will cause the
       # Function to return nil.
       #               -Sean P. M. 05/11/2016
@@ -57,7 +58,7 @@ module Pkg::Util::Misc
     def check_rubygems_ownership(gem_name)
       require 'yaml'
       credentials = YAML.load_file("#{ENV['HOME']}/.gem/credentials")
-      gems = YAML.load(%x(curl -H 'Authorization:#{credentials[:rubygems_api_key]}' https://rubygems.org/api/v1/gems.yaml))
+      gems = YAML.safe_load(%x(curl -H 'Authorization:#{credentials[:rubygems_api_key]}' https://rubygems.org/api/v1/gems.yaml))
       gems.each do |gem|
         if gem['name'] == gem_name
           return true

--- a/lib/packaging/util/os.rb
+++ b/lib/packaging/util/os.rb
@@ -3,6 +3,8 @@
 require 'rbconfig'
 
 module Pkg::Util::OS
+  module_function
+
   def windows?
     case RbConfig::CONFIG['host_os']
     when /mswin|mingw/i
@@ -11,7 +13,6 @@ module Pkg::Util::OS
       false
     end
   end
-  module_function :windows?
 
   DEVNULL = windows? ? 'NUL' : '/dev/null'
 end

--- a/lib/packaging/util/rake_utils.rb
+++ b/lib/packaging/util/rake_utils.rb
@@ -55,6 +55,7 @@ module Pkg::Util::RakeUtils
         unless Pkg::Config.pre_tasks.is_a?(Hash)
           fail "The 'pre_tasks' key must be a Hash of depender => dependency pairs"
         end
+
         Pkg::Config.pre_tasks.each do |depender, dependency|
           add_dependency(depender, dependency)
         end

--- a/lib/packaging/util/serialization.rb
+++ b/lib/packaging/util/serialization.rb
@@ -2,18 +2,16 @@
 
 module Pkg::Util::Serialization
   class << self
-
     # Given the path to a yaml file, load the yaml file into an object and return the object.
     def load_yaml(file)
       require 'yaml'
       file = File.expand_path(file)
       begin
         input_data = YAML.load_file(file) || {}
-      rescue => e
+      rescue StandardError => e
         fail "There was an error loading data from #{file}.\n#{e}"
       end
       input_data
     end
   end
 end
-

--- a/lib/packaging/util/tool.rb
+++ b/lib/packaging/util/tool.rb
@@ -1,7 +1,6 @@
 # Utility methods for handling system binaries
 
 module Pkg::Util::Tool
-
   #   Set up utility methods for handling system binaries
   #
   class << self
@@ -15,27 +14,26 @@ module Pkg::Util::Tool
 
         if Pkg::Util::OS.windows? && File.extname(location).empty?
           exts = ENV['PATHEXT']
-          exts = exts ? exts.split(File::PATH_SEPARATOR) : %w(.EXE .BAT .CMD .COM)
+          exts = exts ? exts.split(File::PATH_SEPARATOR) : %w[.EXE .BAT .CMD .COM]
           exts.each do |ext|
             locationext = File.expand_path(location + ext)
 
-            return '"' + locationext + '"' if FileTest.executable?(locationext)
+            return "\"#{locationext}\"" if FileTest.executable?(locationext)
           end
         end
 
         return location if FileTest.executable? location
       end
       fail "#{tool} tool not found...exiting" if args[:required]
+
       return nil
     end
 
     alias :has_tool :find_tool
-
   end
 
   #   Set up paths to system tools we use in the packaging repo
   #   no matter what distribution we're packaging for.
 
   GIT = Pkg::Util::Tool.check_tool('git')
-
 end

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -15,13 +15,15 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_development_dependency('rspec', ['~> 2.14.1'])
-  gem.add_development_dependency('rubocop', ['~> 0.24.1'])
   gem.add_development_dependency('pry')
+  gem.add_development_dependency('rubocop', ['~> 1.10'])
+  gem.add_development_dependency('rspec', ['~> 3.10'])
+
+  gem.add_runtime_dependency('artifactory', ['~> 3'])
+  gem.add_runtime_dependency('csv', ['~> 3.1'])
   gem.add_runtime_dependency('rake', ['>= 12.3'])
-  gem.add_runtime_dependency('artifactory', ['~> 2'])
   gem.add_runtime_dependency('release-metrics')
-  gem.add_runtime_dependency('csv', ['3.1.5'])
+
   gem.require_path = 'lib'
 
   # Ensure the gem is built out of versioned files

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -142,8 +142,8 @@ describe "Pkg::Config" do
   describe "#new" do
     Build_Params.each do |param|
       it "should have r/w accessors for #{param}" do
-        Pkg::Config.should respond_to(param)
-        Pkg::Config.should respond_to("#{param.to_s}=")
+        expect(Pkg::Config).to respond_to(param)
+        expect(Pkg::Config).to respond_to("#{param.to_s}=")
       end
     end
   end
@@ -153,7 +153,7 @@ describe "Pkg::Config" do
     context "given a valid params hash #{good_params}" do
       it "should set instance variable values for each param" do
         good_params.each do |param, value|
-          Pkg::Config.should_receive(:instance_variable_set).with("@#{param}", value)
+          expect(Pkg::Config).to receive(:instance_variable_set).with("@#{param}", value)
         end
         Pkg::Config.config_from_hash(good_params)
       end
@@ -163,12 +163,12 @@ describe "Pkg::Config" do
     context "given an invalid params hash #{bad_params}" do
       bad_params.each do |param, value|
         it "should print a warning that param '#{param}' is not valid" do
-          Pkg::Config.should_receive(:warn).with(/No build data parameter found for '#{param}'/)
+          expect(Pkg::Config).to receive(:warn).with(/No build data parameter found for '#{param}'/)
           Pkg::Config.config_from_hash(bad_params)
         end
 
         it "should not try to set instance variable @:#{param}" do
-          Pkg::Config.should_not_receive(:instance_variable_set).with("@#{param}", value)
+          expect(Pkg::Config).not_to receive(:instance_variable_set).with("@#{param}", value)
           Pkg::Config.config_from_hash(bad_params)
         end
       end
@@ -177,17 +177,17 @@ describe "Pkg::Config" do
     mixed_params = { :sign_tar => true, :baz => 'qux' }
     context "given a hash with both valid and invalid params" do
       it "should set the valid param" do
-        Pkg::Config.should_receive(:instance_variable_set).with("@sign_tar", true)
+        expect(Pkg::Config).to receive(:instance_variable_set).with("@sign_tar", true)
         Pkg::Config.config_from_hash(mixed_params)
       end
 
       it "should issue a warning that the invalid param is not valid" do
-        Pkg::Config.should_receive(:warn).with(/No build data parameter found for 'baz'/)
+        expect(Pkg::Config).to receive(:warn).with(/No build data parameter found for 'baz'/)
         Pkg::Config.config_from_hash(mixed_params)
       end
 
       it "should not try to set instance variable @:baz" do
-        Pkg::Config.should_not_receive(:instance_variable_set).with("@baz", "qux")
+        expect(Pkg::Config).not_to receive(:instance_variable_set).with("@baz", "qux")
         Pkg::Config.config_from_hash(mixed_params)
       end
     end
@@ -196,7 +196,7 @@ describe "Pkg::Config" do
   describe "#params" do
     it "should return a hash containing keys for all build parameters" do
       params = Pkg::Config.config
-      Build_Params.each { |param| params.has_key?(param).should == true }
+      Build_Params.each { |param| expect(params.has_key?(param)).to be true }
     end
   end
 
@@ -332,9 +332,9 @@ describe "Pkg::Config" do
   describe "#config_to_yaml" do
     it "should write a valid yaml file" do
       file = double('file')
-      File.should_receive(:open).with(anything(), 'w').and_yield(file)
-      file.should_receive(:puts).with(instance_of(String))
-      YAML.should_receive(:load_file).with(file)
+      expect(File).to receive(:open).with(anything(), 'w').and_yield(file)
+      expect(file).to receive(:puts).with(instance_of(String))
+      expect(YAML).to receive(:load_file).with(file)
       expect { YAML.load_file(file) }.to_not raise_error
       Pkg::Config.config_to_yaml
     end
@@ -410,7 +410,7 @@ describe "Pkg::Config" do
   describe "#cow_list" do
     it "should return a list of the cows for a project" do
       Pkg::Config.cows = "base-lucid-i386.cow base-lucid-amd64.cow base-precise-i386.cow base-precise-amd64.cow base-quantal-i386.cow base-quantal-amd64.cow base-saucy-i386.cow base-saucy-amd64.cow base-sid-i386.cow base-sid-amd64.cow base-squeeze-i386.cow base-squeeze-amd64.cow base-stable-i386.cow base-stable-amd64.cow base-testing-i386.cow base-testing-amd64.cow base-trusty-i386.cow base-trusty-amd64.cow base-unstable-i386.cow base-unstable-amd64.cow base-wheezy-i386.cow base-wheezy-amd64.cow"
-      Pkg::Config.cow_list.should eq "lucid precise quantal saucy sid squeeze stable testing trusty unstable wheezy"
+      expect(Pkg::Config.cow_list).to eq "lucid precise quantal saucy sid squeeze stable testing trusty unstable wheezy"
     end
   end
 
@@ -441,27 +441,27 @@ describe "Pkg::Config" do
     it "should set tar_host to staging_server" do
       Pkg::Config.config_from_hash({ :staging_server => 'foo' })
       Pkg::Config.issue_reassignments
-      Pkg::Config.tar_host.should eq("foo")
+      expect(Pkg::Config.tar_host).to eq 'foo'
     end
   end
 
   describe "#config_to_hash" do
     it "should return a hash object" do
       hash = Pkg::Config.config_to_hash
-      hash.should be_a(Hash)
+      expect(hash).to be_a(Hash)
     end
 
     it "should return a hash with the current parameters" do
       Pkg::Config.apt_host = "foo"
-      Pkg::Config.config_to_hash[:apt_host].should eq("foo")
+      expect(Pkg::Config.config_to_hash[:apt_host]).to eq 'foo'
       Pkg::Config.apt_host = "bar"
-      Pkg::Config.config_to_hash[:apt_host].should eq("bar")
+      expect(Pkg::Config.config_to_hash[:apt_host]).to eq 'bar'
     end
   end
 
   describe "#load_default_configs" do
     before(:each) do
-      @project_root = double('project_root')
+      @project_root = double('project_root').to_s
       Pkg::Config.project_root = @project_root
       @test_project_data = File.join(Pkg::Config.project_root, 'ext', 'project_data.yaml')
       @test_build_defaults = File.join(Pkg::Config.project_root, 'ext', 'build_defaults.yaml')
@@ -549,7 +549,7 @@ describe "Pkg::Config" do
       when :bool
         it "should set boolean value on #{v[:var]} for :type == :bool" do
           ENV[v[:envvar].to_s] = "FOO"
-          Pkg::Util.stub(:boolean_value) {"FOO"}
+          allow(Pkg::Util).to receive(:boolean_value).and_return "FOO"
           allow(Pkg::Config).to receive(:instance_variable_set)
           expect(Pkg::Util).to receive(:boolean_value).with("FOO")
           expect(Pkg::Config).to receive(:instance_variable_set).with("@#{v[:var]}", "FOO")
@@ -558,7 +558,7 @@ describe "Pkg::Config" do
       when :array
         it "should set Pkg::Config##{v[:var]} to an Array for :type == :array" do
           ENV[v[:envvar].to_s] = "FOO BAR ARR RAY"
-          Pkg::Config.stub(:string_to_array) {%w(FOO BAR ARR RAY)}
+          allow(Pkg::Config).to receive(:string_to_array).and_return %w(FOO BAR ARR RAY)
           allow(Pkg::Config).to receive(:instance_variable_set)
           expect(Pkg::Config).to receive(:string_to_array).with("FOO BAR ARR RAY")
           expect(Pkg::Config).to receive(:instance_variable_set).with("@#{v[:var]}", %w(FOO BAR ARR RAY))
@@ -567,7 +567,7 @@ describe "Pkg::Config" do
       else
         it "should set Pkg::Config##{v[:var]} to ENV[#{v[:envvar].to_s}]" do
           ENV[v[:envvar].to_s] = "FOO"
-          Pkg::Util.stub(:boolean_value) {"FOO"}
+          allow(Pkg::Util).to receive(:boolean_value).and_return "FOO"
           allow(Pkg::Config).to receive(:instance_variable_set)
           expect(Pkg::Config).to receive(:instance_variable_set).with("@#{v[:var]}", "FOO")
           Pkg::Config.load_envvars

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "Pkg::Deb::Repo" do
-  let(:wget)          { "/opt/tools/bin/wget" }
-  let(:builds_server) { "saturn.puppetlabs.net" }
-  let(:project)       { "deb_repos" }
-  let(:ref)           { "1234abcd" }
+describe 'Pkg::Deb::Repo' do
+  let(:wget)          { '/opt/tools/bin/wget' }
+  let(:builds_server) { 'saturn.puppetlabs.net' }
+  let(:project)       { 'deb_repos' }
+  let(:ref)           { '1234abcd' }
   let(:base_url)      { "http://#{builds_server}/#{project}/#{ref}" }
-  let(:cows)          { ["xenial", "jessie", "trusty", "stretch", ""] }
+  let(:cows)          { ['xenial', 'jessie', 'trusty', 'stretch', ''] }
   let(:wget_results)  { cows.map {|cow| "#{base_url}/repos/apt/#{cow}" }.join("\n") }
   let(:wget_garbage)  { "\n and an index\nhttp://somethingelse.com/robots" }
   let(:repo_configs)  { cows.reject {|cow| cow.empty?}.map {|dist| "pkg/repo_configs/deb/pl-#{project}-#{ref}-#{dist}.list" } }
@@ -29,126 +29,126 @@ describe "Pkg::Deb::Repo" do
     Pkg::Config.jenkins_repo_path = orig_repo_path
   end
 
-  describe "#generate_repo_configs" do
-    it "fails if wget isn't available" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_raise(RuntimeError)
+  describe '#generate_repo_configs' do
+    it 'fails if wget is not available' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_raise(RuntimeError)
       expect {Pkg::Deb::Repo.generate_repo_configs}.to raise_error(RuntimeError)
     end
 
-    it "warns if there are no deb repos available for the build" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_raise(RuntimeError)
-      Pkg::Deb::Repo.should_receive(:warn).with("No debian repos available for #{project} at #{ref}.")
+    it 'warns if there are no deb repos available for the build' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_return(wget)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_raise(RuntimeError)
+      expect(Pkg::Deb::Repo).to receive(:warn).with("No debian repos available for #{project} at #{ref}.")
       Pkg::Deb::Repo.generate_repo_configs
     end
 
-    it "writes the expected repo configs to disk" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_return(wget_results + wget_garbage)
-      FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs/deb")
+    it 'writes the expected repo configs to disk' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_return(wget)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_return(wget_results + wget_garbage)
+      expect(FileUtils).to receive(:mkdir_p).with('pkg/repo_configs/deb')
       config = []
       repo_configs.each_with_index do |repo_config, i|
         config[i] = double(File)
-        File.should_receive(:open).with(repo_config, 'w').and_yield(config[i])
-        config[i].should_receive(:puts)
+        expect(File).to receive(:open).with(repo_config, 'w').and_yield(config[i])
+        expect(config[i]).to receive(:puts)
       end
       Pkg::Deb::Repo.generate_repo_configs
     end
   end
 
-  describe "#retrieve_repo_configs" do
-    it "fails if wget isn't available" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_raise(RuntimeError)
+  describe '#retrieve_repo_configs' do
+    it 'fails if wget is not available' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_raise(RuntimeError)
       expect {Pkg::Deb::Repo.generate_repo_configs}.to raise_error(RuntimeError)
     end
 
-    it "warns if there are no deb repos available for the build" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs").and_return(true)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/deb/").and_raise(RuntimeError)
+    it 'warns if there are no deb repos available for the build' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_return(wget)
+      expect(FileUtils).to receive(:mkdir_p).with('pkg/repo_configs').and_return(true)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/deb/").and_raise(RuntimeError)
       expect {Pkg::Deb::Repo.retrieve_repo_configs}.to raise_error(RuntimeError, /Couldn't retrieve deb apt repo configs/)
     end
   end
 
-  describe "#repo_creation_command" do
-    let(:prefix) { "thing" }
-    let(:artifact_directory) { ["/a/b/c/xenial"] }
+  describe '#repo_creation_command' do
+    let(:prefix) { 'thing' }
+    let(:artifact_directory) { ['/a/b/c/xenial'] }
 
-    it "returns a command to make repos" do
+    it 'returns a command to make repos' do
       command = Pkg::Deb::Repo.repo_creation_command(prefix, artifact_directory)
-      command.should match(/reprepro/)
-      command.should match(/#{prefix}/)
-      command.should match(/#{artifact_directory}/)
+      expect(command).to match(/reprepro/)
+      expect(command).to match(/#{prefix}/)
+      expect(command).to match(/#{artifact_directory}/)
     end
   end
 
-  describe "#create_repos" do
-    let(:command) { "/usr/bin/make some repos" }
-    let(:artifact_directory) { "/tmp/dir/thing" }
+  describe '#create_repos' do
+    let(:command) { '/usr/bin/make some repos' }
+    let(:artifact_directory) { '/tmp/dir/thing' }
     let(:pkg_directories) { ['place/to/deb/xenial', 'other/deb/trusty'] }
 
-    it "generates repo configs remotely and then ships them" do
-      File.stub(:join) {artifact_directory}
-      Pkg::Repo.should_receive(:directories_that_contain_packages).and_return(pkg_directories)
-      Pkg::Repo.should_receive(:populate_repo_directory)
-      Pkg::Deb::Repo.should_receive(:repo_creation_command).and_return(command)
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, command)
-      Pkg::Deb::Repo.should_receive(:generate_repo_configs)
-      Pkg::Deb::Repo.should_receive(:ship_repo_configs)
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, "rm -f #{artifact_directory}/repos/.lock" )
+    it 'generates repo configs remotely and then ships them' do
+      allow(File).to receive(:join).and_return artifact_directory
+      expect(Pkg::Repo).to receive(:directories_that_contain_packages).and_return(pkg_directories)
+      expect(Pkg::Repo).to receive(:populate_repo_directory)
+      expect(Pkg::Deb::Repo).to receive(:repo_creation_command).and_return(command)
+      expect(Pkg::Util::Net).to receive(:remote_execute).with(Pkg::Config.distribution_server, command)
+      expect(Pkg::Deb::Repo).to receive(:generate_repo_configs)
+      expect(Pkg::Deb::Repo).to receive(:ship_repo_configs)
+      expect(Pkg::Util::Net).to receive(:remote_execute).with(Pkg::Config.distribution_server, "rm -f #{artifact_directory}/repos/.lock" )
       Pkg::Deb::Repo.create_repos
     end
   end
 
-  describe "#ship_repo_configs" do
-    it "warns if there are no repo configs to ship" do
-      File.should_receive(:exist?).with("pkg/repo_configs/deb").and_return(true)
-      Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/deb").and_return(true)
-      Pkg::Deb::Repo.should_receive(:warn).with("No repo configs have been generated! Try pl:deb_repo_configs.")
+  describe '#ship_repo_configs' do
+    it 'warns if there are no repo configs to ship' do
+      expect(File).to receive(:exist?).with('pkg/repo_configs/deb').and_return(true)
+      expect(Pkg::Util::File).to receive(:empty_dir?).with('pkg/repo_configs/deb').and_return(true)
+      expect(Pkg::Deb::Repo).to receive(:warn).with('No repo configs have been generated! Try pl:deb_repo_configs.')
       Pkg::Deb::Repo.ship_repo_configs
     end
 
-    it "ships repo configs to the build server" do
-      File.should_receive(:exist?).with("pkg/repo_configs/deb").and_return(true)
-      Pkg::Config.jenkins_repo_path = "/a/b/c/d"
-      Pkg::Config.distribution_server = "a.host.that.wont.exist"
+    it 'ships repo configs to the build server' do
+      expect(File).to receive(:exist?).with('pkg/repo_configs/deb').and_return(true)
+      Pkg::Config.jenkins_repo_path = '/a/b/c/d'
+      Pkg::Config.distribution_server = 'a.host.that.wont.exist'
       repo_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/repo_configs/deb"
-      Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/deb").and_return(false)
-      Pkg::Util::RakeUtils.should_receive(:invoke_task).with("pl:fetch")
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
-      Pkg::Util::Execution.should_receive(:retry_on_fail).with(:times => 3)
+      expect(Pkg::Util::File).to receive(:empty_dir?).with('pkg/repo_configs/deb').and_return(false)
+      expect(Pkg::Util::RakeUtils).to receive(:invoke_task).with('pl:fetch')
+      expect(Pkg::Util::Net).to receive(:remote_execute).with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
+      expect(Pkg::Util::Execution).to receive(:retry_on_fail).with(:times => 3)
       Pkg::Deb::Repo.ship_repo_configs
     end
   end
 
-  describe "#sign_repos" do
-    it "fails without reprepro" do
-      Pkg::Util::Tool.should_receive(:find_tool).with('reprepro', {:required => true}).and_raise(RuntimeError)
+  describe '#sign_repos' do
+    it 'fails without reprepro' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('reprepro', {:required => true}).and_raise(RuntimeError)
       expect { Pkg::Deb::Repo.sign_repos }.to raise_error(RuntimeError)
     end
 
-    it "makes a repo for each dist" do
+    it 'makes a repo for each dist' do
       # stub out start_keychain to prevent actual keychain starts.
-      Pkg::Util::Gpg.stub(:start_keychain)
+      allow(Pkg::Util::Gpg).to receive(:start_keychain)
 
       dists = cows.reject { |cow| cow.empty? }
       distfiles = {}
-      Pkg::Util::File.should_receive(:directories).with("repos/apt").and_return(dists)
+      allow(Pkg::Util::File).to receive(:directories).with('repos/apt').and_return(dists)
 
       # Let the keychain command happen if find_tool('keychain') finds it
-      keychain_command = "/usr/bin/keychain -k mine"
+      keychain_command = '/usr/bin/keychain -k mine'
       allow(Pkg::Util::Execution).to receive(:capture3) { keychain_command }
 
       # Enforce reprepro
-      reprepro_command = "/bin/reprepro"
-      Pkg::Util::Tool.should_receive(:check_tool).with("reprepro").and_return(reprepro_command)
-      Pkg::Util::Execution.should_receive(:capture3).at_least(1).times.with("#{reprepro_command} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
+      reprepro_command = '/bin/reprepro'
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('reprepro').and_return(reprepro_command)
+      expect(Pkg::Util::Execution).to receive(:capture3).at_least(1).times.with("#{reprepro_command} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
 
       dists.each do |dist|
         distfiles[dist] = double
-        Dir.should_receive(:chdir).with("repos/apt/#{dist}").and_yield
-        File.should_receive(:open).with("conf/distributions", "w").and_yield(distfiles[dist])
-        distfiles[dist].should_receive(:puts)
+        expect(Dir).to receive(:chdir).with("repos/apt/#{dist}").and_yield
+        expect(File).to receive(:open).with('conf/distributions', 'w').and_yield(distfiles[dist])
+        expect(distfiles[dist]).to receive(:puts)
       end
 
       Pkg::Deb::Repo.sign_repos

--- a/spec/lib/packaging/deb_spec.rb
+++ b/spec/lib/packaging/deb_spec.rb
@@ -3,50 +3,50 @@ require 'spec_helper'
 require 'packaging/deb'
 
 describe 'deb.rb' do
-  describe "#set_cow_envs" do
+  describe '#set_cow_envs' do
     before(:each) do
-      reset_env(["DIST", "ARCH", "PE_VER", "BUILDMIRROR"])
+      reset_env(['DIST', 'ARCH', 'PE_VER', 'BUILDMIRROR'])
       Pkg::Config.deb_build_mirrors = nil
       Pkg::Config.build_pe = nil
       Pkg::Config.pe_version = nil
     end
 
     after(:all) do
-      reset_env(["DIST", "ARCH", "PE_VER", "BUILDMIRROR"])
+      reset_env(['DIST', 'ARCH', 'PE_VER', 'BUILDMIRROR'])
       Pkg::Config.deb_build_mirrors = nil
       Pkg::Config.build_pe = nil
       Pkg::Config.pe_version = nil
     end
 
-    it "should always set DIST and ARCH correctly" do
-      Pkg::Deb.send(:set_cow_envs, "base-wheezy-i386.cow")
-      ENV["DIST"].should eq("wheezy")
-      ENV["ARCH"].should eq("i386")
-      ENV["PE_VER"].should be_nil
-      ENV["BUILDMIRROR"].should be_nil
+    it 'should always set DIST and ARCH correctly' do
+      Pkg::Deb.send(:set_cow_envs, 'base-wheezy-i386.cow')
+      expect(ENV['DIST']).to eq 'wheezy'
+      expect(ENV['ARCH']).to eq 'i386'
+      expect(ENV['PE_VER']).to be_nil
+      expect(ENV['BUILDMIRROR']).to be_nil
     end
 
-    it "should set BUILDMIRROR if Pkg::Config.deb_build_mirrors is set" do
-      Pkg::Config.deb_build_mirrors = ["deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main", "deb http://debian.is.awesome/wait no it is not"]
-      Pkg::Deb.send(:set_cow_envs, "base-wheezy-i386.cow")
-      ENV["DIST"].should eq("wheezy")
-      ENV["ARCH"].should eq("i386")
-      ENV["PE_VER"].should be_nil
-      ENV["BUILDMIRROR"].should eq("deb http://pl-build-tools.delivery.puppetlabs.net/debian wheezy main | deb http://debian.is.awesome/wait no it is not")
+    it 'should set BUILDMIRROR if Pkg::Config.deb_build_mirrors is set' do
+      Pkg::Config.deb_build_mirrors = ['deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main', 'deb http://debian.is.awesome/wait no it is not']
+      Pkg::Deb.send(:set_cow_envs, 'base-wheezy-i386.cow')
+      expect(ENV['DIST']).to eq 'wheezy'
+      expect(ENV['ARCH']).to eq 'i386'
+      expect(ENV['PE_VER']).to be_nil
+      expect(ENV['BUILDMIRROR']).to eq 'deb http://pl-build-tools.delivery.puppetlabs.net/debian wheezy main | deb http://debian.is.awesome/wait no it is not'
     end
 
-    it "should set PE_VER if Pkg::Config.build_pe is truthy" do
+    it 'should set PE_VER if Pkg::Config.build_pe is truthy' do
       Pkg::Config.build_pe = true
-      Pkg::Config.pe_version = "3.2"
-      Pkg::Deb.send(:set_cow_envs, "base-wheezy-i386.cow")
-      ENV["DIST"].should eq("wheezy")
-      ENV["ARCH"].should eq("i386")
-      ENV["PE_VER"].should eq("3.2")
-      ENV["BUILDMIRROR"].should be_nil
+      Pkg::Config.pe_version = '3.2'
+      Pkg::Deb.send(:set_cow_envs, 'base-wheezy-i386.cow')
+      expect(ENV['DIST']).to eq 'wheezy'
+      expect(ENV['ARCH']).to eq 'i386'
+      expect(ENV['PE_VER']).to eq '3.2'
+      expect(ENV['BUILDMIRROR']).to be_nil
     end
 
-    it "should fail on a badly formatted cow" do
-      expect { Pkg::Deb.send(:set_cow_envs, "wheezy-i386") }.to raise_error(RuntimeError)
+    it 'should fail on a badly formatted cow' do
+      expect { Pkg::Deb.send(:set_cow_envs, 'wheezy-i386') }.to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -103,11 +103,11 @@ describe "#Pkg::Repo" do
     let(:optional_arg) { 'repo_name' }
 
     it 'should return true if command requires arg' do
-      expect(Pkg::Repo.argument_required?(required_arg, repo_command)).to be_true
+      expect(Pkg::Repo.argument_required?(required_arg, repo_command)).to be true
     end
 
     it 'should return false if command does not need arg' do
-      expect(Pkg::Repo.argument_required?(optional_arg, repo_command)).to be_false
+      expect(Pkg::Repo.argument_required?(optional_arg, repo_command)).to be false
     end
   end
 

--- a/spec/lib/packaging/rpm/repo_spec.rb
+++ b/spec/lib/packaging/rpm/repo_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "Pkg::Rpm::Repo" do
-  let(:wget)          { "/opt/tools/bin/wget" }
-  let(:builds_server) { "saturn.puppetlabs.net" }
-  let(:project)       { "rpm_repos" }
-  let(:ref)           { "1234abcd" }
+describe 'Pkg::Rpm::Repo' do
+  let(:wget)          { '/opt/tools/bin/wget' }
+  let(:builds_server) { 'saturn.puppetlabs.net' }
+  let(:project)       { 'rpm_repos' }
+  let(:ref)           { '1234abcd' }
   let(:base_url)      { "http://#{builds_server}/#{project}/#{ref}" }
-  let(:mocks)         { ["el-5-i386", "el-5-x86_64", "el-5-SRPMS"] }
+  let(:mocks)         { ['el-5-i386', 'el-5-x86_64', 'el-5-SRPMS'] }
   let(:wget_results)  {
                         mocks.map do |mock|
                           dist, version, arch = mock.split('-')
@@ -34,99 +34,99 @@ describe "Pkg::Rpm::Repo" do
     Pkg::Config.jenkins_repo_path = orig_repo_path
   end
 
-  describe "#generate_repo_configs" do
-    it "fails if wget isn't available" do
-      Pkg::Util::Tool.stub(:find_tool).with("wget", {:required => true}) {false}
+  describe '#generate_repo_configs' do
+    it 'fails if wget is not available' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}) {false}
       expect {Pkg::Rpm::Repo.generate_repo_configs}.to raise_error(RuntimeError)
     end
 
-    it "warns if there are no rpm repos available for the build" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return("")
-      Pkg::Rpm::Repo.should_receive(:warn).with("No rpm repos were found to generate configs from!")
+    it 'warns if there are no rpm repos available for the build' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_return(wget)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return('')
+      expect(Pkg::Rpm::Repo).to receive(:warn).with('No rpm repos were found to generate configs from!')
       Pkg::Rpm::Repo.generate_repo_configs
     end
 
-    it "writes the expected repo configs to disk" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return(wget_results + wget_garbage)
+    it 'writes the expected repo configs to disk' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_return(wget)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{wget} --spider -r -l 5 --no-parent #{base_url}/repos/ 2>&1").and_return(wget_results + wget_garbage)
       wget_results.split.each do |result|
         cur_result = result.chomp('repodata/')
-        Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{cur_result} 2>&1").and_return("#{cur_result}/thing.rpm")
+        expect(Pkg::Util::Execution).to receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{cur_result} 2>&1").and_return("#{cur_result}/thing.rpm")
       end
-      FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs/rpm")
+      expect(FileUtils).to receive(:mkdir_p).with('pkg/repo_configs/rpm')
       config = []
       repo_configs.each_with_index do |repo_config, i|
-        Pkg::Paths.should_receive(:tag_from_artifact_path).and_return(mocks[i])
-        Pkg::Platforms.should_receive(:parse_platform_tag).and_return(mocks[i].split('-'))
+        expect(Pkg::Paths).to receive(:tag_from_artifact_path).and_return(mocks[i])
+        expect(Pkg::Platforms).to receive(:parse_platform_tag).and_return(mocks[i].split('-'))
         config[i] = double(File)
-        File.should_receive(:open).with(repo_config, 'w').and_yield(config[i])
-        config[i].should_receive(:puts)
+        expect(File).to receive(:open).with(repo_config, 'w').and_yield(config[i])
+        expect(config[i]).to receive(:puts)
       end
       Pkg::Rpm::Repo.generate_repo_configs
     end
   end
 
-  describe "#retrieve_repo_configs" do
-    it "fails if wget isn't available" do
-      Pkg::Util::Tool.stub(:find_tool).with("wget", {:required => true}) {false}
+  describe '#retrieve_repo_configs' do
+    it 'fails if wget is not available' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}) {false}
       expect {Pkg::Rpm::Repo.generate_repo_configs}.to raise_error(RuntimeError)
     end
 
-    it "fails if there are no deb repos available for the build" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs").and_return(true)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/rpm/").and_raise(RuntimeError)
+    it 'fails if there are no deb repos available for the build' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('wget', {:required => true}).and_return(wget)
+      expect(FileUtils).to receive(:mkdir_p).with('pkg/repo_configs').and_return(true)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/rpm/").and_raise(RuntimeError)
       expect {Pkg::Rpm::Repo.retrieve_repo_configs}.to raise_error(RuntimeError, /Couldn't retrieve rpm yum repo configs/)
     end
   end
 
-  describe "#create_local_repos" do
-    let(:command) { "/usr/bin/make some repos" }
-    let(:target_directory) { "/tmp/dir/thing" }
+  describe '#create_local_repos' do
+    let(:command) { '/usr/bin/make some repos' }
+    let(:target_directory) { '/tmp/dir/thing' }
 
-    it "makes a repo in the target directory" do
-      Pkg::Rpm::Repo.should_receive(:repo_creation_command).with(target_directory).and_return("run this thing")
-      Pkg::Util::Execution.should_receive(:capture3).with("bash -c 'run this thing'")
+    it 'makes a repo in the target directory' do
+      expect(Pkg::Rpm::Repo).to receive(:repo_creation_command).with(target_directory).and_return('run this thing')
+      expect(Pkg::Util::Execution).to receive(:capture3).with("bash -c 'run this thing'")
       Pkg::Rpm::Repo.create_local_repos(target_directory)
     end
   end
 
-  describe "#create_remote_repos" do
-    let(:command) { "/usr/bin/make some repos" }
-    let(:artifact_directory) { "/tmp/dir/thing" }
+  describe '#create_remote_repos' do
+    let(:command) { '/usr/bin/make some repos' }
+    let(:artifact_directory) { '/tmp/dir/thing' }
     let(:pkg_directories) { ['el-6-i386', 'el/7/x86_64'] }
 
-    it "makes a repo in the target directory" do
-      File.stub(:join) {artifact_directory}
-      Pkg::Repo.should_receive(:directories_that_contain_packages).and_return(pkg_directories)
-      Pkg::Repo.should_receive(:populate_repo_directory)
-      Pkg::Rpm::Repo.should_receive(:repo_creation_command).and_return(command)
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, command)
-      Pkg::Rpm::Repo.should_receive(:generate_repo_configs)
-      Pkg::Rpm::Repo.should_receive(:ship_repo_configs)
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, "rm -f #{artifact_directory}/repos/.lock" )
+    it 'makes a repo in the target directory' do
+      allow(File).to receive(:join).and_return artifact_directory
+      expect(Pkg::Repo).to receive(:directories_that_contain_packages).and_return(pkg_directories)
+      expect(Pkg::Repo).to receive(:populate_repo_directory)
+      expect(Pkg::Rpm::Repo).to receive(:repo_creation_command).and_return(command)
+      expect(Pkg::Util::Net).to receive(:remote_execute).with(Pkg::Config.distribution_server, command)
+      expect(Pkg::Rpm::Repo).to receive(:generate_repo_configs)
+      expect(Pkg::Rpm::Repo).to receive(:ship_repo_configs)
+      expect(Pkg::Util::Net).to receive(:remote_execute).with(Pkg::Config.distribution_server, "rm -f #{artifact_directory}/repos/.lock" )
       Pkg::Rpm::Repo.create_remote_repos
     end
   end
 
-  describe "#ship_repo_configs" do
-    it "warn if there are no repo configs to ship" do
-      Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/rpm").and_return(true)
-      Pkg::Rpm::Repo.should_receive(:warn).with("No repo configs have been generated! Try pl:rpm_repo_configs.")
+  describe '#ship_repo_configs' do
+    it 'warn if there are no repo configs to ship' do
+      expect(Pkg::Util::File).to receive(:empty_dir?).with('pkg/repo_configs/rpm').and_return(true)
+      expect(Pkg::Rpm::Repo).to receive(:warn).with('No repo configs have been generated! Try pl:rpm_repo_configs.')
       Pkg::Rpm::Repo.ship_repo_configs
     end
 
-    it "ships repo configs to the build server" do
-      Pkg::Config.jenkins_repo_path = "/a/b/c/d"
-      Pkg::Config.project = "thing2"
-      Pkg::Config.ref = "abcd1234"
-      Pkg::Config.distribution_server = "a.host.that.wont.exist"
+    it 'ships repo configs to the build server' do
+      Pkg::Config.jenkins_repo_path = '/a/b/c/d'
+      Pkg::Config.project = 'thing2'
+      Pkg::Config.ref = 'abcd1234'
+      Pkg::Config.distribution_server = 'a.host.that.wont.exist'
       repo_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/repo_configs/rpm"
-      Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/rpm").and_return(false)
-      Pkg::Util::RakeUtils.should_receive(:invoke_task).with("pl:fetch")
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
-      Pkg::Util::Execution.should_receive(:retry_on_fail).with(:times => 3)
+      expect(Pkg::Util::File).to receive(:empty_dir?).with('pkg/repo_configs/rpm').and_return(false)
+      expect(Pkg::Util::RakeUtils).to receive(:invoke_task).with('pl:fetch')
+      expect(Pkg::Util::Net).to receive(:remote_execute).with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
+      expect(Pkg::Util::Execution).to receive(:retry_on_fail).with(:times => 3)
       Pkg::Rpm::Repo.ship_repo_configs
     end
   end

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -128,7 +128,7 @@ DOC
 
       it 'does not fail if there are no rpms to sign' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return([])
-        expect(Pkg::Sign::Rpm.sign_all(rpm_directory)).to_not raise_error
+        expect { Pkg::Sign::Rpm.sign_all(rpm_directory) }.to_not raise_error
       end
     end
   end

--- a/spec/lib/packaging/tar_spec.rb
+++ b/spec/lib/packaging/tar_spec.rb
@@ -1,22 +1,22 @@
 # -*- ruby -*-
 require 'spec_helper'
 
-describe "tar.rb" do
-  let(:project) { "packaging" }
-  let(:version) { "1.2.3" }
-  let(:files)   { [ "a", "b", "c" ] }
+describe 'tar.rb' do
+  let(:project) { 'packaging' }
+  let(:version) { '1.2.3' }
+  let(:files)   { [ 'a', 'b', 'c' ] }
   let(:templates) do
     [
-      "ext/redhat/spec.erb",
-      { "source" => "ext/debian/control.erb", "target" => "ext/debian/not-a-control-file" },
-      "ext/debian/changelog.erb",
-      "ext/packaging/thing.erb"
+      'ext/redhat/spec.erb',
+      { 'source' => 'ext/debian/control.erb', 'target' => 'ext/debian/not-a-control-file' },
+      'ext/debian/changelog.erb',
+      'ext/packaging/thing.erb'
     ]
   end
   let(:expanded_templates) do
     [
       "#{PROJECT_ROOT}/ext/redhat/spec.erb",
-      { "source" => "ext/debian/control.erb", "target" => "ext/debian/not-a-control-file" },
+      { 'source' => 'ext/debian/control.erb', 'target' => 'ext/debian/not-a-control-file' },
       "#{PROJECT_ROOT}/ext/debian/changelog.erb"
     ]
   end
@@ -28,7 +28,7 @@ describe "tar.rb" do
         :version        => version,
         :files          => files,
         :project_root   => PROJECT_ROOT,
-        :packaging_root => "ext/packaging"
+        :packaging_root => 'ext/packaging'
       })
   end
 
@@ -51,63 +51,65 @@ describe "tar.rb" do
     end
   end
 
-  describe "#expand_templates" do
-    it "should be invoked when Pkg::Config.templates is set" do
-      Pkg::Tar.any_instance.should_receive(:expand_templates)
+  describe '#expand_templates' do
+    it 'should be invoked when Pkg::Config.templates is set' do
+      expect_any_instance_of(Pkg::Tar).to receive(:expand_templates)
       Pkg::Tar.new
     end
 
-    it "packaging templates should be filtered and paths should be expanded" do
+    it 'packaging templates should be filtered and paths should be expanded' do
       templates.each do |temp|
         if temp.is_a?(String)
-          Dir.stub(:glob).with(File.join(PROJECT_ROOT, temp)).and_return(File.join(PROJECT_ROOT, temp))
+          allow(Dir).to receive(:glob)
+                          .with(File.join(PROJECT_ROOT, temp))
+                          .and_return(File.join(PROJECT_ROOT, temp))
         end
       end
 
       tar = Pkg::Tar.new
       tar.templates = templates
       tar.expand_templates
-      tar.templates.should eq expanded_templates
+      expect(tar.templates).to eq expanded_templates
     end
   end
 
-  describe "#template" do
+  describe '#template' do
     before(:each) do
       Pkg::Config.templates = expanded_templates
     end
 
-    it "should handle hashes and strings correctly" do
+    it 'should handle hashes and strings correctly' do
       # Set up correct stubs and expectations
       expanded_templates.each do |temp|
         if temp.is_a?(String)
           full_path_temp = File.join(PROJECT_ROOT, temp)
-          target = full_path_temp.sub(File.extname(full_path_temp), "")
+          target = full_path_temp.sub(File.extname(full_path_temp), '')
         elsif temp.is_a?(Hash)
-          full_path_temp = File.join(PROJECT_ROOT, temp["source"])
-          target = File.join(PROJECT_ROOT, temp["target"])
+          full_path_temp = File.join(PROJECT_ROOT, temp['source'])
+          target = File.join(PROJECT_ROOT, temp['target'])
         end
 
-        Dir.stub(:glob).with(full_path_temp).and_return(full_path_temp)
-        File.stub(:exist?).with(full_path_temp).and_return(true)
-        Pkg::Util::File.should_receive(:erb_file).with(full_path_temp, target, true, :binding => an_instance_of(Binding))
+        allow(Dir).to receive(:glob).with(full_path_temp).and_return(full_path_temp)
+        allow(File).to receive(:exist?).with(full_path_temp).and_return(true)
+        expect(Pkg::Util::File)
+          .to receive(:erb_file)
+                .with(full_path_temp, target, true, :binding => an_instance_of(Binding))
       end
 
       Pkg::Tar.new.template
     end
 
-    it "should raise an error if the template source can't be found" do
+    it 'should raise an error if the template source cannot be found' do
       # Set up correct stubs and expectations
       expanded_templates.each do |temp|
         if temp.is_a?(String)
           full_path_temp = File.join(PROJECT_ROOT, temp)
-          target = full_path_temp.sub(File.extname(full_path_temp), "")
         elsif temp.is_a?(Hash)
-          full_path_temp = File.join(PROJECT_ROOT, temp["source"])
-          target = File.join(PROJECT_ROOT, temp["target"])
+          full_path_temp = File.join(PROJECT_ROOT, temp['source'])
         end
 
-        Dir.stub(:glob).with(full_path_temp).and_return(full_path_temp)
-        File.stub(:exist?).with(full_path_temp).and_return(false)
+        allow(Dir).to receive(:glob).with(full_path_temp).and_return(full_path_temp)
+        allow(File).to receive(:exist?).with(full_path_temp).and_return(false)
       end
 
       expect { Pkg::Tar.new.template }.to raise_error RuntimeError

--- a/spec/lib/packaging/util/execution_spec.rb
+++ b/spec/lib/packaging/util/execution_spec.rb
@@ -1,56 +1,56 @@
 require 'spec_helper'
 
-describe "Pkg::Util::Execution" do
-  let(:command)    { "/usr/bin/do-something-important --arg1=thing2" }
-  let(:output)     { "the command returns some really cool stuff that may be useful later" }
+describe 'Pkg::Util::Execution' do
+  let(:command)    { '/usr/bin/do-something-important --arg1=thing2' }
+  let(:output)     { 'the command returns some really cool stuff that may be useful later' }
 
-  describe "#success?" do
-    it "should return false on failure" do
+  describe '#success?' do
+    it 'should return false on failure' do
       %x{false}
-      Pkg::Util::Execution.success?.should be_false
+      expect(Pkg::Util::Execution.success?).to be false
     end
 
-    it "should return true on success" do
+    it 'should return true on success' do
       %x{true}
-      Pkg::Util::Execution.success?.should be_true
+      expect(Pkg::Util::Execution.success?).to be true
     end
 
-    it "should return false when passed an exitstatus object from a failure" do
+    it 'should return false when passed an exitstatus object from a failure' do
       %x{false}
-      Pkg::Util::Execution.success?($?).should be_false
+      expect(Pkg::Util::Execution.success?($?)).to be false
     end
 
-    it "should return true when passed and exitstatus object from a success" do
+    it 'should return true when passed and exitstatus object from a success' do
       %x{true}
-      Pkg::Util::Execution.success?($?).should be_true
+      expect(Pkg::Util::Execution.success?($?)).to be true
     end
   end
 
-  describe "#ex" do
-    it "should raise an error if the command fails" do
-      Pkg::Util::Execution.should_receive(:`).with(command).and_return(true)
-      Pkg::Util::Execution.should_receive(:success?).and_return(false)
+  describe '#ex' do
+    it 'should raise an error if the command fails' do
+      expect(Pkg::Util::Execution).to receive(:`).with(command).and_return(true)
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(false)
       expect{ Pkg::Util::Execution.ex(command) }.to raise_error(RuntimeError)
     end
 
-    it "should return the output of the command for success" do
-      Pkg::Util::Execution.should_receive(:`).with(command).and_return(output)
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
-      Pkg::Util::Execution.ex(command).should == output
+    it 'should return the output of the command for success' do
+      expect(Pkg::Util::Execution).to receive(:`).with(command).and_return(output)
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      expect(Pkg::Util::Execution.ex(command)).to be output
     end
   end
 
-  describe "#capture3" do
-    it "should raise an error if the command fails" do
-      Open3.should_receive(:capture3).with(command).and_return([output, '', 1])
-      Pkg::Util::Execution.should_receive(:success?).with(1).and_return(false)
+  describe '#capture3' do
+    it 'should raise an error if the command fails' do
+      expect(Open3).to receive(:capture3).with(command).and_return([output, '', 1])
+      expect(Pkg::Util::Execution).to receive(:success?).with(1).and_return(false)
       expect{ Pkg::Util::Execution.capture3(command) }.to raise_error(RuntimeError, /#{output}/)
     end
 
-    it "should return the output of the command for success" do
-      Open3.should_receive(:capture3).with(command).and_return([output, '', 0])
-      Pkg::Util::Execution.should_receive(:success?).with(0).and_return(true)
-      Pkg::Util::Execution.capture3(command).should == [output, '', 0]
+    it 'should return the output of the command for success' do
+      expect(Open3).to receive(:capture3).with(command).and_return([output, '', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).with(0).and_return(true)
+      expect(Pkg::Util::Execution.capture3(command)).to eq [output, '', 0]
     end
   end
 end

--- a/spec/lib/packaging/util/file_spec.rb
+++ b/spec/lib/packaging/util/file_spec.rb
@@ -1,112 +1,114 @@
 require 'spec_helper'
 
-describe "Pkg::Util::File" do
-  let(:source)     { "/tmp/placething.tar.gz" }
-  let(:target)     { "/tmp" }
-  let(:options)    { "--thing-for-tar" }
-  let(:tar)        { "/usr/bin/tar" }
-  let(:files)      { ["foo.rb", "foo/bar.rb"] }
-  let(:symlinks)   { ["bar.rb"] }
-  let(:dirs)       { ["foo"] }
-  let(:empty_dirs) { ["bar"] }
+describe 'Pkg::Util::File' do
+  let(:source)     { '/tmp/placething.tar.gz' }
+  let(:target)     { '/tmp' }
+  let(:options)    { '--thing-for-tar' }
+  let(:tar)        { '/usr/bin/tar' }
+  let(:files)      { ['foo.rb', 'foo/bar.rb'] }
+  let(:symlinks)   { ['bar.rb'] }
+  let(:dirs)       { ['foo'] }
+  let(:empty_dirs) { ['bar'] }
 
 
-  describe "#untar_into" do
+  describe '#untar_into' do
     before :each do
-      Pkg::Util::Tool.stub(:find_tool).with('tar', :required => true) { tar }
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('tar', :required => true) { tar }
     end
 
-    it "raises an exception if the source doesn't exist" do
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}).and_raise(RuntimeError)
-      Pkg::Util::Execution.should_not_receive(:capture3)
+    it 'raises an exception if the source does not exist' do
+      expect(Pkg::Util::File).to receive(:file_exists?).with(source, {:required => true}).and_raise(RuntimeError)
+      expect(Pkg::Util::Execution).not_to receive(:capture3)
       expect { Pkg::Util::File.untar_into(source) }.to raise_error(RuntimeError)
     end
 
-    it "unpacks the tarball to the current directory if no target is passed" do
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar}   -xf #{source}")
+    it 'unpacks the tarball to the current directory if no target is passed' do
+      expect(Pkg::Util::File).to receive(:file_exists?).with(source, {:required => true}) { true }
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{tar}   -xf #{source}")
       Pkg::Util::File.untar_into(source)
     end
 
-    it "unpacks the tarball to the current directory with options if no target is passed" do
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar} #{options}  -xf #{source}")
+    it 'unpacks the tarball to the current directory with options if no target is passed' do
+      expect(Pkg::Util::File).to receive(:file_exists?).with(source, {:required => true}) { true }
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{tar} #{options}  -xf #{source}")
       Pkg::Util::File.untar_into(source, nil, options)
     end
 
-    it "unpacks the tarball into the target" do
-      File.stub(:capture3ist?).with(source) { true }
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::File.should_receive(:file_writable?).with(target) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar}  -C #{target} -xf #{source}")
+    it 'unpacks the tarball into the target' do
+      allow(File).to receive(:capture3ist?).with(source).and_return true
+      expect(Pkg::Util::File).to receive(:file_exists?).with(source, {:required => true}) { true }
+      expect(Pkg::Util::File).to receive(:file_writable?).with(target) { true }
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{tar}  -C #{target} -xf #{source}")
       Pkg::Util::File.untar_into(source, target)
     end
 
-    it "unpacks the tarball into the target with options passed" do
-      File.stub(:capture3ist?).with(source) { true }
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::File.should_receive(:file_writable?).with(target) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar} #{options} -C #{target} -xf #{source}")
+    it 'unpacks the tarball into the target with options passed' do
+      allow(File).to receive(:capture3ist?).with(source).and_return true
+      expect(Pkg::Util::File).to receive(:file_exists?).with(source, {:required => true}) { true }
+      expect(Pkg::Util::File).to receive(:file_writable?).with(target) { true }
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{tar} #{options} -C #{target} -xf #{source}")
       Pkg::Util::File.untar_into(source, target, options)
     end
   end
 
-  describe "#files_with_ext" do
-    it "returns nothing if there are no files with that extension" do
-      Pkg::Util::File.files_with_ext("./spec/fixtures/configs/components", ".fake").should be_empty
+  describe '#files_with_ext' do
+    it 'returns nothing if there are no files with that extension' do
+      expect(Pkg::Util::File.files_with_ext('./spec/fixtures/configs/components', '.fake')).to be_empty
     end
 
-    it "returns only the files with that extension" do
-      expect(Pkg::Util::File.files_with_ext("./spec/fixtures/configs/components", ".json")).to include("./spec/fixtures/configs/components/test_file.json")
-      expect(Pkg::Util::File.files_with_ext("./spec/fixtures/configs/components", ".json")).to include("./spec/fixtures/configs/components/test_file_2.json")
+    it 'returns only the files with that extension' do
+      expect(Pkg::Util::File.files_with_ext('./spec/fixtures/configs/components', '.json')).to include('./spec/fixtures/configs/components/test_file.json')
+      expect(Pkg::Util::File.files_with_ext('./spec/fixtures/configs/components', '.json')).to include('./spec/fixtures/configs/components/test_file_2.json')
     end
   end
 
-  describe "#install_files_into_dir" do
-    it "selects the correct files to install" do
+  describe '#install_files_into_dir' do
+    it 'selects the correct files to install' do
       Pkg::Config.load_defaults
       workdir = Pkg::Util::File.mktemp
       patterns = []
 
       # Set up a bunch of default settings for these to avoid a lot more stubbing in each section below
-      File.stub(:file?) { false }
-      File.stub(:symlink?) { false }
-      File.stub(:directory?) { false }
-      Pkg::Util::File.stub(:empty_dir?) { false }
+      allow(File).to receive(:file?).and_return false
+      allow(File).to receive(:symlink?).and_return false
+      allow(File).to receive(:directory?).and_return false
+      allow(Pkg::Util::File).to receive(:empty_dir?).and_return false
 
       # Files should have the path made and should be copied
       files.each do |file|
-        File.stub(:file?).with(file).and_return(true)
-        Dir.stub(:[]).with(file).and_return(file)
-        FileUtils.should_receive(:mkpath).with(File.dirname(File.join(workdir, file)), :verbose => false)
-        FileUtils.should_receive(:cp).with(file, File.join(workdir, file), :verbose => false, :preserve => true)
+        allow(File).to receive(:file?).with(file).and_return true
+        allow(Dir).to receive(:[]).with(file).and_return(file)
+        expect(FileUtils).to receive(:mkpath).with(File.dirname(File.join(workdir, file)), :verbose => false)
+        expect(FileUtils).to receive(:cp).with(file, File.join(workdir, file), :verbose => false, :preserve => true)
         patterns << file
       end
 
       # Symlinks should have the path made and should be copied
       symlinks.each do |file|
-        File.stub(:symlink?).with(file).and_return(true)
-        Dir.stub(:[]).with(file).and_return(file)
-        FileUtils.should_receive(:mkpath).with(File.dirname(File.join(workdir, file)), :verbose => false)
-        FileUtils.should_receive(:cp).with(file, File.join(workdir, file), :verbose => false, :preserve => true)
+        allow(File).to receive(:symlink?).with(file).and_return(true)
+        allow(Dir).to receive(:[]).with(file).and_return(file)
+        expect(FileUtils).to receive(:mkpath).with(File.dirname(File.join(workdir, file)), :verbose => false)
+        expect(FileUtils).to receive(:cp).with(file, File.join(workdir, file), :verbose => false, :preserve => true)
         patterns << file
       end
 
       # Dirs should be added to patterns but no acted upon
       dirs.each do |dir|
-        File.stub(:directory?).with(dir).and_return(true)
-        Dir.stub(:[]).with("#{dir}/**/*").and_return(dir)
-        FileUtils.should_not_receive(:mkpath).with(File.dirname(File.join(workdir, dir)), :verbose => false)
-        FileUtils.should_not_receive(:cp).with(dir, File.join(workdir, dir), :verbose => false, :preserve => true)
+        allow(File).to receive(:directory?).with(dir).and_return(true)
+        allow(Dir).to receive(:[]).with("#{dir}/**/*").and_return(dir)
+        expect(FileUtils).not_to receive(:mkpath)
+                                   .with(File.dirname(File.join(workdir, dir)), :verbose => false)
+        expect(FileUtils).not_to receive(:cp)
+                                   .with(dir, File.join(workdir, dir), :verbose => false, :preserve => true)
         patterns << dir
       end
 
       # Empty dirs should have the path created and nothing copied
       empty_dirs.each do |dir|
-        Pkg::Util::File.stub(:empty_dir?).with(dir).and_return(true)
-        Dir.stub(:[]).with(dir).and_return(dir)
-        FileUtils.should_receive(:mkpath).with(File.join(workdir, dir), :verbose => false)
-        FileUtils.should_not_receive(:cp).with(dir, File.join(workdir, dir), :verbose => false, :preserve => true)
+        allow(Pkg::Util::File).to receive(:empty_dir?).with(dir).and_return(true)
+        allow(Dir).to receive(:[]).with(dir).and_return(dir)
+        expect(FileUtils).to receive(:mkpath).with(File.join(workdir, dir), :verbose => false)
+        expect(FileUtils).not_to receive(:cp).with(dir, File.join(workdir, dir), :verbose => false, :preserve => true)
         patterns << dir
       end
 
@@ -115,25 +117,25 @@ describe "Pkg::Util::File" do
     end
   end
 
-  describe "#directories" do
-    it "returns nil if there is no directory" do
-      File.should_receive(:directory?).with("/tmp").and_return(false)
-      Pkg::Util::File.directories("/tmp").should be_nil
+  describe '#directories' do
+    it 'returns nil if there is no directory' do
+      expect(File).to receive(:directory?).with('/tmp').and_return(false)
+      expect(Pkg::Util::File.directories('/tmp')).to be_nil
     end
 
-    it "returns the empty array if there are no dirs in the directory" do
-      File.should_receive(:directory?).with("/tmp").and_return(true)
-      Dir.should_receive(:glob).with("*").and_return([])
-      Pkg::Util::File.directories("/tmp").should be_empty
+    it 'returns the empty array if there are no dirs in the directory' do
+      expect(File).to receive(:directory?).with('/tmp').and_return(true)
+      expect(Dir).to receive(:glob).with('*').and_return([])
+      expect(Pkg::Util::File.directories('/tmp')).to be_empty
     end
 
-    it "returns an array of the top level directories inside a directory" do
-      File.stub(:directory?) { false }
-      ["/tmp", "/tmp/dir", "/tmp/other_dir"].each do |dir|
-        File.should_receive(:directory?).with(dir).and_return(true)
+    it 'returns an array of the top level directories inside a directory' do
+      allow(File).to receive(:directory?).and_return false
+      ['/tmp', '/tmp/dir', '/tmp/other_dir'].each do |dir|
+        expect(File).to receive(:directory?).with(dir).and_return(true)
       end
-      Dir.should_receive(:glob).with("*").and_return(["/tmp/file", "/tmp/dir", "/tmp/other_dir"])
-      Pkg::Util::File.directories("/tmp").should eq(["/tmp/dir", "/tmp/other_dir"])
+      expect(Dir).to receive(:glob).with('*').and_return(['/tmp/file', '/tmp/dir', '/tmp/other_dir'])
+      expect(Pkg::Util::File.directories('/tmp')).to eq(['/tmp/dir', '/tmp/other_dir'])
     end
   end
 end

--- a/spec/lib/packaging/util/gpg_spec.rb
+++ b/spec/lib/packaging/util/gpg_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe "Pkg::Util::Gpg" do
-  let(:gpg)      { "/local/bin/gpg" }
-  let(:keychain) { "/usr/local/bin/keychain" }
-  let(:gpg_key)  { "abcd1234" }
-  let(:target_file) { "/tmp/file" }
+describe 'Pkg::Util::Gpg' do
+  let(:gpg)      { '/local/bin/gpg' }
+  let(:keychain) { '/usr/local/bin/keychain' }
+  let(:gpg_key)  { 'abcd1234' }
+  let(:target_file) { '/tmp/file' }
 
   before(:each) do
     reset_env(['RPM_GPG_AGENT'])
@@ -12,36 +12,36 @@ describe "Pkg::Util::Gpg" do
   end
 
   describe '#key' do
-    it "fails if Pkg::Config.gpg_key isn't set" do
+    it 'fails if Pkg::Config.gpg_key is not set' do
       allow(Pkg::Config).to receive(:gpg_key).and_return(nil)
       expect { Pkg::Util::Gpg.key }.to raise_error(RuntimeError)
     end
-    it "fails if Pkg::Config.gpg_key is an empty string" do
+    it 'fails if Pkg::Config.gpg_key is an empty string' do
       allow(Pkg::Config).to receive(:gpg_key).and_return('')
       expect { Pkg::Util::Gpg.key }.to raise_error(RuntimeError)
     end
   end
 
   describe '#kill_keychain' do
-    it "doesn't reload the keychain if already loaded" do
-      Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", true)
-      Pkg::Util::Gpg.should_receive(:kill_keychain).never
-      Pkg::Util::Gpg.should_receive(:start_keychain).never
+    it 'does not reload the keychain if already loaded' do
+      Pkg::Util::Gpg.instance_variable_set('@keychain_loaded', true)
+      expect(Pkg::Util::Gpg).not_to receive(:kill_keychain)
+      expect(Pkg::Util::Gpg).not_to receive(:start_keychain)
       Pkg::Util::Gpg.load_keychain
-      Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", nil)
+      Pkg::Util::Gpg.instance_variable_set('@keychain_loaded', nil)
     end
 
-    it "doesn't reload the keychain if ENV['RPM_GPG_AGENT'] is set" do
+    it "does not reload the keychain if ENV['RPM_GPG_AGENT'] is set" do
       ENV['RPM_GPG_AGENT'] = 'blerg'
-      Pkg::Util::Gpg.should_receive(:kill_keychain).never
-      Pkg::Util::Gpg.should_receive(:start_keychain).never
+      expect(Pkg::Util::Gpg).not_to receive(:kill_keychain)
+      expect(Pkg::Util::Gpg).not_to receive(:start_keychain)
       Pkg::Util::Gpg.load_keychain
     end
 
     it 'kills and starts the keychain if not loaded already' do
-      Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", nil)
-      Pkg::Util::Gpg.should_receive(:kill_keychain).once
-      Pkg::Util::Gpg.should_receive(:start_keychain).once
+      Pkg::Util::Gpg.instance_variable_set('@keychain_loaded', nil)
+      expect(Pkg::Util::Gpg).to receive(:kill_keychain).once
+      expect(Pkg::Util::Gpg).to receive(:start_keychain).once
       Pkg::Util::Gpg.load_keychain
     end
   end
@@ -49,15 +49,15 @@ describe "Pkg::Util::Gpg" do
   describe '#sign_file' do
     it 'adds special flags if RPM_GPG_AGENT is set' do
       ENV['RPM_GPG_AGENT'] = 'blerg'
-      additional_flags = "--no-tty --use-agent"
-      Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{gpg}\s#{additional_flags}\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      additional_flags = '--no-tty --use-agent'
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('gpg').and_return(gpg)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{gpg}\s#{additional_flags}\s--armor --detach-sign -u #{gpg_key} #{target_file}")
       Pkg::Util::Gpg.sign_file(target_file)
     end
 
     it 'signs without extra flags when RPM_GPG_AGENT is not set' do
-      Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{gpg}\s\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('gpg').and_return(gpg)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{gpg}\s\s--armor --detach-sign -u #{gpg_key} #{target_file}")
       Pkg::Util::Gpg.sign_file(target_file)
     end
   end

--- a/spec/lib/packaging/util/jenkins_spec.rb
+++ b/spec/lib/packaging/util/jenkins_spec.rb
@@ -2,8 +2,8 @@
 require 'spec_helper'
 
 describe Pkg::Util::Jenkins do
-  let(:build_host) {"Jenkins-foo"}
-  let(:name) {"job-foo"}
+  let(:build_host) {'Jenkins-foo'}
+  let(:name) {'job-foo'}
   around do |example|
     old_build_host = Pkg::Config.jenkins_build_host
     Pkg::Config.jenkins_build_host = build_host
@@ -11,75 +11,78 @@ describe Pkg::Util::Jenkins do
     Pkg::Config.jenkins_build_host = old_build_host
   end
 
-  describe "#create_jenkins_job" do
-    let(:xml_file) {"bar.xml"}
+  describe '#create_jenkins_job' do
+    let(:xml_file) {'bar.xml'}
 
-    it "should call curl_form_data with the correct arguments" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/createItem?name=#{name}", ["-H", '"Content-Type: application/xml"', "--data-binary", "@#{xml_file}"])
+    it 'should call curl_form_data with the correct arguments' do
+      expect(Pkg::Util::Net)
+        .to receive(:curl_form_data)
+              .with("http://#{build_host}/createItem?name=#{name}", ["-H", '"Content-Type: application/xml"', "--data-binary", "@#{xml_file}"])
       Pkg::Util::Jenkins.create_jenkins_job(name, xml_file)
     end
   end
 
-  describe "#jenkins_job_exists?" do
-
-    it "should call curl_form_data with correct arguments" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
+  describe '#jenkins_job_exists?' do
+    it 'should call curl_form_data with correct arguments' do
+      expect(Pkg::Util::Net)
+        .to receive(:curl_form_data)
+              .with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
       Pkg::Util::Jenkins.jenkins_job_exists?(name)
     end
 
-    it "should return false on job not existing" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 1])
-      Pkg::Util::Execution.should_receive(:success?).and_return(false)
-      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
+    it 'should return false on job not existing' do
+      expect(Pkg::Util::Net).to receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 1])
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(false)
+      expect(Pkg::Util::Jenkins.jenkins_job_exists?(name)).to be false
     end
 
-    it "should return false if curl_form_data raised a runtime error" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(false)
-      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
+    it 'should return false if curl_form_data raised a runtime error' do
+      expect(Pkg::Util::Net).to receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(false)
+      expect(Pkg::Util::Jenkins.jenkins_job_exists?(name)).to be false
     end
 
-    it "should return true when job exists" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
-      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_true
+    it 'should return true when job exists' do
+      expect(Pkg::Util::Net).to receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      expect(Pkg::Util::Jenkins.jenkins_job_exists?(name)).to be true
     end
   end
 
   describe '#poll_jenkins_job' do
-    let(:job_url) { "http://cat.meow/" }
+    let(:job_url) { 'http://cat.meow/' }
     let(:build_url) { "#{job_url}/1" }
-    let(:result) { "SUCCESS" }
+    let(:result) { 'SUCCESS' }
     let(:job_hash) { {'lastBuild' => { 'url' => build_url } }}
     let(:build_hash) { {'result' => result, 'building' => false } }
 
     before :each do
-      subject.stub(:get_jenkins_info).with(job_url).and_return(job_hash)
-      subject.stub(:wait_for_build).with(build_url).and_return(build_hash)
+      allow(subject).to receive(:get_jenkins_info).with(job_url).and_return(job_hash)
+      allow(subject).to receive(:wait_for_build).with(build_url).and_return(build_hash)
     end
 
-    context "when polling the given url" do
-      it "return the resulting build_hash when build completes successfully" do
+    context 'when polling the given url' do
+      it 'return the resulting build_hash when build completes successfully' do
         subject.poll_jenkins_job(job_url)
       end
     end
   end
 
   describe '#wait_for_build' do
-    let(:job_url) { "http://cat.meow/" }
+    let(:job_url) { 'http://cat.meow/' }
     let(:build_url) { "#{job_url}/1" }
     let(:build_hash) { {'building' => false } }
 
-    context "when waiting for the given build to finish" do
-      it "return the resulting build_hash when build completes successfully" do
-        subject.should_receive(:get_jenkins_info).with(job_url).and_return(build_hash)
+    context 'when waiting for the given build to finish' do
+      it 'return the resulting build_hash when build completes successfully' do
+        expect(subject).to receive(:get_jenkins_info).with(job_url).and_return(build_hash)
         subject.wait_for_build(job_url)
       end
     end
   end
 
   describe '#get_jenkins_info' do
-    let(:url) { "http://cat.meow/" }
+    let(:url) { 'http://cat.meow/' }
     let(:uri) { URI(url) }
     let(:response) { double }
     let(:valid_json) { "{\"employees\":[
@@ -88,20 +91,20 @@ describe Pkg::Util::Jenkins do
     {\"firstName\":\"Peter\", \"lastName\":\"Jones\"} ]}" }
 
     before :each do
-      response.stub(:body).and_return( valid_json )
-      response.stub(:code).and_return( '200' )
-      Pkg::Util::Jenkins.should_receive(:URI).and_return(uri)
+      allow(response).to receive(:body).and_return valid_json
+      allow(response).to receive(:code).and_return '200'
+      expect(Pkg::Util::Jenkins).to receive(:URI).and_return(uri)
     end
 
-    context "when making HTTP GET request to given url" do
-      it "should return Hash of JSON contents when response is non-error" do
-        Net::HTTP.should_receive(:get_response).with(uri).and_return(response)
+    context 'when making HTTP GET request to given url' do
+      it 'should return Hash of JSON contents when response is non-error' do
+        expect(Net::HTTP).to receive(:get_response).with(uri).and_return(response)
         subject.get_jenkins_info(url)
       end
 
-      it "should raise Runtime error when response is error" do
-        response.stub(:code).and_return( '400' )
-        Net::HTTP.should_receive(:get_response).with(uri).and_return(response)
+      it 'should raise Runtime error when response is error' do
+        allow(response).to receive(:code).and_return '400'
+        expect(Net::HTTP).to receive(:get_response).with(uri).and_return(response)
         expect{
           subject.get_jenkins_info(url)
         }.to raise_error(Exception, /Unable to query .*, please check that it is valid./)

--- a/spec/lib/packaging/util/misc_spec.rb
+++ b/spec/lib/packaging/util/misc_spec.rb
@@ -14,18 +14,18 @@ describe 'Pkg::Util::Misc' do
 
     it 'replaces the token with the Pkg::Config variable' do
       Pkg::Config.config_from_hash({:project => "foo", :repo_name => 'abcdefg'})
-      Pkg::Util::Misc.search_and_replace(orig_string, good_replacements).should eq(updated_string)
+      expect(Pkg::Util::Misc.search_and_replace(orig_string, good_replacements)).to eq updated_string
     end
 
     it 'does no replacement if the Pkg::Config variable is not set' do
       Pkg::Config.config_from_hash({:project => 'foo',})
-      Pkg::Util::Misc.search_and_replace(orig_string, good_replacements).should eq(orig_string)
+      expect(Pkg::Util::Misc.search_and_replace(orig_string, good_replacements)).to eq(orig_string)
     end
 
     it 'warns and continues if the Pkg::Config variable is unknown to packaging' do
       Pkg::Config.config_from_hash({:project => 'foo',})
-      Pkg::Util::Misc.should_receive(:warn).with("replacement value for '#{warn_replacements.keys.first}' probably shouldn't be nil")
-      Pkg::Util::Misc.search_and_replace(orig_string, warn_replacements).should eq(orig_string)
+      expect(Pkg::Util::Misc).to receive(:warn).with("replacement value for '#{warn_replacements.keys.first}' probably shouldn't be nil")
+      expect(Pkg::Util::Misc.search_and_replace(orig_string, warn_replacements)).to eq orig_string
     end
   end
 end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -2,255 +2,255 @@ require 'spec_helper'
 require 'socket'
 require 'open3'
 
-describe "Pkg::Util::Net" do
-  let(:target)     { "/tmp/placething" }
-  let(:target_uri) { "http://google.com" }
-  let(:content)    { "stuff" }
-  let(:rsync)      { "/bin/rsync" }
-  let(:ssh)        { "/usr/local/bin/ssh" }
-  let(:s3cmd)      { "/usr/local/bin/s3cmd" }
+describe 'Pkg::Util::Net' do
+  let(:target)     { '/tmp/placething' }
+  let(:target_uri) { 'http://google.com' }
+  let(:content)    { 'stuff' }
+  let(:rsync)      { '/bin/rsync' }
+  let(:ssh)        { '/usr/local/bin/ssh' }
+  let(:s3cmd)      { '/usr/local/bin/s3cmd' }
 
-  describe "#fetch_uri" do
-    context "given a target directory" do
-      it "does nothing if the directory isn't writable" do
-        File.stub(:writable?).with(File.dirname(target)) { false }
-        File.should_receive(:open).never
+  describe '#fetch_uri' do
+    context 'given a target directory' do
+      it 'does nothing if the directory is not writable' do
+        allow(File).to receive(:writable?).with(File.dirname(target)).and_return false
+        expect(File).to receive(:open).never
         Pkg::Util::Net.fetch_uri(target_uri, target)
       end
 
-      it "writes the content of the uri to a file if directory is writable" do
-        File.should_receive(:writable?).once.with(File.dirname(target)) { true }
-        File.should_receive(:open).once.with(target, 'w')
+      it 'writes the content of the uri to a file if directory is writable' do
+        expect(File).to receive(:writable?).once.with(File.dirname(target)) { true }
+        expect(File).to receive(:open).once.with(target, 'w')
         Pkg::Util::Net.fetch_uri(target_uri, target)
       end
     end
   end
 
-  describe "hostname utils" do
+  describe 'hostname utils' do
 
-    describe "hostname" do
-      it "should return the hostname of the current host" do
-        Socket.stub(:gethostname) { "foo" }
-        Pkg::Util::Net.hostname.should eq("foo")
+    describe 'hostname' do
+      it 'should return the hostname of the current host' do
+        allow(Socket).to receive(:gethostname).and_return 'foo'
+        expect(Pkg::Util::Net.hostname).to eq 'foo'
       end
     end
 
-    describe "check_host" do
-      context "with required :true" do
-        it "should raise an exception if the passed host does not match the current host" do
-          Socket.stub(:gethostname) { "foo" }
-          Pkg::Util::Net.should_receive(:check_host).and_raise(RuntimeError)
-          expect{ Pkg::Util::Net.check_host("bar", :required => true) }.to raise_error(RuntimeError)
+    describe 'check_host' do
+      context 'with required :true' do
+        it 'should raise an exception if the passed host does not match the current host' do
+          allow(Socket).to receive(:gethostname).and_return 'foo'
+          expect(Pkg::Util::Net).to receive(:check_host).and_raise(RuntimeError)
+          expect{ Pkg::Util::Net.check_host('bar', :required => true) }.to raise_error(RuntimeError)
         end
       end
 
-      context "with required :false" do
-        it "should return nil if the passed host does not match the current host" do
-          Socket.stub(:gethostname) { "foo" }
-          Pkg::Util::Net.check_host("bar", :required => false).should be_nil
+      context 'with required :false' do
+        it 'should return nil if the passed host does not match the current host' do
+          allow(Socket).to receive(:gethostname).and_return 'foo'
+          expect(Pkg::Util::Net.check_host('bar', :required => false)).to be_nil
         end
       end
     end
   end
 
-  describe "remote_ssh_cmd" do
-    it "should be able to call via deprecated shim" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
-      Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true)
+  describe 'remote_ssh_cmd' do
+    it 'should be able to call via deprecated shim' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      Pkg::Util::Net.remote_ssh_cmd('foo', 'bar', true)
     end
   end
 
-  describe "remote_execute" do
-    it "should fail if ssh is not present" do
-      Pkg::Util::Tool.stub(:find_tool).with("ssh") { fail }
-      Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_raise(RuntimeError)
-      expect{ Pkg::Util::Net.remote_execute("foo", "bar") }.to raise_error(RuntimeError)
+  describe 'remote_execute' do
+    it 'should fail if ssh is not present' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('ssh') { fail }
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_raise(RuntimeError)
+      expect{ Pkg::Util::Net.remote_execute('foo', 'bar') }.to raise_error(RuntimeError)
     end
 
-    it "should be able to not fail fast" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
+    it 'should be able to not fail fast' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
         Pkg::Util::Net.remote_execute(
-          "foo", "bar", capture_output: false, extra_options: '', fail_fast: false)
+          'foo', 'bar', capture_output: false, extra_options: '', fail_fast: false)
     end
 
-    it "should be able to trace output" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -x;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
+    it 'should be able to trace output' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -x;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
         Pkg::Util::Net.remote_execute(
-          "foo", "bar", capture_output: false, fail_fast: false, trace: true)
+          'foo', 'bar', capture_output: false, fail_fast: false, trace: true)
     end
 
-    context "without output captured" do
-      it "should execute a command :foo on a host :bar using Kernel" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "bar")
+    context 'without output captured' do
+      it 'should execute a command :foo on a host :bar using Kernel' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', 'bar')
       end
 
-      it "should escape single quotes in the command" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "b'ar")
+      it 'should escape single quotes in the command' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', "b'ar")
       end
 
-      it "should raise an error if ssh fails" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(false)
-        expect{ Pkg::Util::Net.remote_execute("foo", "bar") }
+      it 'should raise an error if ssh fails' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(false)
+        expect{ Pkg::Util::Net.remote_execute('foo', 'bar') }
           .to raise_error(RuntimeError, /failed./)
       end
     end
 
-    context "with output captured" do
-      it "should execute a command :foo on a host :bar using Pkg::Util::Execution.capture3" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "bar", capture_output: true)
+    context 'with output captured' do
+      it 'should execute a command :foo on a host :bar using Pkg::Util::Execution.capture3' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', 'bar', capture_output: true)
       end
 
-      it "should escape single quotes in the command" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "b'ar", capture_output: true)
+      it 'should escape single quotes in the command' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', "b'ar", capture_output: true)
       end
 
-      it "should raise an error if ssh fails" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(false)
-        expect{ Pkg::Util::Net.remote_execute("foo", "bar", capture_output: true) }
+      it 'should raise an error if ssh fails' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(false)
+        expect{ Pkg::Util::Net.remote_execute('foo', 'bar', capture_output: true) }
           .to raise_error(RuntimeError, /failed./)
       end
     end
   end
 
-  describe "#rsync_to" do
-    defaults = "--recursive --hard-links --links --verbose --omit-dir-times --no-perms --no-owner --no-group"
-    it "should fail if rsync is not present" do
-      Pkg::Util::Tool.stub(:find_tool).with("rsync") { fail }
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_raise(RuntimeError)
-      expect{ Pkg::Util::Net.rsync_to("foo", "bar", "boo") }.to raise_error(RuntimeError)
+  describe '#rsync_to' do
+    defaults = '--recursive --hard-links --links --verbose --omit-dir-times --no-perms --no-owner --no-group'
+    it 'should fail if rsync is not present' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('rsync') { fail }
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_raise(RuntimeError)
+      expect{ Pkg::Util::Net.rsync_to('foo', 'bar', 'boo') }.to raise_error(RuntimeError)
     end
 
     it "should rsync 'thing' to 'foo@bar:/home/foo' with flags '#{defaults} --ignore-existing'" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --ignore-existing thing foo@bar:/home/foo", true)
-      Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{rsync} #{defaults} --ignore-existing thing foo@bar:/home/foo", true)
+      Pkg::Util::Net.rsync_to('thing', 'foo@bar', '/home/foo')
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include --ignore-existing" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} thing foo@bar:/home/foo", true)
-      Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", extra_flags: [])
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{rsync} #{defaults} thing foo@bar:/home/foo", true)
+      Pkg::Util::Net.rsync_to('thing', 'foo@bar', '/home/foo', extra_flags: [])
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag thing foo@bar:/home/foo", true)
-      Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", extra_flags: ["--foo-bar", "--and-another-flag"])
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag thing foo@bar:/home/foo", true)
+      Pkg::Util::Net.rsync_to('thing', 'foo@bar', '/home/foo', extra_flags: ['--foo-bar', '--and-another-flag'])
     end
   end
 
-  describe "#s3sync_to" do
-    it "should fail if s3cmd is not present" do
-      Pkg::Util::Tool.should_receive(:find_tool).with('s3cmd', :required => true).and_raise(RuntimeError)
-      Pkg::Util::Execution.should_not_receive(:capture3).with("#{s3cmd} sync  'foo' s3://bar/boo/")
-      expect{ Pkg::Util::Net.s3sync_to("foo", "bar", "boo") }.to raise_error(RuntimeError)
+  describe '#s3sync_to' do
+    it 'should fail if s3cmd is not present' do
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('s3cmd', :required => true).and_raise(RuntimeError)
+      expect(Pkg::Util::Execution).not_to receive(:capture3).with("#{s3cmd} sync  'foo' s3://bar/boo/")
+      expect{ Pkg::Util::Net.s3sync_to('foo', 'bar', 'boo') }.to raise_error(RuntimeError)
     end
 
-    it "should fail if ~/.s3cfg is not present" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
-      Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(false)
-      expect{ Pkg::Util::Net.s3sync_to("foo", "bar", "boo") }.to raise_error(RuntimeError, /does not exist/)
+    it 'should fail if ~/.s3cfg is not present' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('s3cmd').and_return(s3cmd)
+      expect(Pkg::Util::File).to receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(false)
+      expect{ Pkg::Util::Net.s3sync_to('foo', 'bar', 'boo') }.to raise_error(RuntimeError, /does not exist/)
     end
 
     it "should s3 sync 'thing' to 's3://foo@bar/home/foo/' with no flags" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
-      Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{s3cmd} sync  'thing' s3://foo@bar/home/foo/")
-      Pkg::Util::Net.s3sync_to("thing", "foo@bar", "home/foo")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('s3cmd').and_return(s3cmd)
+      expect(Pkg::Util::File).to receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{s3cmd} sync  'thing' s3://foo@bar/home/foo/")
+      Pkg::Util::Net.s3sync_to('thing', 'foo@bar', 'home/foo')
     end
 
     it "should s3 sync 'thing' to 's3://foo@bar/home/foo/' with --delete-removed and --acl-public" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
-      Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{s3cmd} sync --delete-removed --acl-public 'thing' s3://foo@bar/home/foo/")
-      Pkg::Util::Net.s3sync_to("thing", "foo@bar", "home/foo", ["--delete-removed", "--acl-public"])
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('s3cmd').and_return(s3cmd)
+      expect(Pkg::Util::File).to receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{s3cmd} sync --delete-removed --acl-public 'thing' s3://foo@bar/home/foo/")
+      Pkg::Util::Net.s3sync_to('thing', 'foo@bar', 'home/foo', ['--delete-removed', '--acl-public'])
     end
   end
 
-  describe "#rsync_from" do
-    defaults = "--recursive --hard-links --links --verbose --omit-dir-times --no-perms --no-owner --no-group"
-    it "should fail if rsync is not present" do
-      Pkg::Util::Tool.stub(:find_tool).with("rsync") { fail }
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_raise(RuntimeError)
-      expect{ Pkg::Util::Net.rsync_from("foo", "bar", "boo") }.to raise_error(RuntimeError)
+  describe '#rsync_from' do
+    defaults = '--recursive --hard-links --links --verbose --omit-dir-times --no-perms --no-owner --no-group'
+    it 'should fail if rsync is not present' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('rsync') { fail }
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_raise(RuntimeError)
+      expect{ Pkg::Util::Net.rsync_from('foo', 'bar', 'boo') }.to raise_error(RuntimeError)
     end
 
     it "should not include the flags '--ignore-existing' by default" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
-      Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
+      Pkg::Util::Net.rsync_from('thing', 'foo@bar', '/home/foo')
     end
 
     it "should rsync 'thing' from 'foo@bar' to '/home/foo' with flags '#{defaults}'" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
-      Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
+      Pkg::Util::Net.rsync_from('thing', 'foo@bar', '/home/foo')
     end
 
     it "rsyncs 'thing' from 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag foo@bar:thing /home/foo", true)
-      Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo", extra_flags: ["--foo-bar", "--and-another-flag"])
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag foo@bar:thing /home/foo", true)
+      Pkg::Util::Net.rsync_from('thing', 'foo@bar', '/home/foo', extra_flags: ['--foo-bar', '--and-another-flag'])
     end
   end
 
-  describe "#curl_form_data" do
-    let(:curl) {"/bin/curl"}
-    let(:form_data) {["name=FOO"]}
+  describe '#curl_form_data' do
+    let(:curl) {'/bin/curl'}
+    let(:form_data) {['name=FOO']}
     let(:options) { {:quiet => true} }
 
-    it "should return false on failure" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i '#{target_uri}'").and_return(['stdout', 'stderr', 1])
-      Pkg::Util::Net.curl_form_data(target_uri).should eq(['stdout', 1])
+    it 'should return false on failure' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{curl} -i '#{target_uri}'").and_return(['stdout', 'stderr', 1])
+      expect(Pkg::Util::Net.curl_form_data(target_uri)).to eq ['stdout', 1]
     end
 
 
-    it "should curl with just the uri" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i '#{target_uri}'")
+    it 'should curl with just the uri' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{curl} -i '#{target_uri}'")
       Pkg::Util::Net.curl_form_data(target_uri)
     end
 
-    it "should curl with the form data and uri" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} '#{target_uri}'")
+    it 'should curl with the form data and uri' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{curl} -i #{form_data[0]} '#{target_uri}'")
       Pkg::Util::Net.curl_form_data(target_uri, form_data)
     end
 
-    it "should curl with form data, uri, and be quiet" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} '#{target_uri}'").and_return(['stdout', 'stderr', 0])
-      Pkg::Util::Net.curl_form_data(target_uri, form_data, options).should eq(['', 0])
+    it 'should curl with form data, uri, and be quiet' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{curl} -i #{form_data[0]} '#{target_uri}'").and_return(['stdout', 'stderr', 0])
+      expect(Pkg::Util::Net.curl_form_data(target_uri, form_data, options)).to eq ['', 0]
     end
 
   end
 
-  describe "#print_url_info" do
-    it "should output correct formatting" do
-      Pkg::Util::Net.should_receive(:puts).with("\n////////////////////////////////////////////////////////////////////////////////\n\n
+  describe '#print_url_info' do
+    it 'should output correct formatting' do
+      expect(Pkg::Util::Net).to receive(:puts).with("\n////////////////////////////////////////////////////////////////////////////////\n\n
   Build submitted. To view your build progress, go to\n#{target_uri}\n\n
 ////////////////////////////////////////////////////////////////////////////////\n\n")
       Pkg::Util::Net.print_url_info(target_uri)

--- a/spec/lib/packaging/util/rake_utils_spec.rb
+++ b/spec/lib/packaging/util/rake_utils_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Pkg::Util::RakeUtils" do
+describe 'Pkg::Util::RakeUtils' do
   let(:foo_defined?) { Rake::Task.task_defined?(:foo) }
   let(:bar_defined?) { Rake::Task.task_defined?(:bar) }
   let(:define_foo)   { body = proc{}; Rake::Task.define_task(:foo, &body) }
@@ -12,21 +12,21 @@ describe "Pkg::Util::RakeUtils" do
     end
   end
 
-  describe "#task_defined?" do
-    context "given a Rake::Task task name" do
-      it "should return true if the task exists" do
-        Rake::Task.stub(:task_defined?).with(:foo) {true}
-        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be_true
+  describe '#task_defined?' do
+    context 'given a Rake::Task task name' do
+      it 'should return true if the task exists' do
+        allow(Rake::Task).to receive(:task_defined?).with(:foo).and_return true
+        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be true
       end
-      it "should return false if the task does not exist" do
-        Rake::Task.stub(:task_defined?).with(:foo) {false}
-        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be_false
+      it 'should return false if the task does not exist' do
+        allow(Rake::Task).to receive(:task_defined?).with(:foo).and_return false
+        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be false
       end
     end
   end
 
-  describe "#get_task" do
-    it "should return a task object for a named task" do
+  describe '#get_task' do
+    it 'should return a task object for a named task' do
       foo = nil
       if !foo_defined?
         foo = define_foo
@@ -39,8 +39,8 @@ describe "Pkg::Util::RakeUtils" do
     end
   end
 
-  describe "#add_dependency" do
-    it "should add a dependency to a given rake task" do
+  describe '#add_dependency' do
+    it 'should add a dependency to a given rake task' do
       foo = nil
       bar = nil
       if !foo_defined?
@@ -54,13 +54,13 @@ describe "Pkg::Util::RakeUtils" do
         bar = Rake::Task[:bar]
       end
       Pkg::Util::RakeUtils.add_dependency(foo, bar)
-      expect(Rake::Task["foo"].prerequisites).to include(bar)
+      expect(Rake::Task['foo'].prerequisites).to include(bar)
     end
   end
 
-  describe "#evaluate_pre_tasks" do
-    context "Given a data file with :pre_tasks defined" do
-      it "should, for each k=>v pair, add v as a dependency to k" do
+  describe '#evaluate_pre_tasks' do
+    context 'Given a data file with :pre_tasks defined' do
+      it 'should, for each k=>v pair, add v as a dependency to k' do
         Pkg::Config.config_from_yaml(File.join(FIXTURES, 'util', 'pre_tasks.yaml'))
         expect(Pkg::Util::RakeUtils).to receive(:add_dependency)
         Pkg::Util::RakeUtils.evaluate_pre_tasks

--- a/spec/lib/packaging_spec.rb
+++ b/spec/lib/packaging_spec.rb
@@ -2,18 +2,17 @@ require 'spec_helper'
 
 #   We load packaging.rb once, in spec_helper, to avoid reloading the library
 #   and issuing warnings about already defined constants.
-describe "Pkg" do
-  it "should require the utilities module, Pkg::Util" do
-    Pkg::Util.should_not be_nil
+describe 'Pkg' do
+  it 'should require the utilities module, Pkg::Util' do
+    expect(Pkg::Util).not_to be_nil
   end
 
-  it  "should require the configuration module, Pkg::Config" do
-    Pkg::Config.should_not be_nil
+  it  'should require the configuration module, Pkg::Config' do
+    expect(Pkg::Config).not_to be_nil
   end
 
-  it  "should require the tar library, Pkg::Tar" do
-    Pkg::Tar.should_not be_nil
+  it  'should require the tar library, Pkg::Tar' do
+    expect(Pkg::Tar).not_to be_nil
   end
 
 end
-

--- a/tasks/30_metrics.rake
+++ b/tasks/30_metrics.rake
@@ -1,11 +1,11 @@
-@metrics          = []
+@metrics = []
 def add_shipped_metrics(args)
   @metrics << {
-    :type         => 'shipped',
-    :package      => (args[:package]             || Pkg::Config.project),
-    :version      => (args[:version]             || Pkg::Config.version),
-    :pe_version   => (args[:pe_version]          || Pkg::Config.pe_version),
-    :is_rc        => (args[:is_rc]               || false),
+    :type => 'shipped',
+    :package => (args[:package]             || Pkg::Config.project),
+    :version => (args[:version]             || Pkg::Config.version),
+    :pe_version => (args[:pe_version] || Pkg::Config.pe_version),
+    :is_rc => (args[:is_rc] || false)
   }
 end
 
@@ -22,11 +22,11 @@ def post_shipped_metrics
     res = Net::HTTP.post_form(
       uri,
       {
-        'type'          => type,
-        'package'       => package,
-        'version'       => version,
-        'pe_version'    => pe_version,
-        'is_rc'         => is_rc,
+        'type' => type,
+        'package' => package,
+        'version' => version,
+        'pe_version' => pe_version,
+        'is_rc' => is_rc
       }
     )
   end

--- a/tasks/archive.rake
+++ b/tasks/archive.rake
@@ -1,11 +1,10 @@
 namespace :pl do
   namespace :remote do
-
     desc "Move packages from repo paths to archive staging paths"
-    task :stage_archives, [:yum_directories, :apt_directories, :downloads_directories] => 'pl:fetch' do |_t, args|
-      yum_directories = args.yum_directories ? args.yum_directories.split(' ') : []
-      apt_directories = args.apt_directories ? args.apt_directories.split(' ') : []
-      downloads_directories = args.downloads_directories ? args.downloads_directories.split(' ') : []
+    task :stage_archives, %i[yum_directories apt_directories downloads_directories] => 'pl:fetch' do |_t, args|
+      yum_directories = args.yum_directories ? args.yum_directories.split : []
+      apt_directories = args.apt_directories ? args.apt_directories.split : []
+      downloads_directories = args.downloads_directories ? args.downloads_directories.split : []
 
       yum_directories.each do |directory|
         Pkg::Archive.stage_yum_archives(directory)

--- a/tasks/clean.rake
+++ b/tasks/clean.rake
@@ -2,4 +2,3 @@ desc "Clean all built packages, eg rm -rf pkg"
 task :clean do
   rm_rf 'pkg'
 end
-

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -24,7 +24,7 @@ def debuild(args)
   results_dir = args[:work_dir]
   begin
     sh "debuild --no-lintian -uc -us"
-  rescue => e
+  rescue StandardError => e
     fail "Something went wrong. Hopefully the backscroll or #{results_dir}/#{Pkg::Config.project}_#{Pkg::Config.debversion}.build file has a clue.\n#{e}"
   end
 end
@@ -47,13 +47,12 @@ task :prep_deb_tars, :work_dir do |t, args|
     pkg_dir = "#{work_dir}/#{Pkg::Config.project}-#{Pkg::Config.debversion}"
     cd 'ext' do
       Pathname('debian').find do |file|
-        case
-        when file.to_s =~ /~$/, file.to_s =~ /^#/
+        if file.to_s =~ /~$/ || file.to_s =~ /^#/
           next
-        when file.directory?
+        elsif file.directory?
           mkdir_p "#{pkg_dir}/#{file}"
-        when file.extname == '.erb'
-          Pkg::Util::File.erb_file(file, "#{pkg_dir}/#{file.sub(/\.[^\.]*$/, '')}", false, :binding => Pkg::Config.get_binding)
+        elsif file.extname == '.erb'
+          Pkg::Util::File.erb_file(file, "#{pkg_dir}/#{file.sub(/\.[^.]*$/, '')}", false, :binding => Pkg::Config.get_binding)
         else
           cp file, "#{pkg_dir}/#{file}"
         end
@@ -70,10 +69,10 @@ task :build_deb, :deb_command, :cow do |t, args|
     work_dir  = Pkg::Util::File.mktemp
     subdir    = 'pe/' if Pkg::Config.build_pe
     codename = /base-(.*)-(.*)\.cow/.match(cow)[1] unless cow.nil?
-    dest_dir  = File.join(Pkg::Config.project_root, "pkg", "#{subdir}deb", codename.to_s, subrepo.to_s)
+    dest_dir = File.join(Pkg::Config.project_root, "pkg", "#{subdir}deb", codename.to_s, subrepo.to_s)
     Pkg::Util::Tool.check_tool(deb_build)
     mkdir_p dest_dir
-    deb_args  = { :work_dir => work_dir, :cow => cow }
+    deb_args = { :work_dir => work_dir, :cow => cow }
     Rake::Task[:prep_deb_tars].reenable
     Rake::Task[:prep_deb_tars].invoke(work_dir)
     cd "#{work_dir}/#{Pkg::Config.project}-#{Pkg::Config.debversion}" do
@@ -112,7 +111,7 @@ end
 
 namespace :pl do
   desc "Create a deb from this repo using the default cow #{Pkg::Config.default_cow}."
-  task :deb => "package:tar"  do
+  task :deb => "package:tar" do
     Pkg::Util.check_var('PE_VER', Pkg::Config.pe_version) if Pkg::Config.build_pe
     Rake::Task[:build_deb].invoke('pdebuild', Pkg::Config.default_cow)
   end
@@ -120,7 +119,7 @@ namespace :pl do
   desc "Create debs from this git repository using all cows specified in build_defaults yaml"
   task :deb_all do
     Pkg::Util.check_var('PE_VER', Pkg::Config.pe_version) if Pkg::Config.build_pe
-    Pkg::Config.cows.split(' ').each do |cow|
+    Pkg::Config.cows.split.each do |cow|
       Rake::Task["package:tar"].invoke
       Rake::Task[:build_deb].reenable
       Rake::Task[:build_deb].invoke('pdebuild', cow)

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -12,9 +12,9 @@ if Pkg::Config.build_doc
     RDoc::Task.new(:doc) do |rdoc|
       rdoc.rdoc_dir = 'doc'
       rdoc.title = "#{Pkg::Config.project} version #{Pkg::Config.version}"
-      Pkg::Config.gem_rdoc_options.each do |option|
-        rdoc.options << option
-      end unless Pkg::Config.gem_rdoc_options.nil?
+      Pkg::Config.gem_rdoc_options&.each do |option|
+          rdoc.options << option
+        end
     end
   end
 end

--- a/tasks/education.rake
+++ b/tasks/education.rake
@@ -1,7 +1,6 @@
 namespace :pl do
   namespace :jenkins do
-    task :deploy_learning_vm, [:vm, :md5, :target_bucket, :target_directory] => "pl:fetch" do |t, args|
-
+    task :deploy_learning_vm, %i[vm md5 target_bucket target_directory] => "pl:fetch" do |t, args|
       vm = args.vm or fail ":vm is a required argument for #{t}"
       md5 = args.md5 or fail ":md5 is a required argument for #{t}"
       target_bucket = args.target_bucket or fail ":target_bucket is a required argument for #{t}"
@@ -13,8 +12,7 @@ namespace :pl do
       puts "'#{vm}' and '#{md5}' have been shipped via s3 to '#{target_bucket}/#{target_directory}'"
     end
 
-    task :deploy_training_vm, [:vm, :md5, :target_host, :target_directory] => "pl:fetch" do |t, args|
-
+    task :deploy_training_vm, %i[vm md5 target_host target_directory] => "pl:fetch" do |t, args|
       vm = args.vm or fail ":vm is a required argument for #{t}"
       md5 = args.md5 or fail ":md5 is a required argument for #{t}"
       target_host = args.target_host or fail ":target_host is a required argument for #{t}"

--- a/tasks/fetch.rake
+++ b/tasks/fetch.rake
@@ -15,8 +15,8 @@ end
 team_data_branch = Pkg::Config.team
 
 if Pkg::Config.build_pe
-  project_data_branch = 'pe-' + project_data_branch unless project_data_branch =~ /^pe-/
-  team_data_branch = 'pe-' + team_data_branch unless team_data_branch =~ /^pe-/
+  project_data_branch = "pe-#{project_data_branch}" unless project_data_branch =~ /^pe-/
+  team_data_branch = "pe-#{team_data_branch}" unless team_data_branch =~ /^pe-/
 end
 
 # The pl:fetch task pulls down two files from the build-data repo that contain additional

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 def glob_gem_files
   gem_files = []
   gem_excludes_file_list = []
-  gem_excludes_raw = Pkg::Config.gem_excludes.nil? ? [] : Pkg::Config.gem_excludes.split(' ')
+  gem_excludes_raw = Pkg::Config.gem_excludes.nil? ? [] : Pkg::Config.gem_excludes.split
   gem_excludes_raw << 'ext/packaging'
   gem_excludes_raw << 'pkg'
   gem_excludes_raw.each do |exclude|
@@ -13,7 +13,7 @@ def glob_gem_files
       gem_excludes_file_list << exclude
     end
   end
-  files = FileList[Pkg::Config.gem_files.split(' ')]
+  files = FileList[Pkg::Config.gem_files.split]
   files.each do |file|
     if File.directory?(file)
       gem_files += FileList["#{file}/**/*"]
@@ -54,25 +54,25 @@ def create_default_gem_spec
     s.require_path = Pkg::Config.gem_require_path                    unless Pkg::Config.gem_require_path.nil?
     s.required_ruby_version = Pkg::Config.gem_required_ruby_version  unless Pkg::Config.gem_required_ruby_version.nil?
     s.required_rubygems_version = Pkg::Config.gem_required_rubygems_version unless Pkg::Config.gem_required_rubygems_version.nil?
-    s.test_files = FileList[Pkg::Config.gem_test_files.split(' ')]   unless Pkg::Config.gem_test_files.nil?
-    s.rubyforge_project = Pkg::Config.gem_forge_project              unless Pkg::Config.gem_forge_project.nil?
-    Pkg::Config.gem_rdoc_options.each do |option|
-      s.rdoc_options << option
-    end unless Pkg::Config.gem_rdoc_options.nil?
+    s.test_files = FileList[Pkg::Config.gem_test_files.split] unless Pkg::Config.gem_test_files.nil?
+    s.rubyforge_project = Pkg::Config.gem_forge_project unless Pkg::Config.gem_forge_project.nil?
+    Pkg::Config.gem_rdoc_options&.each do |option|
+        s.rdoc_options << option
+      end
   end
 
-  Pkg::Config.gem_runtime_dependencies.each do |gem, version|
-    spec = add_gem_dependency(:spec => spec, :gem => gem, :version => version, :type => :runtime)
-  end unless Pkg::Config.gem_runtime_dependencies.nil?
+  Pkg::Config.gem_runtime_dependencies&.each do |gem, version|
+      spec = add_gem_dependency(:spec => spec, :gem => gem, :version => version, :type => :runtime)
+    end
 
-  Pkg::Config.gem_development_dependencies.each do |gem, version|
-    spec = add_gem_dependency(:spec => spec, :gem => gem, :version => version, :type => :development)
-  end unless Pkg::Config.gem_development_dependencies.nil?
+  Pkg::Config.gem_development_dependencies&.each do |gem, version|
+      spec = add_gem_dependency(:spec => spec, :gem => gem, :version => version, :type => :development)
+    end
   spec
 end
 
 def create_gem(spec, gembuilddir)
-  gem_files = glob_gem_files + FileList[(Pkg::Config.gem_test_files || '').split(' ')]
+  gem_files = glob_gem_files + FileList[(Pkg::Config.gem_test_files || '').split]
   workdir = File.join(Pkg::Util::File.mktemp)
 
   bench = Benchmark.realtime do
@@ -99,6 +99,7 @@ end
 
 def unknown_gems_platform?(platform)
   return true if platform.os == "unknown"
+
   false
 end
 
@@ -106,9 +107,11 @@ def create_platform_specific_gems
   Pkg::Config.gem_platform_dependencies.each do |platform, dependency_hash|
     spec = create_default_gem_spec
     pf = Gem::Platform.new(platform)
-    fail "
-      Platform: '#{platform}' is not recognized by rubygems.
-      This is probably an erroneous 'gem_platform_dependencies' entry!" if unknown_gems_platform?(pf)
+    if unknown_gems_platform?(pf)
+      fail "
+        Platform: '#{platform}' is not recognized by rubygems.
+        This is probably an erroneous 'gem_platform_dependencies' entry!"
+    end
     spec.platform = pf
     dependency_hash.each do |type, gems|
       t = case type

--- a/tasks/load_extras.rake
+++ b/tasks/load_extras.rake
@@ -10,6 +10,7 @@ namespace :pl do
     unless ENV['PARAMS_FILE'] && ENV['PARAMS_FILE'] != ''
       tempdir = args.tempdir
       raise "pl:load_extras requires a directory containing extras data" if tempdir.nil?
+
       Pkg::Config.config_from_yaml("#{tempdir}/#{Pkg::Config.builder_data_file}")
 
       # Environment variables take precedence over those loaded from configs,
@@ -18,4 +19,3 @@ namespace :pl do
     end
   end
 end
-

--- a/tasks/pe_rpm.rake
+++ b/tasks/pe_rpm.rake
@@ -10,4 +10,3 @@ if Pkg::Config.build_pe
     task :mock => ["pl:fetch", "pl:mock"]
   end
 end
-

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -13,10 +13,11 @@
 namespace :pl do
   namespace :jenkins do
     desc "Retrieve packages from the distribution server\. Check out commit to retrieve"
-    task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
+    task :retrieve, %i[remote_target local_target] => 'pl:fetch' do |t, args|
       unless Pkg::Config.project
         fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
       end
+
       remote_target = args.remote_target || "artifacts"
       local_target = args.local_target || "pkg"
       mkdir_p local_target
@@ -28,6 +29,7 @@ namespace :pl do
         Pkg::Retrieve.retrieve_all(build_url, build_path, local_target)
       end
       fail "Uh oh, looks like we didn't find anything in #{local_target} when attempting to retrieve from #{build_url}!" if Dir["#{local_target}/*"].empty?
+
       puts "Packages staged in #{local_target}"
     end
   end
@@ -37,10 +39,11 @@ if Pkg::Config.build_pe
   namespace :pe do
     namespace :jenkins do
       desc "Retrieve packages from the distribution server\. Check out commit to retrieve"
-      task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
+      task :retrieve, %i[remote_target local_target] => 'pl:fetch' do |t, args|
         unless Pkg::Config.project
           fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
         end
+
         remote_target = args.remote_target || "artifacts"
         local_target = args.local_target || "pkg"
         build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"

--- a/tasks/rpm.rake
+++ b/tasks/rpm.rake
@@ -30,7 +30,7 @@ def build_rpm(buildarg = "-bs")
   rpm_old_version = '--define "_source_filedigest_algorithm 1" --define "_binary_filedigest_algorithm 1" \
      --define "_binary_payload w9.gzdio" --define "_source_payload w9.gzdio" \
      --define "_default_patch_fuzz 2"'
-  args = rpm_define + ' ' + rpm_old_version
+  args = "#{rpm_define} #{rpm_old_version}"
   FileUtils.mkdir_p('pkg/srpm')
   if buildarg == '-ba'
     FileUtils.mkdir_p('pkg/rpm')
@@ -47,7 +47,7 @@ def build_rpm(buildarg = "-bs")
   puts
   output = FileList['pkg/*/*.rpm']
   puts "Wrote:"
-  output.each do | line |
+  output.each do |line|
     puts line
   end
 end
@@ -63,4 +63,3 @@ namespace :package do
     build_rpm("-ba")
   end
 end
-

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -73,6 +73,7 @@ namespace :pl do
       end
     end
     fail unless signed
+
     puts "All rpms signed"
   end
 
@@ -139,11 +140,11 @@ namespace :pl do
       remote_repo   = Pkg::Util::Net.remote_unpack_git_bundle(Pkg::Config.signing_server, 'HEAD', nil, signing_bundle)
       build_params  = Pkg::Util::Net.remote_buildparams(Pkg::Config.signing_server, Pkg::Config)
       Pkg::Util::Net.rsync_to(root_dir, Pkg::Config.signing_server, remote_repo)
-      rake_command = <<-DOC
-cd #{remote_repo} ;
-#{Pkg::Util::Net.remote_bundle_install_command}
-bundle exec rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(" ")} PARAMS_FILE=#{build_params}
-DOC
+      rake_command = <<~DOC
+        cd #{remote_repo} ;
+        #{Pkg::Util::Net.remote_bundle_install_command}
+        bundle exec rake #{sign_tasks.map { |task| task + "[#{root_dir}]" }.join(' ')} PARAMS_FILE=#{build_params}
+      DOC
       Pkg::Util::Net.remote_execute(Pkg::Config.signing_server, rake_command)
       Pkg::Util::Net.rsync_from("#{remote_repo}/#{root_dir}/", Pkg::Config.signing_server, "#{root_dir}/")
       Pkg::Util::Net.remote_execute(Pkg::Config.signing_server, "rm -rf #{remote_repo}")

--- a/tasks/tag.rake
+++ b/tasks/tag.rake
@@ -5,4 +5,3 @@ namespace 'pl' do
     Pkg::Util::Git.tag(ENV['TAG'])
   end
 end
-

--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -1,7 +1,6 @@
 namespace :package do
   desc "Create a source tar archive"
   task :tar => [:clean] do
-
     if Pkg::Config.pre_tar_task
       Pkg::Util::RakeUtils.invoke_task(Pkg::Config.pre_tar_task)
     end
@@ -14,7 +13,7 @@ namespace :package do
     # by the tar class. Otherwise, we load what we consider to be the "default"
     # set, which is default for historical purposes.
     #
-    tar.templates ||= Dir[File.join(Pkg::Config.project_root, "ext", "**", "*.erb")].select { |i| i !~ /ext\/packaging|ext\/osx/ }
+    tar.templates ||= Dir[File.join(Pkg::Config.project_root, "ext", "**", "*.erb")].reject { |i| i =~ /ext\/packaging|ext\/osx/ }
 
     tar.pkg!
 
@@ -25,4 +24,3 @@ end
 namespace :pl do
   task :tar => ["package:tar"]
 end
-

--- a/tasks/update.rake
+++ b/tasks/update.rake
@@ -2,15 +2,14 @@ namespace :package do
   desc "Update your clone of the packaging repo with `git pull`"
   task :update do
     cd 'ext/packaging' do
-      remote = Pkg::Config.packaging_url.split(' ')[0]
-      branch = Pkg::Config.packaging_url.split(' ')[1].split('=')[1]
+      remote = Pkg::Config.packaging_url.split[0]
+      branch = Pkg::Config.packaging_url.split[1].split('=')[1]
       if branch.nil? or remote.nil?
-        $stderr.puts "Couldn't parse the packaging repo URL from 'ext/build_defaults.yaml'."
-        $stderr.puts "Normally this is a string in the format git@github.com:<User>/<packaging_repo> --branch=<branch>"
+        warn "Couldn't parse the packaging repo URL from 'ext/build_defaults.yaml'."
+        warn "Normally this is a string in the format git@github.com:<User>/<packaging_repo> --branch=<branch>"
       else
         Pkg::Util::Git.pull(remote, branch)
       end
     end
   end
 end
-

--- a/tasks/vanagon.rake
+++ b/tasks/vanagon.rake
@@ -30,6 +30,7 @@ namespace :vanagon do
     Rake::Task["vanagon:check_tags"].invoke
     puts "Does this look correct?"
     return unless Pkg::Util.ask_yes_or_no
+
     Rake::Task["pl:jenkins:uber_build"].invoke(args.poll_interval)
   end
 end

--- a/tasks/vendor_gems.rake
+++ b/tasks/vendor_gems.rake
@@ -8,7 +8,7 @@ if Pkg::Config.pre_tar_task
       require 'bundler'
 
       class UI
-        LEVELS = %w(silent error warn confirm info debug)
+        LEVELS = %w[silent error warn confirm info debug]
 
         def warn(message, newline = nil)
           puts message
@@ -30,15 +30,13 @@ if Pkg::Config.pre_tar_task
           puts message
         end
 
-        def confirm(message, newline = nil)
-        end
+        def confirm(message, newline = nil); end
 
         def debug?
           true
         end
 
-        def ask(message)
-        end
+        def ask(message); end
 
         def quiet?
           false
@@ -46,6 +44,7 @@ if Pkg::Config.pre_tar_task
 
         def level=(level)
           raise ArgumentError unless LEVELS.include?(level.to_s)
+
           @level = level
         end
 
@@ -54,12 +53,12 @@ if Pkg::Config.pre_tar_task
         end
 
         def silence
-          old_level, @level = @level, "silent"
+          old_level = @level
+          @level = "silent"
           yield
         ensure
           @level = old_level
         end
-
       end
 
       class RGProxy < ::Gem::SilentUI

--- a/tasks/version.rake
+++ b/tasks/version.rake
@@ -24,10 +24,9 @@ namespace :package do
   end
 
   # A set of tasks for printing the version
-  [:version, :rpmversion, :rpmrelease, :debversion, :release].each do |task|
-    task "#{task}" do
+  %i[version rpmversion rpmrelease debversion release].each do |task|
+    task task.to_s do
       $stdout.puts Pkg::Config.instance_variable_get("@#{task}")
     end
   end
 end
-

--- a/tasks/z_data_dump.rake
+++ b/tasks/z_data_dump.rake
@@ -16,7 +16,7 @@ namespace :pl do
   desc "Write all package build parameters to a yaml file, pass OUTPUT_DIR to specify outut location"
   task :write_build_params do
     if ENV['TASK']
-      task_args = ENV['TASK'].split(' ')
+      task_args = ENV['TASK'].split
       Pkg::Config.task = { :task => task_args[0], :args => task_args[1..-1] }
     end
     Pkg::Config.config_to_yaml(ENV['OUTPUT_DIR'])
@@ -37,10 +37,11 @@ namespace :pl do
     # We want a string that is the from "@<param name>"
     if param = args.param
       getter = param.dup
-      if param[0] == ':'
+      case param[0]
+      when ':'
         getter = param[1..-1]
         param[0] = "@"
-      elsif param[0] == "@"
+      when "@"
         getter = param[1..-1]
       else
         param.insert(0, "@")
@@ -62,4 +63,3 @@ namespace :pl do
     end
   end
 end
-


### PR DESCRIPTION
I got a bee in my bonnet about this being rather out-of-date, so I
updated it. Not sure if it's a worthwhile change but submitted for
discussion.

I updated the dependency versions in the gemspec.

I updated rspec examples from deprecated spec syntax by replacing old 'should' and 'stub' rspec syntax with updated 'expect' and 'allow'

Inside the spec examples, I got more conventional about using single
quotes when making fixed strings.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.