### PR TITLE
(RE-13941) Ship debs to new puppet-version based repos

### DIFF
--- a/lib/packaging.rb
+++ b/lib/packaging.rb
@@ -11,6 +11,7 @@ module Pkg
   require 'packaging/artifactory'
   require 'packaging/config'
   require 'packaging/deb'
+  require 'packaging/fetch'
   require 'packaging/gem'
   require 'packaging/metrics'
   require 'packaging/nuget'

--- a/lib/packaging/fetch.rb
+++ b/lib/packaging/fetch.rb
@@ -1,0 +1,68 @@
+module Pkg
+  class Fetch
+    class << self
+      def fetch
+        packaging_dot_file = "#{ENV['HOME']}/.packaging"
+        data_repo = Pkg::Config.build_data_repo
+
+        # Each team has a build-defaults file that specifies local infrastructure targets
+        # for things like builders, target locations for build artifacts, etc Since much
+        # of these don't change, one file can be maintained for the team.  Each project
+        # also has a data file for information specific to it. If the project builds
+        # both PE and not PE, it has two files, one for PE, and the other for FOSS
+
+        team_data_branch = Pkg::Config.team
+        project_data_branch = Pkg::Config.project
+        if Pkg::Config.dev_build
+          puts "Info: This is a dev build."
+          project_data_branch = "#{Pkg::Config.project}-dev"
+        end
+
+        if Pkg::Config.build_pe
+          project_data_branch = 'pe-' + project_data_branch unless project_data_branch =~ /^pe-/
+          team_data_branch = 'pe-' + team_data_branch unless team_data_branch =~ /^pe-/
+        end
+
+        # Remove .packaging directory from old-style extras loading
+        FileUtils.rm_rf packaging_dot_file if File.directory? packaging_dot_file
+
+        # Touch the .packaging file which is allows packaging to present remote tasks
+        FileUtils.touch packaging_dot_file
+
+        build_data_directory = Pkg::Util::File.mktemp
+        %x(git clone #{data_repo} #{build_data_directory})
+        unless $?.success?
+          fail 'Error: could not fetch the build-data repo. Are permissions correct?'
+        end
+        
+        Dir.chdir(build_data_directory) do
+          [team_data_branch, project_data_branch].each do |branch|
+            %x(git checkout #{branch})
+            unless $?.success?
+              warn "Warning: no build_defaults found in branch '#{branch}' of '#{data_repo}'. " \
+                   "Skipping."
+              next
+            end
+            load_extras(build_data_directory)
+          end
+        end
+      ensure
+        FileUtils.rm_rf build_data_directory
+      end
+
+      def load_extras(build_data_directory)
+        # Don't do this if the user has provided a non-standard PARAMS_FILE
+        return unless ENV['PARAMS_FILE'].to_s.empty?
+
+        unless File.directory? build_data_directory
+          raise "Error: load_extras requires a directory containing extras data."
+        end
+        Pkg::Config.config_from_yaml(File.join(build_data_directory, Pkg::Config.builder_data_file))
+
+        # Environment variables take precedence over those loaded from configs,
+        # so we make sure that any we clobbered are reset.
+        Pkg::Config.load_envvars
+      end
+    end
+  end
+end

--- a/lib/packaging/repo.rb
+++ b/lib/packaging/repo.rb
@@ -36,7 +36,8 @@ module Pkg::Repo
       Dir.chdir(File.join('pkg', local_target)) do
         puts "Info: Archiving #{repo_location} as #{archive_name}"
         target_tarball = File.join('repos', "#{archive_name}.tar.gz")
-        tar_command = "#{tar} --owner=0 --group=0 --create --gzip --file #{target_tarball} #{repo_location}"
+        tar_command = "#{tar} --owner=0 --group=0 --create --gzip " \
+                      "--file #{target_tarball} #{repo_location}"
         stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
         return stdout
       end
@@ -67,7 +68,8 @@ module Pkg::Repo
           tar_action = "--update"
         end
 
-        tar_command = "#{tar} --owner=0 --group=0 #{tar_action} --file #{all_repos_tarball_name} #{repo_tarball_path}"
+        tar_command = "#{tar} --owner=0 --group=0 #{tar_action} " \
+                      "--file #{all_repos_tarball_name} #{repo_tarball_path}"
         stdout, _, _ = Pkg::Util::Execution.capture3(tar_command)
         puts stdout
       end
@@ -117,7 +119,8 @@ module Pkg::Repo
               )
       return stdout.split
     rescue => e
-      fail "Error: Could not retrieve directories that contain #{pkg_ext} packages in #{Pkg::Config.distribution_server}:#{artifact_directory}"
+      fail "Error: Could not retrieve directories that contain #{pkg_ext} packages in " \
+           "#{Pkg::Config.distribution_server}:#{artifact_directory}: #{e}"
     end
 
     def populate_repo_directory(artifact_parent_directory)
@@ -126,7 +129,8 @@ module Pkg::Repo
       cmd << 'rsync --archive --verbose --one-file-system --ignore-existing artifacts/ repos/ '
       Pkg::Util::Net.remote_execute(Pkg::Config.distribution_server, cmd)
     rescue => e
-      fail "Error: Could not populate repos directory in #{Pkg::Config.distribution_server}:#{artifact_parent_directory}"
+      fail "Error: Could not populate repos directory in " \
+           "#{Pkg::Config.distribution_server}:#{artifact_parent_directory}: #{e}"
     end
 
     def argument_required?(argument_name, repo_command)
@@ -136,7 +140,9 @@ module Pkg::Repo
     def update_repo(remote_host, command, options = {})
       fail_message = "Error: Missing required argument '%s', update your build_defaults?"
       [:repo_name, :repo_path, :repo_host, :repo_url].each do |option|
-        fail fail_message % option.to_s if argument_required?(option.to_s, command) && !options[option]
+        if argument_required?(option.to_s, command) && !options[option]
+          fail format(fail_message, option.to_s)
+        end
       end
 
       whitelist = {

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -111,6 +111,12 @@ module Pkg::Util::Ship
     ship_pkgs(things_to_ship, Pkg::Config.yum_staging_server, remote_path, opts)
   end
 
+  def apt_stage_artifacts(local_staging_directory, repo_name)
+    Pkg::Util::Execution.ex(
+      "env REPO_NAME=#{repo_name} apt-stage-artifacts #{local_staging_directory}"
+    )
+  end
+
   def ship_debs(local_staging_directory, remote_path, opts = {})
     things_to_ship = [
       "#{local_staging_directory}/**/*.debian.tar.gz",
@@ -175,7 +181,7 @@ module Pkg::Util::Ship
       return nil
     end
 
-    cmd = <<-CMD
+    <<-ROLLING_REPO_LINK_COMMAND
       if [ ! -d #{base_path} ] ; then
         echo "Link target '#{base_path}' does not exist; skipping"
         exit 0
@@ -194,7 +200,7 @@ module Pkg::Util::Ship
         exit 1
       fi
       ln -s #{base_path} #{link_path}
-    CMD
+    ROLLING_REPO_LINK_COMMAND
   end
 
   def create_rolling_repo_link(platform_tag, staging_server, repo_path, nonfinal = false)

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -111,9 +111,9 @@ module Pkg::Util::Ship
     ship_pkgs(things_to_ship, Pkg::Config.yum_staging_server, remote_path, opts)
   end
 
-  def apt_stage_artifacts(local_staging_directory, repo_name)
+  def apt_stage_artifacts(local_staging_directory, repo_type = :stable)
     Pkg::Util::Execution.ex(
-      "env REPO_NAME=#{repo_name} apt-stage-artifacts #{local_staging_directory}"
+      "apt-stage-artifacts --repo-type=#{repo_type.to_s} #{local_staging_directory}"
     )
   end
 

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('rspec', ['~> 2.14.1'])
   gem.add_development_dependency('rubocop', ['~> 0.24.1'])
-  gem.add_development_dependency('pry-byebug')
 
   gem.add_runtime_dependency('artifactory', ['~> 3'])
+  gem.add_runtime_dependency('apt_stage_artifacts', ['>= 0.6.2'])
   gem.add_runtime_dependency('csv', ['3.1.5'])
   gem.add_runtime_dependency('fileutils')
   gem.add_runtime_dependency('release-metrics')

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -6,7 +6,8 @@ Gem::Specification.new do |gem|
   gem.date    = Date.today.to_s
 
   gem.summary = "Puppet Labs' packaging automation"
-  gem.description = "Packaging automation written in Rake and Ruby. Easily build native packages for most platforms with a few data files and git."
+  gem.description = "Packaging automation written in Rake and Ruby. "\
+                    "Builds native packages for most platforms with a few data files and git."
   gem.license = "Apache-2.0"
 
   gem.authors  = ['Puppet Labs']
@@ -18,13 +19,17 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec', ['~> 2.14.1'])
   gem.add_development_dependency('rubocop', ['~> 0.24.1'])
   gem.add_development_dependency('pry-byebug')
-  gem.add_runtime_dependency('rake', ['>= 12.3'])
+
   gem.add_runtime_dependency('artifactory', ['~> 3'])
-  gem.add_runtime_dependency('release-metrics')
   gem.add_runtime_dependency('csv', ['3.1.5'])
+  gem.add_runtime_dependency('fileutils')
+  gem.add_runtime_dependency('release-metrics')
+  gem.add_runtime_dependency('rake', ['>= 12.3'])
+
   gem.require_path = 'lib'
 
   # Ensure the gem is built out of versioned files
-  gem.files = Dir['{lib,spec,static_artifacts,tasks,templates}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")
+  gem.files = Dir['{lib,spec,static_artifacts,tasks,templates}/**/*', 'README*', 'LICENSE*'] &
+              `git ls-files -z`.split("\0")
   gem.test_files = Dir['spec/**/*_spec.rb']
 end

--- a/tasks/fetch.rake
+++ b/tasks/fetch.rake
@@ -1,23 +1,3 @@
-# Each team has a build-defaults file that specifies local infrastructure targets
-# for things like builders, target locations for build artifacts, etc Since much
-# of these don't change, one file can be maintained for the team.  Each project
-# also has a data file for information specific to it. If the project builds
-# both PE and not PE, it has two files, one for PE, and the other for FOSS
-#
-data_repo = Pkg::Config.build_data_repo
-
-if Pkg::Config.dev_build
-  puts "NOTICE: This is a dev build!"
-  project_data_branch = "#{Pkg::Config.project}-dev"
-else
-  project_data_branch = Pkg::Config.project
-end
-team_data_branch = Pkg::Config.team
-
-if Pkg::Config.build_pe
-  project_data_branch = 'pe-' + project_data_branch unless project_data_branch =~ /^pe-/
-  team_data_branch = 'pe-' + team_data_branch unless team_data_branch =~ /^pe-/
-end
 
 # The pl:fetch task pulls down two files from the build-data repo that contain additional
 # data specific to Puppet Labs release infrastructure intended to augment/override any
@@ -25,36 +5,13 @@ end
 #
 # It uses curl to download the files, and places them in a temporary
 # directory, e.g. /tmp/somedirectory/{project,team}/Pkg::Config.builder_data_file
+
 namespace :pl do
   desc "retrieve build-data configurations to override/extend local build_defaults"
   task :fetch do
-    # Remove .packaging directory from old-style extras loading
-    rm_rf "#{ENV['HOME']}/.packaging" if File.directory?("#{ENV['HOME']}/.packaging")
-
-    # Touch the .packaging file which is allows packaging to present remote tasks
-    touch "#{ENV['HOME']}/.packaging"
-
-    begin
-      build_data_directory = Pkg::Util::File.mktemp
-      %x(git clone #{data_repo} #{build_data_directory})
-      unless $?.success?
-        fail 'Error: could not fetch the build-data repo. Maybe you do not have the correct permissions?'
-      end
-
-      Dir.chdir(build_data_directory) do
-        [team_data_branch, project_data_branch].each do |branch|
-          %x(git checkout #{branch})
-          unless $?.success?
-            warn "Warning: no build_defaults found in branch '#{branch}' of '#{data_repo}'. Skipping."
-            next
-          end
-          Pkg::Util::RakeUtils.invoke_task('pl:load_extras', build_data_directory)
-        end
-      end
-    ensure
-      rm_rf build_data_directory
-    end
-
+    Pkg::Fetch.fetch
     Pkg::Util::RakeUtils.invoke_task('config:validate')
   end
 end
+
+

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -194,12 +194,12 @@ namespace :pl do
       #
       begin
         _, retval = Pkg::Util::Net.curl_form_data(trigger_url, args)
-        if Pkg::Util::Execution.success?(retval)
-          puts "Build submitted. To view your build results, go to #{job_url}"
-          puts "Your packages will be available at http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
-        else
-          fail "An error occurred submitting the job to jenkins. Take a look at the preceding http response for more info."
+        unless Pkg::Util::Execution.success?(retval)
+          fail "An error occurred submitting the job to jenkins. See the preceding http response."
         end
+
+        puts "Build submitted. Go to #{job_url} for build information."
+        puts "Packages will be delivered to http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}"
       ensure
         # Clean up after ourselves
         rm bundle

--- a/tasks/load_extras.rake
+++ b/tasks/load_extras.rake
@@ -7,15 +7,8 @@
 # PL Release team
 namespace :pl do
   task :load_extras, :tempdir do |t, args|
-    unless ENV['PARAMS_FILE'] && ENV['PARAMS_FILE'] != ''
-      tempdir = args.tempdir
-      raise "pl:load_extras requires a directory containing extras data" if tempdir.nil?
-      Pkg::Config.config_from_yaml("#{tempdir}/#{Pkg::Config.builder_data_file}")
-
-      # Environment variables take precedence over those loaded from configs,
-      # so we make sure that any we clobbered are reset.
-      Pkg::Config.load_envvars
-    end
+    Pkg::Fetch.load_extras(args.tempdir)
   end
 end
+
 

--- a/tasks/retrieve.rake
+++ b/tasks/retrieve.rake
@@ -14,30 +14,11 @@ namespace :pl do
   namespace :jenkins do
     desc "Retrieve packages from the distribution server. Check out commit to retrieve"
     task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
-      unless Pkg::Config.project
-        fail "Error: 'project' unset. Set the project in build_defaults.yaml or " \
-             "with the 'PROJECT_OVERRIDE' environment variable."
-      end
-
       remote_target = args.remote_target || 'artifacts'
       local_target = args.local_target || 'pkg'
-      mkdir_p local_target
 
-      build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
-      build_path = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
-
-      if Pkg::Config.foss_only
-        Pkg::Retrieve.foss_only_retrieve(build_url, local_target)
-      else
-        Pkg::Retrieve.retrieve_all(build_url, build_path, local_target)
-      end
-
-      if Dir["#{local_target}/*"].empty?
-        fail "Error: Retrieval from '#{build_url}' into '#{Dir.pwd}/#{local_target}' failed. " \
-             "No artifacts were found."
-      end
-      puts "Info: Packages retrieved to '#{Dir.pwd}/#{local_target}'"
-    end
+      Pkg::Retrieve.retrieve(remote_target, local_target)
+    end 
   end
 end
 
@@ -46,17 +27,12 @@ if Pkg::Config.build_pe
     namespace :jenkins do
       desc "Retrieve packages from the distribution server. Check out commit to retrieve"
       task :retrieve, [:remote_target, :local_target] => 'pl:fetch' do |t, args|
-        unless Pkg::Config.project
-          fail "Error: 'project' unset. Set the project in build_defaults.yaml or " \
-               "with the 'PROJECT_OVERRIDE' environment variable."
-        end
-
         remote_target = args.remote_target || 'artifacts'
         local_target = args.local_target || 'pkg'
-        build_url = "http://#{Pkg::Config.builds_server}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
-        build_path = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/#{remote_target}"
-        Pkg::Retrieve.retrieve_all(build_url, build_path, local_target)
+
+        Pkg::Retrieve.retrieve_pe(remote_target, local_target)
       end
     end
   end
 end
+

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -9,36 +9,68 @@ namespace :pl do
     task update_yum_repo: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => Pkg::Paths.yum_repo_name, :repo_path => Pkg::Config.yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: Pkg::Paths.yum_repo_name,
+          repo_path: Pkg::Config.yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     desc "Update all final yum repositories on '#{Pkg::Config.yum_staging_server}'"
     task update_all_final_yum_repos: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => '', :repo_path => Pkg::Config.yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: '',
+          repo_path: Pkg::Config.yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     desc "Update '#{Pkg::Config.nonfinal_repo_name}' nightly yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_nightlies_yum_repo: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository-nightlies/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => Pkg::Config.nonfinal_repo_name, :repo_path => Pkg::Config.nonfinal_yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: Pkg::Config.nonfinal_repo_name,
+          repo_path: Pkg::Config.nonfinal_yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     desc "Update all nightly yum repositories on '#{Pkg::Config.yum_staging_server}'"
     task update_all_nightlies_yum_repos: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository-nightlies/Rakefile mk_repo'
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.yum_staging_server, command, { :repo_name => '', :repo_path => Pkg::Config.nonfinal_yum_repo_path, :repo_host => Pkg::Config.yum_staging_server })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.yum_staging_server,
+        command,
+        {
+          repo_name: '',
+          repo_path: Pkg::Config.nonfinal_yum_repo_path,
+          repo_host: Pkg::Config.yum_staging_server
+        }
+      )
     end
 
     task freight: :update_apt_repo
@@ -46,17 +78,35 @@ namespace :pl do
     desc "Update remote apt repository on '#{Pkg::Config.apt_signing_server}'"
     task update_apt_repo: 'pl:fetch' do
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.apt_signing_server, Pkg::Config.apt_repo_command, { :repo_name => Pkg::Paths.apt_repo_name, :repo_path => Pkg::Config.apt_repo_path, :repo_host => Pkg::Config.apt_host, :repo_url => Pkg::Config.apt_repo_url })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.apt_signing_server,
+        Pkg::Config.apt_repo_command,
+        {
+          repo_name: Pkg::Paths.apt_repo_name,
+          repo_path: Pkg::Config.apt_repo_path,
+          repo_host: Pkg::Config.apt_host,
+          repo_url: Pkg::Config.apt_repo_url
+        }
+      )
     end
 
     desc "Update nightlies apt repository on '#{Pkg::Config.apt_signing_server}'"
     task update_nightlies_apt_repo: 'pl:fetch' do
       $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Repo.update_repo(Pkg::Config.apt_signing_server, Pkg::Config.nonfinal_apt_repo_command, { :repo_name => Pkg::Config.nonfinal_repo_name, :repo_path => Pkg::Config.nonfinal_apt_repo_path, :repo_host => Pkg::Config.apt_host, :repo_url => Pkg::Config.apt_repo_url })
-      end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Repo.update_repo(
+        Pkg::Config.apt_signing_server,
+        Pkg::Config.nonfinal_apt_repo_command,
+        {
+          repo_name: Pkg::Config.nonfinal_repo_name,
+          repo_path: Pkg::Config.nonfinal_apt_repo_path,
+          repo_host: Pkg::Config.apt_host,
+          repo_url: Pkg::Config.apt_repo_url
+        }
+      )
     end
 
     desc "Update apt and yum repos"
@@ -74,151 +124,175 @@ namespace :pl do
     desc "Update remote ips repository on #{Pkg::Config.ips_host}"
     task :update_ips_repo  => 'pl:fetch' do
       if Dir['pkg/ips/pkgs/**/*'].empty? && Dir['pkg/solaris/11/**/*'].empty?
-        $stdout.puts "There aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11. Maybe something went wrong?"
-      else
+        $stdout.puts "Warning: No p5p packages found in pkg/ips/pkgs or pkg/solaris/11. Skipping."
+        next
+      end
 
-        if !Dir['pkg/ips/pkgs/**/*'].empty?
-          source_dir = 'pkg/ips/pkgs/'
-        else
-          source_dir = 'pkg/solaris/11/'
-        end
+      source_dir = 'pkg/solaris/11/'
+      source_dir = 'pkg/ips/pkgs/' if !Dir['pkg/ips/pkgs/**/*'].empty?
 
-        tmpdir, _ = Pkg::Util::Net.remote_execute(
-                  Pkg::Config.ips_host,
-                  'mktemp -d -p /var/tmp',
-                  { capture_output: true }
-                )
-        tmpdir.chomp!
+      tmpdir, _ = Pkg::Util::Net.remote_execute(
+                Pkg::Config.ips_host,
+                'mktemp -d -p /var/tmp',
+                { capture_output: true }
+              )
+      tmpdir.chomp!
 
-        Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
+      Pkg::Util::Net.rsync_to(source_dir, Pkg::Config.ips_host, tmpdir)
 
-        remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
+      remote_cmd = %(for pkg in #{tmpdir}/*.p5p; do
       sudo pkgrecv -s $pkg -d #{Pkg::Config.ips_path} '*';
       done)
 
-        Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, remote_cmd)
-        Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}")
-        Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, "sudo /usr/sbin/svcadm restart svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
-      end
+      Pkg::Util::Net.remote_execute(Pkg::Config.ips_host, remote_cmd)
+      Pkg::Util::Net.remote_execute(
+        Pkg::Config.ips_host, "sudo pkgrepo refresh -s #{Pkg::Config.ips_path}"
+      )
+      Pkg::Util::Net.remote_execute(
+        Pkg::Config.ips_host,
+        "sudo /usr/sbin/svcadm restart " \
+        "svc:/application/pkg/server:#{Pkg::Config.ips_repo || 'default'}")
     end
 
     desc "Move dmg repos from #{Pkg::Config.dmg_staging_server} to #{Pkg::Config.dmg_host}"
     task deploy_dmg_repo: 'pl:fetch' do
       puts "Really run remote rsync to deploy OS X repos from #{Pkg::Config.dmg_staging_server} to #{Pkg::Config.dmg_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.dmg_path, target_host: Pkg::Config.dmg_host, extra_flags: ['--update'])
-          Pkg::Util::Net.remote_execute(Pkg::Config.dmg_staging_server, cmd)
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      cmd = Pkg::Util::Net.rsync_cmd(
+        Pkg::Config.dmg_path,
+        target_host: Pkg::Config.dmg_host,
+        extra_flags: ['--update']
+      )
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(Pkg::Config.dmg_staging_server, cmd)
       end
     end
 
     desc "Move swix repos from #{Pkg::Config.swix_staging_server} to #{Pkg::Config.swix_host}"
     task deploy_swix_repo: 'pl:fetch' do
       puts "Really run remote rsync to deploy Arista repos from #{Pkg::Config.swix_staging_server} to #{Pkg::Config.swix_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.swix_path, target_host: Pkg::Config.swix_host, extra_flags: ['--update'])
-          Pkg::Util::Net.remote_execute(Pkg::Config.swix_staging_server, cmd)
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      cmd = Pkg::Util::Net.rsync_cmd(
+        Pkg::Config.swix_path,
+        target_host: Pkg::Config.swix_host,
+        extra_flags: ['--update']
+      )
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(Pkg::Config.swix_staging_server, cmd)
       end
     end
 
     desc "Move tar repos from #{Pkg::Config.tar_staging_server} to #{Pkg::Config.tar_host}"
     task deploy_tar_repo: 'pl:fetch' do
       puts "Really run remote rsync to deploy source tarballs from #{Pkg::Config.tar_staging_server} to #{Pkg::Config.tar_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        files = Dir.glob("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*")
-        if files.empty?
-          puts 'There are no tarballs to ship'
-        else
-          Pkg::Util::Execution.retry_on_fail(times: 3) do
-            cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.tarball_path, target_host: Pkg::Config.tar_host, extra_flags: ['--update'])
-            Pkg::Util::Net.remote_execute(Pkg::Config.tar_staging_server, cmd)
-          end
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      files = Dir.glob("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*")
+      if files.empty?
+        puts 'There are no tarballs to ship'
+        next
+      end
+
+      cmd = Pkg::Util::Net.rsync_cmd(
+        Pkg::Config.tarball_path,
+        target_host: Pkg::Config.tar_host,
+        extra_flags: ['--update']
+      )
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(Pkg::Config.tar_staging_server, cmd)
       end
     end
 
     desc "Move MSI repos from #{Pkg::Config.msi_staging_server} to #{Pkg::Config.msi_host}"
     task deploy_msi_repo: 'pl:fetch' do
       puts "Really run remote rsync to deploy source MSIs from #{Pkg::Config.msi_staging_server} to #{Pkg::Config.msi_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        files = Dir.glob('pkg/windows/**/*.msi')
-        if files.empty?
-          puts 'There are no MSIs to ship'
-        else
-          Pkg::Util::Execution.retry_on_fail(times: 3) do
-            cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.msi_path, target_host: Pkg::Config.msi_host, extra_flags: ['--update'])
-            Pkg::Util::Net.remote_execute(Pkg::Config.msi_staging_server, cmd)
-          end
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      files = Dir.glob('pkg/windows/**/*.msi')
+      if files.empty?
+        puts 'There are no MSIs to ship'
+        next
+      end
+
+      cmd = Pkg::Util::Net.rsync_cmd(
+        Pkg::Config.msi_path,
+        target_host: Pkg::Config.msi_host,
+        extra_flags: ['--update']
+      )
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(Pkg::Config.msi_staging_server, cmd)
       end
     end
 
     desc "Move signed deb repos from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}"
     task deploy_apt_repo: 'pl:fetch' do
       puts "Really run remote rsync to deploy Debian repos from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          Pkg::Deb::Repo.deploy_repos(
-            Pkg::Config.apt_repo_path,
-            Pkg::Config.apt_repo_staging_path,
-            Pkg::Config.apt_signing_server,
-            Pkg::Config.apt_host,
-            ENV['DRYRUN']
-          )
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Deb::Repo.deploy_repos(
+          Pkg::Config.apt_repo_path,
+          Pkg::Config.apt_repo_staging_path,
+          Pkg::Config.apt_signing_server,
+          Pkg::Config.apt_host,
+          ENV['DRYRUN']
+        )
       end
     end
 
     desc "Copy signed deb repos from #{Pkg::Config.apt_signing_server} to AWS S3"
     task :deploy_apt_repo_to_s3 => 'pl:fetch' do
       puts "Really run S3 sync to deploy Debian repos from #{Pkg::Config.apt_signing_server} to AWS S3? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          command = 'sudo /usr/local/bin/s3_repo_sync.sh apt.puppetlabs.com'
-          Pkg::Util::Net.remote_execute(Pkg::Config.apt_signing_server, command)
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      command = 'sudo /usr/local/bin/s3_repo_sync.sh apt.puppetlabs.com'
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(Pkg::Config.apt_signing_server, command)
       end
     end
 
     desc "Copy rpm repos from #{Pkg::Config.yum_staging_server} to #{Pkg::Config.yum_host}"
     task deploy_yum_repo: 'pl:fetch' do
       puts "Really run remote rsync to deploy yum repos from #{Pkg::Config.yum_staging_server} to #{Pkg::Config.yum_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          Pkg::Rpm::Repo.deploy_repos(
-            Pkg::Config.yum_repo_path,
-            Pkg::Config.yum_staging_server,
-            Pkg::Config.yum_host,
-            ENV['DRYRUN']
-          )
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Rpm::Repo.deploy_repos(
+          Pkg::Config.yum_repo_path,
+          Pkg::Config.yum_staging_server,
+          Pkg::Config.yum_host,
+          ENV['DRYRUN']
+        )
       end
     end
 
     desc "Copy signed RPM repos from #{Pkg::Config.yum_staging_server} to AWS S3"
     task :deploy_yum_repo_to_s3 => 'pl:fetch' do
       puts "Really run S3 sync to deploy RPM repos from #{Pkg::Config.yum_staging_server} to AWS S3? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          command = 'sudo /usr/local/bin/s3_repo_sync.sh yum.puppetlabs.com'
-          Pkg::Util::Net.remote_execute(Pkg::Config.yum_staging_server, command)
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      command = 'sudo /usr/local/bin/s3_repo_sync.sh yum.puppetlabs.com'
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(Pkg::Config.yum_staging_server, command)
       end
     end
 
     desc "Sync downloads.puppetlabs.com from #{Pkg::Config.staging_server} to AWS S3"
     task :deploy_downloads_to_s3 => 'pl:fetch' do
       puts "Really run S3 sync to sync downloads.puppetlabs.com from #{Pkg::Config.staging_server} to AWS S3? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          command = 'sudo /usr/local/bin/s3_repo_sync.sh downloads.puppetlabs.com'
-          Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, command)
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      command = 'sudo /usr/local/bin/s3_repo_sync.sh downloads.puppetlabs.com'
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, command)
       end
     end
+
 
     desc "Sync apt, yum, and downloads.pl.com to AWS S3"
     task :deploy_final_builds_to_s3 => "pl:fetch" do
@@ -230,7 +304,7 @@ namespace :pl do
     desc "Sync nightlies.puppetlabs.com from #{Pkg::Config.staging_server} to AWS S3"
     task :deploy_nightlies_to_s3 => 'pl:fetch' do
       puts "Deploying nightly builds from #{Pkg::Config.staging_server} to AWS S3..."
-      Pkg::Util::Execution.retry_on_fail(:times => 3) do
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
         command = 'sudo /usr/local/bin/s3_repo_sync.sh nightlies.puppet.com'
         Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, command)
       end
@@ -240,14 +314,16 @@ namespace :pl do
     task :deploy_to_rsync_server => 'pl:fetch' do
       # This task must run after the S3 sync has run, or else /opt/repo-s3-stage won't be up-to-date
       puts "Really run rsync to sync apt and yum from #{Pkg::Config.staging_server} to rsync servers? Only say yes if the S3 sync task has run. [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          Pkg::Config.rsync_servers.each do |rsync_server|
-            ['apt', 'yum'].each do |repo|
-              # Don't --delete so that folks using archived packages can continue to do so
-              command = "sudo su - rsync --command 'rsync --verbose -a --exclude '*.html' /opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/ rsync@#{rsync_server}:/opt/repository/#{repo}'"
-              Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, command)
-            end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Config.rsync_servers.each do |rsync_server|
+          ['apt', 'yum'].each do |repo|
+            # Don't --delete so that folks using archived packages can continue to do so
+            command = "sudo su - rsync --command 'rsync --verbose -a --exclude '*.html' " \
+                      "/opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/ " \
+                      "rsync@#{rsync_server}:/opt/repository/#{repo}'"
+            Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, command)
           end
         end
       end
@@ -288,85 +364,94 @@ namespace :pl do
 
   desc "Ship nightly debs to #{Pkg::Config.apt_signing_server}"
   task ship_nightly_debs: 'pl:fetch' do
-    Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.nonfinal_apt_repo_staging_path, chattr: false, nonfinal: true)
+    Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.nonfinal_apt_repo_staging_path,
+                              chattr: false, nonfinal: true)
   end
 
   desc 'Ship built gem to rubygems.org, internal Gem mirror, and public file server'
   task ship_gem: 'pl:fetch' do
     # We want to ship a Gem only for projects that build gems, so
     # all of the Gem shipping tasks are wrapped in an `if`.
-    if Pkg::Config.build_gem
-      # Even if a project builds a gem, if it uses the odd_even or zero-based
-      # strategies, we only want to ship final gems because otherwise a
-      # development gem would be preferred over the last final gem
-      if Pkg::Util::Version.final?
-        FileList['pkg/*.gem'].each do |gem_file|
-          puts 'This will ship to an internal gem mirror, a public file server, and rubygems.org'
-          puts "Do you want to start shipping the rubygem '#{gem_file}'?"
-          next unless Pkg::Util.ask_yes_or_no
-          Rake::Task['pl:ship_gem_to_rubygems'].execute(file: gem_file)
-        end
+    next unless Pkg::Config.build_gem
 
-        Rake::Task['pl:ship_gem_to_downloads'].invoke
-      else
-        $stderr.puts 'Not shipping development gem using odd_even strategy for the sake of your users.'
-      end
+    # Even if a project builds a gem, if it uses the odd_even or zero-based
+    # strategies, we only want to ship final gems because otherwise a
+    # development gem would be preferred over the last final gem
+    unless Pkg::Util::Version.final?
+      $stderr.puts 'Not shipping development gem using odd_even strategy.'
+      next
     end
+
+    FileList['pkg/*.gem'].each do |gem_file|
+      puts 'This will ship to an internal gem mirror, a public file server, and rubygems.org'
+      puts "Do you want to start shipping the rubygem '#{gem_file}'?"
+      next unless Pkg::Util.ask_yes_or_no
+      Rake::Task['pl:ship_gem_to_rubygems'].execute(file: gem_file)
+    end
+
+    Rake::Task['pl:ship_gem_to_downloads'].invoke
   end
 
   desc 'Ship built gem to internal Gem mirror and public nightlies file server'
   task ship_nightly_gem: 'pl:fetch' do
     # We want to ship a Gem only for projects that build gems, so
     # all of the Gem shipping tasks are wrapped in an `if`.
-    if Pkg::Config.build_gem
-      fail 'Value `Pkg::Config.gem_host` not defined, skipping nightly ship' unless Pkg::Config.gem_host
-      fail 'Value `Pkg::Config.nonfinal_gem_path` not defined, skipping nightly ship' unless Pkg::Config.nonfinal_gem_path
-      FileList['pkg/*.gem'].each do |gem_file|
-        Pkg::Gem.ship_to_internal_mirror(gem_file)
-      end
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.nonfinal_gem_path, platform_independent: true)
-      end
+    next unless Pkg::Config.build_gem
+
+    unless Pkg::Config.gem_host
+      fail 'Value `Pkg::Config.gem_host` not defined, skipping nightly ship'
+    end
+
+    unless Pkg::Config.nonfinal_gem_path
+      fail 'Value `Pkg::Config.nonfinal_gem_path` not defined, skipping nightly ship'
+    end
+
+    FileList['pkg/*.gem'].each do |gem_file|
+      Pkg::Gem.ship_to_internal_mirror(gem_file)
+    end
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.nonfinal_gem_path, platform_independent: true)
     end
   end
 
   desc 'Ship built gem to rubygems.org'
   task :ship_gem_to_rubygems, [:file] => 'pl:fetch' do |_t, args|
     puts "Do you want to ship #{args[:file]} to rubygems.org?"
-    if Pkg::Util.ask_yes_or_no
-      puts "Shipping gem #{args[:file]} to rubygems.org"
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Gem.ship_to_rubygems(args[:file])
-      end
+    next unless Pkg::Util.ask_yes_or_no
+
+    puts "Shipping gem #{args[:file]} to rubygems.org"
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Gem.ship_to_rubygems(args[:file])
     end
   end
 
   desc "Ship built gems to public Downloads server (#{Pkg::Config.gem_host})"
   task :ship_gem_to_downloads => 'pl:fetch' do
-    if Pkg::Config.gem_host && Pkg::Config.gem_path
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)
-      end
-    else
-      warn 'Value `Pkg::Config.gem_host` not defined; skipping shipping to public Download server'
+    unless Pkg::Config.gem_host && Pkg::Config.gem_path
+      warn 'Value `Pkg::Config.gem_host` not defined; skipping shipping to public download server'
+      next
+    end
+
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)
     end
   end
 
   desc "Ship svr4 packages to #{Pkg::Config.svr4_host}"
   task :ship_svr4 do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
-      if File.directory?("pkg/solaris/10")
-        Pkg::Util::Ship.ship_svr4('pkg', Pkg::Config.svr4_path)
-      end
+    next unless File.directory?("pkg/solaris/10")
+
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_svr4('pkg', Pkg::Config.svr4_path)
     end
   end
 
   desc "Ship p5p packages to #{Pkg::Config.p5p_host}"
   task :ship_p5p do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
-      if File.directory?("pkg/solaris/11")
-        Pkg::Util::Ship.ship_p5p('pkg', Pkg::Config.p5p_path)
-      end
+    next unless File.directory?("pkg/solaris/11")
+
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_p5p('pkg', Pkg::Config.p5p_path)
     end
   end
 
@@ -396,19 +481,25 @@ namespace :pl do
 
   desc "ship tarball and signature to #{Pkg::Config.tar_staging_server}"
   task ship_tar: 'pl:fetch' do
-    if Pkg::Config.build_tar
-      Pkg::Util::Ship.ship_tar('pkg', Pkg::Config.tarball_path, excludes: ['signing_bundle', 'packaging-bundle'], platform_independent: true)
-    end
+    next unless Pkg::Config.build_tar
+
+    Pkg::Util::Ship.ship_tar(
+      'pkg',
+      Pkg::Config.tarball_path,
+      excludes: ['signing_bundle', 'packaging-bundle'],
+      platform_independent: true
+    )
   end
 
   desc "ship Windows nuget packages to #{Pkg::Config.nuget_host}"
   task ship_nuget: 'pl:fetch' do
     packages = Dir['pkg/**/*.nupkg']
     if packages.empty?
-      $stdout.puts "There aren't any nuget packages in pkg/windows. Maybe something went wrong?"
-    else
-      Pkg::Nuget.ship(packages)
+      $stdout.puts "There aren't any nuget packages in pkg/windows. Skipping."
+      next
     end
+
+    Pkg::Nuget.ship(packages)
   end
 
   desc "Ship MSI packages to #{Pkg::Config.msi_staging_server}"
@@ -420,7 +511,11 @@ namespace :pl do
   desc "Ship nightly MSI packages to #{Pkg::Config.msi_staging_server}"
   task ship_nightly_msi: 'pl:fetch' do
     path = Pkg::Paths.remote_repo_base(package_format: 'msi', nonfinal: true)
-    Pkg::Util::Ship.ship_msi('pkg', path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"], nonfinal: true)
+    Pkg::Util::Ship.ship_msi(
+      'pkg',
+      path,
+      excludes: ["#{Pkg::Config.project}-x(86|64).msi"],
+      nonfinal: true)
   end
 
   desc "Add #{Pkg::Config.project} version #{Pkg::Config.ref} to release-metrics"
@@ -430,22 +525,25 @@ namespace :pl do
 
   desc 'UBER ship: ship all the things in pkg'
   task uber_ship: 'pl:fetch' do
-    if Pkg::Util.confirm_ship(FileList['pkg/**/*'])
-      Rake::Task['pl:ship_rpms'].invoke
-      Rake::Task['pl:ship_debs'].invoke
-      Rake::Task['pl:ship_dmg'].invoke
-      Rake::Task['pl:ship_swix'].invoke
-      Rake::Task['pl:ship_nuget'].invoke
-      Rake::Task['pl:ship_tar'].invoke
-      Rake::Task['pl:ship_svr4'].invoke
-      Rake::Task['pl:ship_p5p'].invoke
-      Rake::Task['pl:ship_msi'].invoke
-      add_shipped_metrics(pe_version: ENV['PE_VER'], is_rc: !Pkg::Util::Version.final?) if Pkg::Config.benchmark
-      post_shipped_metrics if Pkg::Config.benchmark
-    else
+    unless Pkg::Util.confirm_ship(FileList['pkg/**/*'])
       puts 'Ship canceled'
       exit
     end
+
+    Rake::Task['pl:ship_rpms'].invoke
+    Rake::Task['pl:ship_debs'].invoke
+    Rake::Task['pl:ship_dmg'].invoke
+    Rake::Task['pl:ship_swix'].invoke
+    Rake::Task['pl:ship_nuget'].invoke
+    Rake::Task['pl:ship_tar'].invoke
+    Rake::Task['pl:ship_svr4'].invoke
+    Rake::Task['pl:ship_p5p'].invoke
+    Rake::Task['pl:ship_msi'].invoke
+
+    add_shipped_metrics(
+      pe_version: ENV['PE_VER'],
+      is_rc: !Pkg::Util::Version.final?)
+    post_shipped_metrics if Pkg::Config.benchmark
   end
 
   desc 'Create the rolling repo links'
@@ -472,12 +570,18 @@ namespace :pl do
       errs << 'TEAM environment variable is not set. This should be set to release'
     end
     # Check SSH access to the staging servers
-    ssh_errs << Pkg::Util::Net.check_host_ssh(Pkg::Util.filter_configs('staging_server').values.uniq)
+    ssh_errs << Pkg::Util::Net.check_host_ssh(
+      Pkg::Util.filter_configs('staging_server').values.uniq)
+
     # Check SSH access to the signing servers, with some windows special-ness
-    ssh_errs << Pkg::Util::Net.check_host_ssh(Pkg::Util.filter_configs('signing_server').values.uniq - [Pkg::Config.msi_signing_server])
+    ssh_errs << Pkg::Util::Net.check_host_ssh(
+      Pkg::Util.filter_configs('signing_server').values.uniq - [Pkg::Config.msi_signing_server])
     ssh_errs << Pkg::Util::Net.check_host_ssh("Administrator@#{Pkg::Config.msi_signing_server}")
+
     # Check SSH access to the final shipped hosts
-    ssh_errs << Pkg::Util::Net.check_host_ssh(Pkg::Util.filter_configs('^(?!.*(?=build|internal)).*_host$').values.uniq)
+    ssh_errs << Pkg::Util::Net.check_host_ssh(
+      Pkg::Util.filter_configs('^(?!.*(?=build|internal)).*_host$').values.uniq)
+
     ssh_errs.flatten!
     unless ssh_errs.empty?
       ssh_errs.each do |host|
@@ -526,14 +630,15 @@ namespace :pl do
     end
 
     puts "\n\n"
-    if errs.empty?
-      puts 'Hooray! You should be good for shipping!'
-    else
+    unless errs.empty?
       puts "Found #{errs.length} issues:"
       errs.each do |err|
         puts " * #{err}"
       end
+      next
     end
+
+    puts 'Hooray! You should be good for shipping!'
   end
 
   # It is odd to namespace this ship task under :jenkins, but this task is
@@ -564,7 +669,6 @@ namespace :pl do
 
       Pkg::Ship::DistributionServer.ship(local_dir, target)
       Pkg::Ship::Artifactory.ship(local_dir, target)
-
     end
 
     desc 'Ship generated repository configs to the distribution server'

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -1,4 +1,4 @@
-namespace :pl do
+day namespace :pl do
   namespace :remote do
     # These hacky bits execute a pre-existing rake task on the Pkg::Config.apt_host
     # The rake task takes packages in a specific directory and freights them
@@ -359,13 +359,21 @@ namespace :pl do
 
   desc "Ship cow-built debs to #{Pkg::Config.apt_signing_server}"
   task ship_debs: 'pl:fetch' do
+    # This is the original version. It manually uploads into a freight library.
     Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.apt_repo_staging_path, chattr: false)
+
+    # Updated version. We allow freight to do the work for us.
+    Pkg::Util::Ship.apt_stage_artifacts('pkg', Pkg::Config.repo_name)
   end
 
   desc "Ship nightly debs to #{Pkg::Config.apt_signing_server}"
   task ship_nightly_debs: 'pl:fetch' do
+    # This is the original version. It manually uploads into a freight library.
     Pkg::Util::Ship.ship_debs('pkg', Pkg::Config.nonfinal_apt_repo_staging_path,
                               chattr: false, nonfinal: true)
+
+    # This is the original version. It manually uploads into a freight library.
+    Pkg::Util::Ship.apt_stage_artifacts('pkg', Pkg::Config.nonfinal_repo_name)
   end
 
   desc 'Ship built gem to rubygems.org, internal Gem mirror, and public file server'

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -677,6 +677,7 @@ day namespace :pl do
 
       Pkg::Ship::DistributionServer.ship(local_dir, target)
       Pkg::Ship::Artifactory.ship(local_dir, target)
+      Pkg::Util::Ship.apt_stage_artifacts(local_dir, Pkg::Config.repo_name)
     end
 
     desc 'Ship generated repository configs to the distribution server'


### PR DESCRIPTION
Update ship_debs to ship to both the older freight repos on weth and
the new ones separated by puppet major version.

In the new world, let freight do all the work rather than upload
behind its back.

Also, take care of some code clarity/cleanup issues.

Move code out of tasks and into ruby methods.

Refactor large if/else statements into guardian clauses.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.