### PR TITLE
(RE-13941) Add shim to support new apt shipping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,121 +1,85 @@
+---
+
 AllCops:
   Include:
-    - 'lib/**/*.rb'
-    - 'tasks/**/*'
+  - lib/**/*.rb
+  - tasks/**/*
   Exclude:
-    - '**/*.erb'
-    - 'spec/**/*'
-    - 'vendor/**/*'
+  - "**/*.erb"
+  - spec/**/*
+  - vendor/**/*
 
+Lint/AmbiguousOperator:
+  Enabled: false
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/BlockAlignment:
+  Enabled: false
 
 Lint/ConditionPosition:
   Enabled: true
 
-Lint/ElseLayout:
-  Enabled: true
-
-Lint/UnreachableCode:
-  Enabled: true
-
-Lint/UselessComparison:
-  Enabled: true
-
-# MAYBE useful - no return inside ensure block.
-Lint/EnsureReturn:
-  Enabled: true
-
-# MAYBE useful - errors when rescue {} happens.
-Lint/HandleExceptions:
+Lint/Debugger:
   Enabled: false
 
-# MAYBE useful - catches while 1
-Lint/LiteralInCondition:
-  Enabled: false
-
-# MAYBE useful - but too many instances
-Lint/ShadowingOuterLocalVariable:
-  Enabled: false
-
-# Can catch complicated strings.
-Lint/LiteralInInterpolation:
-  Enabled: true
-
-
-# DISABLED really useless. Detects return as last statement.
-Style/RedundantReturn:
-  Enabled: false
-
-# DISABLED since the instances do not seem to indicate any specific errors.
-Lint/AmbiguousOperator:
-  Enabled: false
-
-# DISABLED since for all the checked, we are basically checking nil
-# TODO: Change the checking so that if the variable being assigned to has
-# a value ALREADY, then raise an error.
-Lint/AssignmentInCondition:
-  Enabled: false
-
-# DISABLED - not useful
-Style/SpaceBeforeComment:
-  Enabled: false
-
-# DISABLED - not useful
-Style/HashSyntax:
-  Enabled: false
-
-# USES: as shortcut for non nil&valid checking a = x() and a.empty?
-# DISABLED - not useful
-Style/AndOr:
-  Enabled: false
-
-# DISABLED - not useful
-Style/RedundantSelf:
-  Enabled: false
-
-# DISABLED - not useful
-Style/MethodLength:
-  Enabled: false
-
-# DISABLED - not useful
-Style/WhileUntilModifier:
-  Enabled: false
-
-# DISABLED - the offender is just haskell envy
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
-# DISABLED
-Lint/Eval:
-  Enabled: false
-# DISABLED
-Lint/BlockAlignment:
-  Enabled: false
-
-# DISABLED
 Lint/DefEndAlignment:
   Enabled: false
 
-# DISABLED
-Lint/EndAlignment:
-  Enabled: false
-
-# DISABLED
 Lint/DeprecatedClassMethods:
   Enabled: false
 
-# DISABLED
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EndAlignment:
+  Enabled: false
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/Eval:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false
+
+Lint/LiteralInCondition:
+  Enabled: false
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
 Lint/Loop:
   Enabled: false
 
-# DISABLED
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
+
+Lint/RequireParentheses:
+  Enabled: true
 
 Lint/RescueException:
   Enabled: false
 
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+Lint/SpaceBeforeFirstArg:
+  Enabled: true
+
 Lint/StringConversionInInterpolation:
   Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
 
 Lint/UnusedBlockArgument:
   Enabled: false
@@ -123,15 +87,15 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Enabled: false
 
-# DISABLED - TODO
 Lint/UselessAccessModifier:
   Enabled: false
 
-# DISABLED - TODO
 Lint/UselessAssignment:
   Enabled: false
 
-# DISABLED - TODO
+Lint/UselessComparison:
+  Enabled: true
+
 Lint/Void:
   Enabled: false
 
@@ -153,13 +117,16 @@ Style/AlignHash:
 Style/AlignParameters:
   Enabled: false
 
-Style/BlockNesting:
+Style/AndOr:
   Enabled: false
 
 Style/AsciiComments:
   Enabled: false
 
 Style/Attr:
+  Enabled: false
+
+Style/BlockNesting:
   Enabled: false
 
 Style/Blocks:
@@ -195,39 +162,220 @@ Style/ClassMethods:
 Style/ClassVars:
   Enabled: false
 
-Style/WhenThen:
+Style/CollectionMethods:
   Enabled: false
 
-
-# DISABLED - not useful
-Style/WordArray:
+Style/ColonMethodCall:
   Enabled: false
 
-Style/UnneededPercentQ:
+Style/CommentAnnotation:
   Enabled: false
 
-Style/Tab:
+Style/CommentIndentation:
   Enabled: false
 
-Style/SpaceBeforeSemicolon:
-  Enabled: true
-
-Style/TrailingBlankLines:
+Style/ConstantName:
   Enabled: false
 
-Style/SpaceInsideBlockBraces:
+Style/CyclomaticComplexity:
+  Enabled: false
+
+Style/DefWithParentheses:
+  Enabled: false
+
+Style/DeprecatedHashMethods:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DotPosition:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/EmptyLineBetweenDefs:
+  Enabled: false
+
+Style/EmptyLines:
+  Enabled: false
+
+Style/EmptyLinesAroundAccessModifier:
+  Enabled: false
+
+Style/EmptyLinesAroundBody:
+  Enabled: false
+
+Style/EmptyLiteral:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false
+
+Style/EvenOdd:
   Enabled: true
 
-Style/SpaceInsideBrackets:
+Style/FileName:
   Enabled: true
 
-Style/SpaceInsideHashLiteralBraces:
+Style/For:
   Enabled: true
 
-Style/SpaceInsideParens:
+Style/FormatString:
   Enabled: true
+
+Style/GlobalVars:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/HashSyntax:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IfWithSemicolon:
+  Enabled: true
+
+Style/IndentArray:
+  Enabled: false
+
+Style/IndentHash:
+  Enabled: false
+
+Style/IndentationConsistency:
+  Enabled: true
+
+Style/IndentationWidth:
+  Enabled: true
+
+Style/Lambda:
+  Enabled: false
 
 Style/LeadingCommentSpace:
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Enabled: false
+
+Style/LineLength:
+  Enabled: false
+
+Style/MethodCallParentheses:
+  Enabled: true
+
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/MethodLength:
+  Enabled: false
+
+Style/MethodName:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: true
+
+Style/MultilineIfThen:
+  Enabled: true
+
+Style/MultilineTernaryOperator:
+  Enabled: true
+
+Style/NegatedIf:
+  Enabled: true
+
+Style/NegatedWhile:
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Enabled: true
+
+Style/Next:
+  Enabled: false
+
+Style/NilComparison:
+  Enabled: true
+
+Style/NonNilCheck:
+  Enabled: true
+
+Style/Not:
+  Enabled: true
+
+Style/NumericLiterals:
+  Enabled: true
+
+Style/OneLineConditional:
+  Enabled: true
+
+Style/OpMethod:
+  Enabled: true
+
+Style/ParameterLists:
+  Enabled: true
+
+Style/ParenthesesAroundCondition:
+  Enabled: true
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%W': '[]'
+    '%i': '()'
+  Enabled: true
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/PredicateName:
+  Enabled: false
+
+Style/Proc:
+  Enabled: true
+
+Style/RaiseArgs:
+  Enabled: true
+
+Style/RedundantBegin:
+  Enabled: true
+
+Style/RedundantException:
+  Enabled: true
+
+Style/RedundantReturn:
+  Enabled: false
+
+Style/RedundantSelf:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/RescueModifier:
+  Enabled: true
+
+Style/SelfAssignment:
+  Enabled: true
+
+Style/Semicolon:
+  Enabled: true
+
+Style/SignalException:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SingleLineMethods:
   Enabled: false
 
 Style/SingleSpaceBeforeFirstArg:
@@ -263,122 +411,41 @@ Style/SpaceBeforeBlockBraces:
 Style/SpaceBeforeComma:
   Enabled: true
 
-
-Style/CollectionMethods:
+Style/SpaceBeforeComment:
   Enabled: false
 
-Style/CommentIndentation:
-  Enabled: false
-
-Style/ColonMethodCall:
-  Enabled: false
-
-Style/CommentAnnotation:
-  Enabled: false
-
-Style/CyclomaticComplexity:
-  Enabled: false
-
-Style/ConstantName:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/DefWithParentheses:
-  Enabled: false
-
-Style/DeprecatedHashMethods:
-  Enabled: false
-
-Style/DotPosition:
-  Enabled: false
-
-# DISABLED - used for converting to bool
-Style/DoubleNegation:
-  Enabled: false
-
-Style/EachWithObject:
-  Enabled: false
-
-Style/EmptyLineBetweenDefs:
-  Enabled: false
-
-Style/IndentArray:
-  Enabled: false
-
-Style/IndentHash:
-  Enabled: false
-
-Style/IndentationConsistency:
+Style/SpaceBeforeSemicolon:
   Enabled: true
 
-Style/IndentationWidth:
+Style/SpaceInsideBlockBraces:
   Enabled: true
 
-Style/EmptyLines:
-  Enabled: false
-
-Style/EmptyLinesAroundAccessModifier:
-  Enabled: false
-
-Style/EmptyLinesAroundBody:
-  Enabled: false
-
-Style/EmptyLiteral:
-  Enabled: false
-
-Style/LineLength:
-  Enabled: false
-
-Style/MethodCallParentheses:
+Style/SpaceInsideBrackets:
   Enabled: true
 
-Style/MethodDefParentheses:
+Style/SpaceInsideHashLiteralBraces:
   Enabled: true
 
-Style/LineEndConcatenation:
+Style/SpaceInsideParens:
+  Enabled: true
+
+Style/SpecialGlobalVars:
   Enabled: false
-
-Style/TrailingWhitespace:
-  Enabled: true
 
 Style/StringLiterals:
+  Enabled: false
+
+Style/Tab:
+  Enabled: false
+
+Style/TrailingBlankLines:
   Enabled: false
 
 Style/TrailingComma:
   Enabled: false
 
-Style/GlobalVars:
-  Enabled: false
-
-Style/GuardClause:
-  Enabled: false
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-Style/MultilineIfThen:
+Style/TrailingWhitespace:
   Enabled: true
-
-Style/NegatedIf:
-  Enabled: true
-
-Style/NegatedWhile:
-  Enabled: true
-
-Style/Next:
-  Enabled: false
-
-Style/SingleLineBlockParams:
-  Enabled: false
-
-Style/SingleLineMethods:
-  Enabled: false
-
-Style/SpecialGlobalVars:
-  Enabled: false
-
 
 Style/TrivialAccessors:
   Enabled: false
@@ -386,7 +453,9 @@ Style/TrivialAccessors:
 Style/UnlessElse:
   Enabled: true
 
-# This pushes preference for shell commands as backticks instead of %x
+Style/UnneededPercentQ:
+  Enabled: false
+
 Style/UnneededPercentX:
   Enabled: false
 
@@ -396,114 +465,14 @@ Style/VariableInterpolation:
 Style/VariableName:
   Enabled: true
 
+Style/WhenThen:
+  Enabled: false
+
 Style/WhileUntilDo:
   Enabled: true
 
-Style/EvenOdd:
-  Enabled: true
-
-Style/FileName:
-  Enabled: true
-
-Style/For:
-  Enabled: true
-
-Style/Lambda:
+Style/WhileUntilModifier:
   Enabled: false
 
-Style/MethodName:
-  Enabled: false
-
-Style/MultilineTernaryOperator:
-  Enabled: true
-
-Style/NestedTernaryOperator:
-  Enabled: true
-
-Style/NilComparison:
-  Enabled: true
-
-Style/FormatString:
-  Enabled: true
-
-Style/MultilineBlockChain:
-  Enabled: true
-
-Style/Semicolon:
-  Enabled: true
-
-Style/SignalException:
-  Enabled: false
-
-Style/NonNilCheck:
-  Enabled: true
-
-Style/Not:
-  Enabled: true
-
-Style/NumericLiterals:
-  Enabled: true
-
-Style/OneLineConditional:
-  Enabled: true
-
-Style/OpMethod:
-  Enabled: true
-
-Style/ParenthesesAroundCondition:
-  Enabled: true
-
-Style/PercentLiteralDelimiters:
-  Enabled: true
-
-Style/PerlBackrefs:
-  Enabled: false
-
-Style/PredicateName:
-  Enabled: false
-
-Style/RedundantException:
-  Enabled: true
-
-Style/SelfAssignment:
-  Enabled: true
-
-
-Style/Proc:
-  Enabled: true
-
-Style/RaiseArgs:
-  Enabled: true
-
-Style/RedundantBegin:
-  Enabled: true
-
-Style/RescueModifier:
-  Enabled: true
-
-Style/RegexpLiteral:
-  Enabled: false
-
-Lint/UnderscorePrefixedVariableName:
-  Enabled: true
-
-Style/ParameterLists:
-  Enabled: true
-
-Lint/RequireParentheses:
-  Enabled: true
-
-Lint/SpaceBeforeFirstArg:
-  Enabled: true
-
-Style/ModuleFunction:
-  Enabled: false
-
-Lint/Debugger:
-  Enabled: false
-
-Style/IfWithSemicolon:
-  Enabled: true
-
-Style/Encoding:
+Style/WordArray:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 notifications:
   email: false
 rvm:
-  - 2.3.8
-  - 2.4.1
-  - 2.6.5
+  - 2.5.9
+  - 2.6.8
+  - 2.7.4
 
 env:
   - "CHECK='rspec spec --color --format documentation --order random'"

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -36,7 +36,8 @@ module Pkg::Repo
       Dir.chdir(File.join('pkg', local_target)) do
         puts "Info: Archiving #{repo_location} as #{archive_name}"
         target_tarball = File.join('repos', "#{archive_name}.tar.gz")
-        tar_command = "#{tar} --owner=0 --group=0 --create --gzip --file #{target_tarball} #{repo_location}"
+        tar_command = %W[#{tar} --owner=0 --group=0 --create --gzip
+          --file #{target_tarball} #{repo_location}].join(' ')
         stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
         return stdout
       end
@@ -62,12 +63,12 @@ module Pkg::Repo
           next
         end
 
-        tar_action = "--create"
-        if File.exist?(all_repos_tarball_name)
-          tar_action = "--update"
-        end
+        tar_action = '--create'
+        tar_action = '--update' if File.exist?(all_repos_tarball_name)
 
-        tar_command = "#{tar} --owner=0 --group=0 #{tar_action} --file #{all_repos_tarball_name} #{repo_tarball_path}"
+        tar_command = %W[#{tar} --owner=0 --group=0 #{tar_action}
+          --file #{all_repos_tarball_name} #{repo_tarball_path}].join(' ')
+
         stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
         puts stdout
       end
@@ -117,7 +118,8 @@ module Pkg::Repo
               )
       return stdout.split
     rescue => e
-      fail "Error: Could not retrieve directories that contain #{pkg_ext} packages in #{Pkg::Config.distribution_server}:#{artifact_directory}"
+      fail "Error: Could not retrieve directories that contain #{pkg_ext} " \
+           "packages in #{Pkg::Config.distribution_server}:#{artifact_directory}: #{e}"
     end
 
     def populate_repo_directory(artifact_parent_directory)
@@ -126,7 +128,8 @@ module Pkg::Repo
       cmd << 'rsync --archive --verbose --one-file-system --ignore-existing artifacts/ repos/ '
       Pkg::Util::Net.remote_execute(Pkg::Config.distribution_server, cmd)
     rescue => e
-      fail "Error: Could not populate repos directory in #{Pkg::Config.distribution_server}:#{artifact_parent_directory}"
+      fail "Error: Could not populate repos directory in " \
+           "#{Pkg::Config.distribution_server}:#{artifact_parent_directory}: #{e}"
     end
 
     def argument_required?(argument_name, repo_command)
@@ -134,12 +137,12 @@ module Pkg::Repo
     end
 
     def update_repo(remote_host, command, options = {})
-      fail_message = "Error: Missing required argument '%s', update your build_defaults?"
+      fail_message = "Error: Missing required argument '%s', perhaps update build_defaults?"
       [:repo_name, :repo_path, :repo_host, :repo_url].each do |option|
         fail fail_message % option.to_s if argument_required?(option.to_s, command) && !options[option]
       end
 
-      whitelist = {
+      repo_configuration = {
         __REPO_NAME__: options[:repo_name],
         __REPO_PATH__: options[:repo_path],
         __REPO_HOST__: options[:repo_host],
@@ -149,7 +152,7 @@ module Pkg::Repo
       }
       Pkg::Util::Net.remote_execute(
         remote_host,
-        Pkg::Util::Misc.search_and_replace(command, whitelist))
+        Pkg::Util::Misc.search_and_replace(command, repo_configuration))
     end
   end
 end

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -4,8 +4,12 @@ module Pkg::Util
   require 'benchmark'
   require 'base64'
   require 'io/console'
+  require 'packaging/util/apt_staging_server'
+  require 'packaging/util/build_metadata'
   require 'packaging/util/date'
+  require 'packaging/util/distribution_server'
   require 'packaging/util/execution'
+  require 'packaging/util/ezbake'
   require 'packaging/util/file'
   require 'packaging/util/git'
   require 'packaging/util/gpg'
@@ -19,6 +23,7 @@ module Pkg::Util
   require 'packaging/util/tool'
   require 'packaging/util/rake_utils'
   require 'packaging/util/version'
+  require 'packaging/util/windows'
   require 'packaging/util/git_tags'
 
   def self.boolean_value(var)

--- a/lib/packaging/util/apt_staging_server.rb
+++ b/lib/packaging/util/apt_staging_server.rb
@@ -1,0 +1,8 @@
+# Utility methods for handling Apt staging server.
+
+module Pkg::Util::AptStagingServer
+  def self.send_packages(pkg_directory, apt_component = 'stable')
+    %x(apt-stage-artifacts --component=#{apt_component} #{pkg_directory})
+    fail 'APT artifact staging failed.' unless $CHILD_STATUS.success?
+  end
+end

--- a/lib/packaging/util/build_metadata.rb
+++ b/lib/packaging/util/build_metadata.rb
@@ -1,0 +1,17 @@
+# Utility methods for handling miscellaneous build metadata
+
+require 'fileutils'
+
+module Pkg::Util::BuildMetadata
+  class << self
+    def add_misc_json_files(target_directory)
+      misc_json_files = Dir.glob('ext/build_metadata*.json')
+      misc_json_files.each do |source_file|
+        target_file = File.join(
+          target_directory, "#{Pkg::Config.ref}.#{File.basename(source_file)}"
+        )
+        FileUtils.cp(source_file, target_file)
+      end
+    end
+  end
+end

--- a/lib/packaging/util/distribution_server.rb
+++ b/lib/packaging/util/distribution_server.rb
@@ -1,0 +1,42 @@
+# Utility methods for the older distribution server
+
+require 'fileutils'
+
+module Pkg::Util::DistributionServer
+  class << self
+    def send_packages(local_source_directory, remote_target_directory)
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(
+          Pkg::Config.distribution_server,
+          "mkdir --mode=775 --parents #{remote_target_directory}"
+        )
+        Pkg::Util::Net.rsync_to(
+          "#{local_source_directory}/",
+          Pkg::Config.distribution_server, "#{remote_target_directory}/",
+          extra_flags: ['--ignore-existing', '--exclude repo_configs']
+        )
+      end
+
+      # In order to get a snapshot of what this build looked like at the time
+      # of shipping, we also generate and ship the params file
+      #
+      Pkg::Config.config_to_yaml(local_source_directory)
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.rsync_to(
+          "#{local_source_directory}/#{Pkg::Config.ref}.yaml",
+          Pkg::Config.distribution_server, "#{remote_target_directory}/",
+          extra_flags: ["--exclude repo_configs"]
+        )
+      end
+
+      # If we just shipped a tagged version, we want to make it immutable
+      files = Dir.glob("#{local_source_directory}/**/*")
+                 .select { |f| File.file?(f) and !f.include? "#{Pkg::Config.ref}.yaml" }
+                 .map { |f| "#{remote_target_directory}/#{f.sub(/^#{local_source_directory}\//, '')}" }
+
+      Pkg::Util::Net.remote_set_ownership(Pkg::Config.distribution_server, 'root', 'release', files)
+      Pkg::Util::Net.remote_set_permissions(Pkg::Config.distribution_server, '0664', files)
+      Pkg::Util::Net.remote_set_immutable(Pkg::Config.distribution_server, files)
+    end
+  end
+end

--- a/lib/packaging/util/ezbake.rb
+++ b/lib/packaging/util/ezbake.rb
@@ -1,0 +1,26 @@
+# Utility methods for handling ezbake
+
+require 'fileutils'
+
+module Pkg::Util::EZbake
+  class << self
+    def add_manifest(target_directory)
+      ezbake_manifest = File.join('ext', 'ezbake.manifest')
+      ezbake_yaml = File.join('ext', 'ezbake.manifest.yaml')
+
+      if File.exist?(ezbake_manifest)
+        FileUtils.cp(
+          ezbake_manifest,
+          File.join(target_directory, "#{Pkg::Config.ref}.ezbake.manifest")
+        )
+      end
+
+      if File.exists?(ezbake_yaml)
+        FileUtils.cp(
+          ezbake_yaml,
+          File.join(target_directory, "#{Pkg::Config.ref}.ezbake.manifest.yaml")
+        )
+      end
+    end
+  end
+end

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -159,7 +159,7 @@ module Pkg::Util::Net
       raise(ArgumentError, "Cannot sync path '#{origin}' because both origin_host and target_host are nil. Perhaps you need to set TEAM=release ?") unless
         options[:origin_host] || options[:target_host]
 
-      cmd = %W(
+      cmd = %W[
         #{options[:bin]}
         --recursive
         --hard-links
@@ -169,7 +169,7 @@ module Pkg::Util::Net
         --no-perms
         --no-owner
         --no-group
-      ) + [*options[:extra_flags]]
+      ] + [*options[:extra_flags]]
 
       cmd << '--dry-run' if options[:dryrun]
       cmd << Pkg::Util.pseudo_uri(path: origin, host: options[:origin_host])

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -1,14 +1,20 @@
 # Module for shipping all packages to places
+
+require 'English'
 require 'tmpdir'
+
 module Pkg::Util::Ship
   module_function
 
-  def collect_packages(pkg_exts, excludes = []) # rubocop:disable Metrics/MethodLength
+  def collect_packages(pkg_exts, excludes = [])
     pkgs = pkg_exts.map { |ext| Dir.glob(ext) }.flatten
     return [] if pkgs.empty?
-    excludes.each do |exclude|
-      pkgs.delete_if { |p| p.match(exclude) }
-    end if excludes
+
+    if excludes
+      excludes.each do |exclude|
+        pkgs.delete_if { |p| p.match(exclude) }
+      end
+    end
     if pkgs.empty?
       $stdout.puts "No packages with (#{pkg_exts.join(', ')}) extensions found staged in 'pkg'"
       $stdout.puts "Maybe your excludes argument (#{excludes}) is too restrictive?"
@@ -59,13 +65,13 @@ module Pkg::Util::Ship
   #   false (most paths will be platform dependent), but set to true for gems
   #   and tarballs since those just land directly under /opt/downloads/<project>
   #
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def ship_pkgs(pkg_exts, staging_server, remote_path, opts = {})
     options = {
       excludes: [],
       chattr: true,
       platform_independent: false,
-      nonfinal: false }.merge(opts)
+      nonfinal: false
+    }.merge(opts)
 
     # First find the packages to be shipped. We must find them before moving
     # to our temporary staging directory
@@ -73,35 +79,39 @@ module Pkg::Util::Ship
     return false if local_packages.empty?
 
     tmpdir = Dir.mktmpdir
-    staged_pkgs = reorganize_packages(local_packages, tmpdir, options[:platform_independent], options[:nonfinal])
+    staged_pkgs = reorganize_packages(
+      local_packages, tmpdir, options[:platform_independent], options[:nonfinal]
+    )
 
     puts staged_pkgs.sort
     puts "Do you want to ship the above files to (#{staging_server})?"
-    if Pkg::Util.ask_yes_or_no
-      extra_flags = ['--ignore-existing', '--delay-updates']
-      extra_flags << '--dry-run' if ENV['DRYRUN']
+    return false unless Pkg::Util.ask_yes_or_no
 
-      staged_pkgs.each do |pkg|
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          sub_string = 'pkg'
-          remote_pkg = pkg.sub(sub_string, remote_path)
-          remote_basepath = File.dirname(remote_pkg)
-          Pkg::Util::Net.remote_execute(staging_server, "mkdir -p #{remote_basepath}")
-          Pkg::Util::Net.rsync_to(
-            File.join(tmpdir, pkg),
-            staging_server,
-            remote_basepath,
-            extra_flags: extra_flags
-          )
+    extra_flags = %w(--ignore-existing --delay-updates)
+    extra_flags << '--dry-run' if ENV['DRYRUN']
 
-          Pkg::Util::Net.remote_set_ownership(staging_server, 'root', 'release', [remote_basepath, remote_pkg])
-          Pkg::Util::Net.remote_set_permissions(staging_server, '775', [remote_basepath])
-          Pkg::Util::Net.remote_set_permissions(staging_server, '0664', [remote_pkg])
-          Pkg::Util::Net.remote_set_immutable(staging_server, [remote_pkg]) if options[:chattr]
-        end
+    staged_pkgs.each do |pkg|
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        sub_string = 'pkg'
+        remote_pkg = pkg.sub(sub_string, remote_path)
+        remote_basepath = File.dirname(remote_pkg)
+        Pkg::Util::Net.remote_execute(staging_server, "mkdir -p #{remote_basepath}")
+        Pkg::Util::Net.rsync_to(
+          File.join(tmpdir, pkg),
+          staging_server,
+          remote_basepath,
+          extra_flags: extra_flags
+        )
+
+        Pkg::Util::Net.remote_set_ownership(
+          staging_server, 'root', 'release', [remote_basepath, remote_pkg]
+        )
+        Pkg::Util::Net.remote_set_permissions(staging_server, '775', [remote_basepath])
+        Pkg::Util::Net.remote_set_permissions(staging_server, '0664', [remote_pkg])
+        Pkg::Util::Net.remote_set_immutable(staging_server, [remote_pkg]) if options[:chattr]
       end
-      return true
     end
+    return true
   end
 
   def ship_rpms(local_staging_directory, remote_path, opts = {})
@@ -123,6 +133,8 @@ module Pkg::Util::Ship
     ship_pkgs(things_to_ship, Pkg::Config.apt_signing_server, remote_path, opts)
   end
 
+
+
   def ship_svr4(local_staging_directory, remote_path, opts = {})
     ship_pkgs(["#{local_staging_directory}/**/*.pkg.gz"], Pkg::Config.svr4_host, remote_path, opts)
   end
@@ -132,33 +144,63 @@ module Pkg::Util::Ship
   end
 
   def ship_dmg(local_staging_directory, remote_path, opts = {})
-    packages_have_shipped = ship_pkgs(["#{local_staging_directory}/**/*.dmg"],
-                                      Pkg::Config.dmg_staging_server, remote_path, opts)
+    packages_have_shipped = ship_pkgs(
+      ["#{local_staging_directory}/**/*.dmg"],
+      Pkg::Config.dmg_staging_server, remote_path, opts
+    )
 
-    if packages_have_shipped
-      Pkg::Platforms.platform_tags_for_package_format('dmg').each do |platform_tag|
-        # Create the latest symlink for the current supported repo
-        Pkg::Util::Net.remote_create_latest_symlink(
-          Pkg::Config.project,
-          Pkg::Paths.artifacts_path(platform_tag, remote_path, opts[:nonfinal]),
-          'dmg'
-        )
-      end
+    return unless packages_have_shipped
+
+    Pkg::Platforms.platform_tags_for_package_format('dmg').each do |platform_tag|
+      # Create the latest symlink for the current supported repo
+      Pkg::Util::Net.remote_create_latest_symlink(
+        Pkg::Config.project,
+        Pkg::Paths.artifacts_path(platform_tag, remote_path, opts[:nonfinal]),
+        'dmg'
+      )
     end
   end
 
   def ship_swix(local_staging_directory, remote_path, opts = {})
-    ship_pkgs(["#{local_staging_directory}/**/*.swix"], Pkg::Config.swix_staging_server, remote_path, opts)
+    ship_pkgs(
+      ["#{local_staging_directory}/**/*.swix"],
+      Pkg::Config.swix_staging_server,
+      remote_path,
+      opts
+    )
   end
 
   def ship_msi(local_staging_directory, remote_path, opts = {})
-    packages_have_shipped = ship_pkgs(["#{local_staging_directory}/**/*.msi"], Pkg::Config.msi_staging_server, remote_path, opts)
+    packages_have_shipped = ship_pkgs(
+      ["#{local_staging_directory}/**/*.msi"],
+      Pkg::Config.msi_staging_server,
+      remote_path,
+      opts
+    )
+    return unless packages_have_shipped
 
-    if packages_have_shipped
-      # Create the symlinks for the latest supported repo
-      Pkg::Util::Net.remote_create_latest_symlink(Pkg::Config.project, Pkg::Paths.artifacts_path(Pkg::Platforms.generic_platform_tag('windows'), remote_path, opts[:nonfinal]), 'msi', arch: 'x64')
-      Pkg::Util::Net.remote_create_latest_symlink(Pkg::Config.project, Pkg::Paths.artifacts_path(Pkg::Platforms.generic_platform_tag('windows'), remote_path, opts[:nonfinal]), 'msi', arch: 'x86')
-    end
+    # Create the symlinks for the latest supported repo
+    Pkg::Util::Net.remote_create_latest_symlink(
+      Pkg::Config.project,
+      Pkg::Paths.artifacts_path(
+        Pkg::Platforms.generic_platform_tag('windows'),
+        remote_path,
+        opts[:nonfinal]
+      ),
+      'msi',
+      arch: 'x64'
+    )
+
+    Pkg::Util::Net.remote_create_latest_symlink(
+      Pkg::Config.project,
+      Pkg::Paths.artifacts_path(
+        Pkg::Platforms.generic_platform_tag('windows'),
+        remote_path,
+        opts[:nonfinal]
+      ),
+      'msi',
+      arch: 'x86'
+    )
   end
 
   def ship_gem(local_staging_directory, remote_path, opts = {})
@@ -166,44 +208,32 @@ module Pkg::Util::Ship
   end
 
   def ship_tar(local_staging_directory, remote_path, opts = {})
-    ship_pkgs(["#{local_staging_directory}/*.tar.gz*"], Pkg::Config.tar_staging_server, remote_path, opts)
+    ship_pkgs(
+      ["#{local_staging_directory}/*.tar.gz*"],
+      Pkg::Config.tar_staging_server,
+      remote_path,
+      opts
+    )
   end
 
   def rolling_repo_link_command(platform_tag, repo_path, nonfinal = false)
-    base_path, link_path = Pkg::Paths.artifacts_base_path_and_link_path(platform_tag, repo_path, nonfinal)
+    base_path, link_path = Pkg::Paths.artifacts_base_path_and_link_path(
+      platform_tag,
+      repo_path,
+      nonfinal
+    )
 
     if link_path.nil?
       puts "No link target set, not creating rolling repo link for #{base_path}"
       return nil
     end
-
-    cmd = <<-CMD
-      if [ ! -d #{base_path} ] ; then
-        echo "Link target '#{base_path}' does not exist; skipping"
-        exit 0
-      fi
-      # If it's a link but pointing to the wrong place, remove the link
-      # This is likely to happen around the transition times, like puppet5 -> puppet6
-      if [ -L #{link_path} ] && [ ! #{base_path} -ef #{link_path} ] ; then
-        rm #{link_path}
-      # This is the link you're looking for, nothing to see here
-      elif [ -L #{link_path} ] ; then
-        exit 0
-      # Don't want to delete it if it isn't a link, that could be destructive
-      # So, fail!
-      elif [ -e #{link_path} ] ; then
-        echo "#{link_path} exists but isn't a link, I don't know what to do with this" >&2
-        exit 1
-      fi
-      ln -s #{base_path} #{link_path}
-    CMD
   end
 
   def create_rolling_repo_link(platform_tag, staging_server, repo_path, nonfinal = false)
     command = rolling_repo_link_command(platform_tag, repo_path, nonfinal)
 
     Pkg::Util::Net.remote_execute(staging_server, command) unless command.nil?
-  rescue => e
+  rescue StandardError => e
     fail "Failed to create rolling repo link for '#{platform_tag}'.\n#{e}\n#{e.backtrace}"
   end
 
@@ -214,10 +244,33 @@ module Pkg::Util::Ship
     swix_path = Pkg::Paths.remote_repo_base(nonfinal: nonfinal, package_format: 'swix')
     msi_path = Pkg::Paths.remote_repo_base(nonfinal: nonfinal, package_format: 'msi')
 
-    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('el'), Pkg::Config.yum_staging_server, yum_path, nonfinal)
-    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('osx'), Pkg::Config.dmg_staging_server, dmg_path, nonfinal)
-    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('eos'), Pkg::Config.swix_staging_server, swix_path, nonfinal)
-    create_rolling_repo_link(Pkg::Platforms.generic_platform_tag('windows'), Pkg::Config.msi_staging_server, msi_path, nonfinal)
+    create_rolling_repo_link(
+      Pkg::Platforms.generic_platform_tag('el'),
+      Pkg::Config.yum_staging_server,
+      yum_path,
+      nonfinal
+    )
+
+    create_rolling_repo_link(
+      Pkg::Platforms.generic_platform_tag('osx'),
+      Pkg::Config.dmg_staging_server,
+      dmg_path,
+      nonfinal
+    )
+
+    create_rolling_repo_link(
+      Pkg::Platforms.generic_platform_tag('eos'),
+      Pkg::Config.swix_staging_server,
+      swix_path,
+      nonfinal
+    )
+
+    create_rolling_repo_link(
+      Pkg::Platforms.generic_platform_tag('windows'),
+      Pkg::Config.msi_staging_server,
+      msi_path,
+      nonfinal
+    )
 
     # We need to iterate through all the supported platforms here because of
     # how deb repos are set up. Each codename will have its own link from the
@@ -231,7 +284,12 @@ module Pkg::Util::Ship
       apt_path = Pkg::Config.nonfinal_apt_repo_staging_path
     end
     Pkg::Platforms.codenames.each do |codename|
-      create_rolling_repo_link(Pkg::Platforms.codename_to_tags(codename)[0], Pkg::Config.apt_signing_server, apt_path, nonfinal)
+      create_rolling_repo_link(
+        Pkg::Platforms.codename_to_tags(codename)[0],
+        Pkg::Config.apt_signing_server,
+        apt_path,
+        nonfinal
+      )
     end
   end
 

--- a/lib/packaging/util/windows.rb
+++ b/lib/packaging/util/windows.rb
@@ -1,0 +1,38 @@
+# Utility methods for handling windows
+
+require 'fileutils'
+
+module Pkg::Util::Windows
+  class << self
+    def add_msi_links(local_source_directory)
+      {
+        'windows' => ['x86', 'x64'],
+        'windowsfips' => ['x64']
+      }.each_pair do |platform, archs|
+        packages = Dir["#{local_source_directory}/#{platform}/*"]
+
+        archs.each do |arch|
+          package_version = Pkg::Util::Git.describe.tr('-', '.')
+          package_filename = File.join(
+            local_source_directory, platform,
+            "#{Pkg::Config.project}-#{package_version}-#{arch}.msi"
+          )
+          link_filename = File.join(
+            local_source_directory,
+            platform,
+            "#{Pkg::Config.project}-#{arch}.msi"
+          )
+
+          next unless !packages.include?(link_filename) && packages.include?(package_filename)
+
+          # Dear future code spelunkers:
+          # Using symlinks instead of hard links causes failures when we try
+          # to set these files to be immutable. Also be wary of whether the
+          # linking utility you're using expects the source path to be relative
+          # to the link target or pwd.
+          FileUtils.ln(package_filename, link_filename)
+        end
+      end
+    end
+  end
+end

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -13,15 +13,19 @@ Gem::Specification.new do |gem|
   gem.email    = 'info@puppetlabs.com'
   gem.homepage = 'http://github.com/puppetlabs/packaging'
 
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.5.0'
 
+  gem.add_development_dependency('pry-byebug')
   gem.add_development_dependency('rspec', ['~> 2.14.1'])
   gem.add_development_dependency('rubocop', ['~> 0.24.1'])
   gem.add_development_dependency('pry')
-  gem.add_runtime_dependency('rake', ['>= 12.3'])
+
+  gem.add_runtime_dependency('apt_stage_artifacts')
   gem.add_runtime_dependency('artifactory', ['~> 2'])
-  gem.add_runtime_dependency('release-metrics')
   gem.add_runtime_dependency('csv', ['3.1.5'])
+  gem.add_runtime_dependency('release-metrics')
+  gem.add_runtime_dependency('rake', ['>= 12.3'])
+
   gem.require_path = 'lib'
 
   # Ensure the gem is built out of versioned files

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -286,7 +286,7 @@ namespace :pl do
         ship_nightly_msi
       )
       tasks.map { |t| "pl:#{t}" }.each do |t|
-        puts "Running #{t} . . ."
+        puts "Running #{t}:"
         Rake::Task[t].invoke
       end
     end

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -1,44 +1,77 @@
 namespace :pl do
   namespace :remote do
-    # These hacky bits execute a pre-existing rake task on the Pkg::Config.apt_host
-    # The rake task takes packages in a specific directory and freights them
-    # to various target yum and apt repositories based on their specific type
-    # e.g., final vs devel vs PE vs FOSS packages
+    # Repo updates are the ways we convince the various repos to regenerate any repo-based
+    # metadata.
+    #
+    # It is broken up into various pieces and types to try to avoid too much redundant
+    # behavior.
 
     desc "Update '#{Pkg::Config.repo_name}' yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_yum_repo: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => Pkg::Paths.yum_repo_name, :repo_path => Pkg::Config.yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: Pkg::Paths.yum_repo_name,
+          repo_path: Pkg::Config.yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     desc "Update all final yum repositories on '#{Pkg::Config.yum_staging_server}'"
     task update_all_final_yum_repos: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => '', :repo_path => Pkg::Config.yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: '',
+          repo_path: Pkg::Config.yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     desc "Update '#{Pkg::Config.nonfinal_repo_name}' nightly yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_nightlies_yum_repo: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository-nightlies/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => Pkg::Config.nonfinal_repo_name, :repo_path => Pkg::Config.nonfinal_yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: Pkg::Config.nonfinal_repo_name,
+          repo_path: Pkg::Config.nonfinal_yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     desc "Update all nightly yum repositories on '#{Pkg::Config.yum_staging_server}'"
     task update_all_nightlies_yum_repos: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository-nightlies/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => '', :repo_path => Pkg::Config.nonfinal_yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: '',
+          repo_path: Pkg::Config.nonfinal_yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     task freight: :update_apt_repo
@@ -46,17 +79,35 @@ namespace :pl do
     desc "Update remote apt repository on '#{Pkg::Config.apt_signing_server}'"
     task update_apt_repo: 'pl:fetch' do
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.apt_signing_server, Pkg::Config.apt_repo_command, { :repo_name => Pkg::Paths.apt_repo_name, :repo_path => Pkg::Config.apt_repo_path, :repo_host => Pkg::Config.apt_host, :repo_url => Pkg::Config.apt_repo_url })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.apt_signing_server,
+        Pkg::Config.apt_repo_command,
+        {
+          repo_name: Pkg::Paths.apt_repo_name,
+          repo_path: Pkg::Config.apt_repo_path,
+          repo_host: Pkg::Config.apt_host,
+          repo_url: Pkg::Config.apt_repo_url
+        }
+      )
     end
 
     desc "Update nightlies apt repository on '#{Pkg::Config.apt_signing_server}'"
     task update_nightlies_apt_repo: 'pl:fetch' do
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.apt_signing_server, Pkg::Config.nonfinal_apt_repo_command, { :repo_name => Pkg::Config.nonfinal_repo_name, :repo_path => Pkg::Config.nonfinal_apt_repo_path, :repo_host => Pkg::Config.apt_host, :repo_url => Pkg::Config.apt_repo_url })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.apt_signing_server,
+        Pkg::Config.nonfinal_apt_repo_command,
+        {
+          repo_name: Pkg::Config.nonfinal_repo_name,
+          repo_path: Pkg::Config.nonfinal_apt_repo_path,
+          repo_host: Pkg::Config.apt_host,
+          repo_url: Pkg::Config.apt_repo_url
+        }
+      )
     end
 
     desc "Update apt and yum repos"
@@ -74,32 +125,31 @@ namespace :pl do
     desc "Update remote ips repository on #{Pkg::Config.ips_host}"
     task :update_ips_repo  => 'pl:fetch' do
       if Dir['pkg/ips/pkgs/**/*'].empty? && Dir['pkg/solaris/11/**/*'].empty?
-        $stdout.puts "There aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11. Maybe something went wrong?"
-      else
+        $stdout.puts "Error: there aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11."
+        next
+      end
 
-        if !Dir['pkg/ips/pkgs/**/*'].empty?
-          source_dir = 'pkg/ips/pkgs/'
-        else
-          source_dir = 'pkg/solaris/11/'
-        end
+      source_dir = 'pkg/solaris/11/'
+      source_dir = 'pkg/ips/pkgs/' unless Dir['pkg/ips/pkgs/**/*'].empty?
 
-        tmpdir, _ = Pkg::Util::Net.remote_execute(
-                  Pkg::Config.ips_host,
-                  'mktemp -d -p /var/tmp',
-                  { capture_output: true }
-                )
-        tmpdir.chomp!
+      tmpdir, _ = Pkg::Util::Net.remote_execute(
+                Pkg::Config.ips_host,
+                'mktemp -d -p /var/tmp',
+                { capture_output: true }
+              )
+      tmpdir.chomp!
 
-        Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
+      Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
 
-        remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
-      sudo pkgrecv -s $pkg -d #{Pkg::Config.ips_path} '*';
+      remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
+        sudo pkgrecv -s $pkg -d #{Pkg::Config.ips_path} '*';
       done)
 
-        Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, remote_cmd)
-        Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
-        Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
-      end
+      Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, remote_cmd)
+      Pkg::Util::Net.remote_execute(Pkg::Config.ips_host,
+        "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
+      Pkg::Util::Net.remote_execute(Pkg::Config.ips_host,
+        "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
     end
 
     desc "Move dmg repos from #{Pkg::Config.dmg_staging_server} to #{Pkg::Config.dmg_host}"
@@ -235,6 +285,7 @@ namespace :pl do
 
     desc "Sync signed apt repos from #{Pkg::Config.apt_signing_server} to Google Cloud Platform"
     task :sync_apt_repo_to_gcp => 'pl:fetch' do
+      ssh = Pkg::Util::Tool.check_tool('ssh')
       target_site = 'apt.repos.puppetlabs.com'
       sync_command_puppet_6 = "#{GCP_REPO_SYNC} apt.repos.puppet.com puppet6"
       sync_command_puppet_7 = "#{GCP_REPO_SYNC} apt.repos.puppet.com puppet7"
@@ -243,8 +294,11 @@ namespace :pl do
       puts
 
       Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Util::Net.remote_execute(Pkg::Config.apt_signing_server, sync_command_puppet_6)
-        Pkg::Util::Net.remote_execute(Pkg::Config.apt_signing_server, sync_command_puppet_7)
+        %x(#{ssh} #{Pkg::Config.apt_signing_server} '/bin/bash -l -c "#{sync_command_puppet_6}"')
+      end
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        %x(#{ssh} #{Pkg::Config.apt_signing_server} '/bin/bash -l -c "#{sync_command_puppet_7}"')
       end
     end
     # Keep 'deploy' for backward compatibility
@@ -292,6 +346,13 @@ namespace :pl do
     end
   end
 
+  ##
+  ## Here's where we start 'shipping' (old terminology) or 'staging' (current terminology)
+  ## by copying local 'pkg' directories to the staging server.
+  ##
+  ## Note, that for debs, we conflate 'staging server' with 'signing server' because we
+  ## must stage in th place where we sign.
+  ##
   desc "Ship mocked rpms to #{Pkg::Config.yum_staging_server}"
   task ship_rpms: 'pl:fetch' do
     Pkg::Util::Ship.ship_rpms('pkg', Pkg::Config.yum_repo_path)
@@ -302,6 +363,7 @@ namespace :pl do
     Pkg::Util::Ship.ship_rpms('pkg', Pkg::Config.nonfinal_yum_repo_path, nonfinal: true)
   end
 
+  ## This is the old-style deb shipping
   desc "Ship cow-built debs to #{Pkg::Config.apt_signing_server}"
   task ship_debs: 'pl:fetch' do
     Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.apt_repo_staging_path, chattr: false)
@@ -310,6 +372,18 @@ namespace :pl do
   desc "Ship nightly debs to #{Pkg::Config.apt_signing_server}"
   task ship_nightly_debs: 'pl:fetch' do
     Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.nonfinal_apt_repo_staging_path, chattr: false, nonfinal: true)
+  end
+
+  ## This is the new-style apt stager
+  desc "Stage debs to #{Pkg::Config.apt_signing_server}"
+  task stage_stable_debs: 'pl:fetch' do
+    Pkg::Util::AptStagingServer.send_packages('pkg', 'stable')
+  end
+  task stage_debs: :stage_stable_debs
+
+  desc "Stage nightly debs to #{Pkg::Config.apt_signing_server}"
+  task stage_nightly_debs: 'pl:fetch' do
+    Pkg::Util::AptStagingServer.send_packages('pkg', 'nightly')
   end
 
   desc 'Ship built gem to rubygems.org, internal Gem mirror, and public file server'
@@ -325,12 +399,13 @@ namespace :pl do
           puts 'This will ship to an internal gem mirror, a public file server, and rubygems.org'
           puts "Do you want to start shipping the rubygem '#{gem_file}'?"
           next unless Pkg::Util.ask_yes_or_no
+
           Rake::Task['pl:ship_gem_to_rubygems'].execute(file: gem_file)
         end
 
         Rake::Task['pl:ship_gem_to_downloads'].invoke
       else
-        $stderr.puts 'Not shipping development gem using odd_even strategy for the sake of your users.'
+        warn 'Not shipping development gem using odd_even strategy for the sake of your users.'
       end
     end
   end
@@ -342,6 +417,7 @@ namespace :pl do
     if Pkg::Config.build_gem
       fail 'Value `Pkg::Config.gem_host` not defined, skipping nightly ship' unless Pkg::Config.gem_host
       fail 'Value `Pkg::Config.nonfinal_gem_path` not defined, skipping nightly ship' unless Pkg::Config.nonfinal_gem_path
+
       FileList['pkg/*.gem'].each do |gem_file|
         Pkg::Gem.ship_to_internal_mirror(gem_file)
       end
@@ -451,21 +527,25 @@ namespace :pl do
 
   desc 'UBER ship: ship all the things in pkg'
   task uber_ship: 'pl:fetch' do
-    if Pkg::Util.confirm_ship(FileList['pkg/**/*'])
-      Rake::Task['pl:ship_rpms'].invoke
-      Rake::Task['pl:ship_debs'].invoke
-      Rake::Task['pl:ship_dmg'].invoke
-      Rake::Task['pl:ship_swix'].invoke
-      Rake::Task['pl:ship_nuget'].invoke
-      Rake::Task['pl:ship_tar'].invoke
-      Rake::Task['pl:ship_svr4'].invoke
-      Rake::Task['pl:ship_p5p'].invoke
-      Rake::Task['pl:ship_msi'].invoke
-      add_shipped_metrics(pe_version: ENV['PE_VER'], is_rc: !Pkg::Util::Version.final?) if Pkg::Config.benchmark
-      post_shipped_metrics if Pkg::Config.benchmark
-    else
+    unless Pkg::Util.confirm_ship(FileList['pkg/**/*'])
       puts 'Ship canceled'
       exit
+    end
+
+    Rake::Task['pl:ship_rpms'].invoke
+    Rake::Task['pl:ship_debs'].invoke
+    Rake::Task['pl:stage_stable_debs'].invoke
+    Rake::Task['pl:ship_dmg'].invoke
+    Rake::Task['pl:ship_swix'].invoke
+    Rake::Task['pl:ship_nuget'].invoke
+    Rake::Task['pl:ship_tar'].invoke
+    Rake::Task['pl:ship_svr4'].invoke
+    Rake::Task['pl:ship_p5p'].invoke
+    Rake::Task['pl:ship_msi'].invoke
+
+    if Pkg::Config.benchmark
+      add_shipped_metrics(pe_version: ENV['PE_VER'], is_rc: !Pkg::Util::Version.final?)
+      post_shipped_metrics
     end
   end
 
@@ -530,7 +610,7 @@ namespace :pl do
           { extra_options: '-oBatchMode=yes' }
         )
       end
-    rescue
+    rescue StandardError
       errs << "Unlocking the OSX keychain failed! Check the password in your .bashrc on #{Pkg::Config.osx_signing_server}"
     end
 
@@ -569,66 +649,56 @@ namespace :pl do
     task :ship_to_artifactory, :local_dir do |_t, args|
       Pkg::Util::RakeUtils.invoke_task('pl:fetch')
       unless Pkg::Config.project
-        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
+        fail "Error: 'project' must be set in build_defaults.yaml or " \
+             "in the 'PROJECT_OVERRIDE' environment variable."
       end
+
       artifactory = Pkg::ManageArtifactory.new(Pkg::Config.project, Pkg::Config.ref)
 
       local_dir = args.local_dir || 'pkg'
-      artifacts = Dir.glob("#{local_dir}/**/*").reject { |e| File.directory? e }
-      artifacts.sort! do |a, b|
-        if File.extname(a) =~ /(md5|sha\d+)/ && File.extname(b) !~ /(md5|sha\d+)/
-          1
-        elsif File.extname(b) =~ /(md5|sha\d+)/ && File.extname(a) !~ /(md5|sha\d+)/
-          -1
-        else
-          a <=> b
-        end
-      end
-      artifacts.each do |artifact|
-        if File.extname(artifact) == ".yaml" || File.extname(artifact) == ".json"
+      Dir.glob("#{local_dir}/**/*").reject { |e| File.directory? e }.each do |artifact|
+        # Always deploy yamls and jsons
+        if artifact.end_with?('.yaml', '.json')
           artifactory.deploy_package(artifact)
-        elsif artifactory.package_exists_on_artifactory?(artifact)
-          warn "Attempt to upload '#{artifact}' failed. Package already exists!"
-        else
-          artifactory.deploy_package(artifact)
+          next
         end
+
+        # Don't deploy if the package already exists
+        if artifactory.package_exists_on_artifactory?(artifact)
+          warn "Attempt to upload '#{artifact}' failed. Package already exists."
+          next
+        end
+
+        artifactory.deploy_package(artifact)
       end
     end
 
-    desc 'Ship pkg directory contents to distribution server'
+    desc 'Ship "pkg" directory contents to distribution server'
     task :ship, :target, :local_dir do |_t, args|
       Pkg::Util::RakeUtils.invoke_task('pl:fetch')
       unless Pkg::Config.project
-        fail "You must set the 'project' in build_defaults.yaml or with the 'PROJECT_OVERRIDE' environment variable."
+        fail "Error: 'project' must be set in build_defaults.yaml or " \
+             "in the 'PROJECT_OVERRIDE' environment variable."
       end
+
       target = args.target || 'artifacts'
       local_dir = args.local_dir || 'pkg'
-      project_basedir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
-      artifact_dir = "#{project_basedir}/#{target}"
+      project_basedir = File.join(
+        Pkg::Config.jenkins_repo_path, Pkg::Config.project, Pkg::Config.ref
+      )
+      artifact_dir = File.join(project_basedir, target)
 
       # For EZBake builds, we also want to include the ezbake.manifest file to
       # get a snapshot of this build and all dependencies. We eventually will
       # create a yaml version of this file, but until that point we want to
       # make the original ezbake.manifest available
-      #
-      ezbake_manifest = File.join('ext', 'ezbake.manifest')
-      if File.exist?(ezbake_manifest)
-        cp(ezbake_manifest, File.join(local_dir, "#{Pkg::Config.ref}.ezbake.manifest"))
-      end
-      ezbake_yaml = File.join("ext", "ezbake.manifest.yaml")
-      if File.exists?(ezbake_yaml)
-        cp(ezbake_yaml, File.join(local_dir, "#{Pkg::Config.ref}.ezbake.manifest.yaml"))
-      end
+      Pkg::Util::EZbake.add_manifest(local_dir)
 
       # Inside build_metadata*.json files there is additional metadata containing
       # information such as git ref and dependencies that are needed at build
       # time. If these files exist, copy them downstream.
       # Typically these files are named 'ext/build_metadata.<project>.<platform>.json'
-      build_metadata_json_files = Dir.glob('ext/build_metadata*.json')
-      build_metadata_json_files.each do |source_file|
-        target_file = File.join(local_dir, "#{Pkg::Config.ref}.#{File.basename(source_file)}")
-        cp(source_file, target_file)
-      end
+      Pkg::Util::BuildMetadata.add_misc_json_files(local_dir)
 
       # Sadly, the packaging repo cannot yet act on its own, without living
       # inside of a packaging-repo compatible project. This means in order to
@@ -664,54 +734,69 @@ namespace :pl do
       # and if the source package exists before linking. Searching for the
       # packages has been restricted specifically to just the pkg/windows dir
       # on purpose, as this is where we currently have all windows packages
-      # building to. Once we move the Metadata about the output location in
-      # to one source of truth we can refactor this to use that to search
-      #                                           -Sean P. M. 08/12/16
+      # building to.
+      Pkg::Util::Windows.add_msi_links(local_dir)
 
-      {
-        'windows' => ['x86', 'x64'],
-        'windowsfips' => ['x64']
-      }.each_pair do |platform, archs|
-        packages = Dir["#{local_dir}/#{platform}/*"]
+      # Send packages to the distribution server.
+      Pkg::Util::DistributionServer.send_packages(local_dir, artifact_dir)
 
-        archs.each do |arch|
-          package_version = Pkg::Util::Git.describe.tr('-', '.')
-          package_filename = File.join(local_dir, platform, "#{Pkg::Config.project}-#{package_version}-#{arch}.msi")
-          link_filename = File.join(local_dir, platform, "#{Pkg::Config.project}-#{arch}.msi")
+      # Send deb packages to APT staging server
+      Pkg::Util::AptStagingServer.send_packages(local_dir)
+    end
 
-          next unless !packages.include?(link_filename) && packages.include?(package_filename)
-          # Dear future code spelunkers:
-          # Using symlinks instead of hard links causes failures when we try
-          # to set these files to be immutable. Also be wary of whether the
-          # linking utility you're using expects the source path to be relative
-          # to the link target or pwd.
-          #
-          FileUtils.ln(package_filename, link_filename)
+    desc 'TEST Ship "pkg" directory contents to distribution server'
+    task :exg_test_ship, :target, :local_dir do |_t, args|
+      Pkg::Util::RakeUtils.invoke_task('pl:fetch')
+      unless Pkg::Config.project
+        fail "Error: 'project' must be set in build_defaults.yaml or " \
+             "in the 'PROJECT_OVERRIDE' environment variable."
+      end
+
+      local_dir = args.local_dir || 'pkg'
+
+      # For EZBake builds, we also want to include the ezbake.manifest file to
+      # get a snapshot of this build and all dependencies. We eventually will
+      # create a yaml version of this file, but until that point we want to
+      # make the original ezbake.manifest available
+      Pkg::Util::EZbake.add_manifest(local_dir)
+
+      # Inside build_metadata*.json files there is additional metadata containing
+      # information such as git ref and dependencies that are needed at build
+      # time. If these files exist, copy them downstream.
+      # Typically these files are named 'ext/build_metadata.<project>.<platform>.json'
+      Pkg::Util::BuildMetadata.add_misc_json_files(local_dir)
+
+      # Sadly, the packaging repo cannot yet act on its own, without living
+      # inside of a packaging-repo compatible project. This means in order to
+      # use the packaging repo for shipping and signing (things that really
+      # don't require build automation, specifically) we still need the project
+      # clone itself.
+      Pkg::Util::Git.bundle('HEAD', 'signing_bundle', local_dir)
+
+      # While we're bundling things, let's also make a git bundle of the
+      # packaging repo that we're using when we invoke pl:jenkins:ship. We can
+      # have a reasonable level of confidence, later on, that the git bundle on
+      # the distribution server was, in fact, the git bundle used to create the
+      # associated packages. This is because this ship task is automatically
+      # called upon completion each cell of the pl:jenkins:uber_build, and we
+      # have --ignore-existing set below. As such, the only git bundle that
+      # should possibly be on the distribution is the one used to create the
+      # packages.
+      # We're bundling the packaging repo because it allows us to keep an
+      # archive of the packaging source that was used to create the packages,
+      # so that later on if we need to rebuild an older package to audit it or
+      # for some other reason we're assured that the new package isn't
+      # different by virtue of the packaging automation.
+      if defined?(PACKAGING_ROOT)
+        packaging_bundle = ''
+        cd PACKAGING_ROOT do
+          packaging_bundle = Pkg::Util::Git.bundle('HEAD', 'packaging-bundle')
         end
+        mv(packaging_bundle, local_dir)
       end
 
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Util::Net.remote_execute(Pkg::Config.distribution_server, "mkdir --mode=775 -p #{project_basedir}")
-        Pkg::Util::Net.remote_execute(Pkg::Config.distribution_server, "mkdir -p #{artifact_dir}")
-        Pkg::Util::Net.rsync_to("#{local_dir}/", Pkg::Config.distribution_server, "#{artifact_dir}/", extra_flags: ['--ignore-existing', '--exclude repo_configs'])
-      end
-
-      # In order to get a snapshot of what this build looked like at the time
-      # of shipping, we also generate and ship the params file
-      #
-      Pkg::Config.config_to_yaml(local_dir)
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
-        Pkg::Util::Net.rsync_to("#{local_dir}/#{Pkg::Config.ref}.yaml", Pkg::Config.distribution_server, "#{artifact_dir}/", extra_flags: ["--exclude repo_configs"])
-      end
-
-      # If we just shipped a tagged version, we want to make it immutable
-      files = Dir.glob("#{local_dir}/**/*").select { |f| File.file?(f) and !f.include? "#{Pkg::Config.ref}.yaml" }.map do |file|
-        "#{artifact_dir}/#{file.sub(/^#{local_dir}\//, '')}"
-      end
-
-      Pkg::Util::Net.remote_set_ownership(Pkg::Config.distribution_server, 'root', 'release', files)
-      Pkg::Util::Net.remote_set_permissions(Pkg::Config.distribution_server, '0664', files)
-      Pkg::Util::Net.remote_set_immutable(Pkg::Config.distribution_server, files)
+      # Send deb packages to APT staging server
+      Pkg::Util::AptStagingServer.send_packages(local_dir)
     end
 
     desc 'Ship generated repository configs to the distribution server'


### PR DESCRIPTION
(RE-13941) Ship to new puppet-version based apt repos
    
    - Broke some of the :ship tasks into smaller bits and moved them out of Rake.
    
    - Introduced two new tasks, `pl:stage_nightly_debs` and `pl:stage_stable_debs`
      for sending debs to a staging area for repos based on puppet major version.
    
    - The above new tasks use a required set of shims from the `apt_stage_repos` gem.
    
    - Code cleanup for my own readability and positioning for future planned development
