### PR TITLE
(PA-3602) Update platform hash to include Fedora 34 x86_64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-11477) Remove support for cisco-wrlinux and eos as those were EOL'd for platform6.
 - (RE-13479) Remove support for AIX 6.1
 - (PA-3614)  Add macOS 11 to platforms
+- (PA-3602)  Add Fedora 34 to platforms
 
 ## [0.99.76] - 2021-03-21
 ### Added

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -108,6 +108,14 @@ module Pkg
           signature_format: 'v4',
           repo: true,
         },
+        '34' => {
+          architectures: ['x86_64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
       },
 
       'osx' => {


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
