### PR TITLE
(RE-14142) Refactor dmg signing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (RE-14142) MacOS signing is fairly broken
+
+### Changed
 - (RE-11477) Remove support for cisco-wrlinux and eos as those were EOL'd for platform6.
 - (RE-13479) Remove support for AIX 6.1
 - (PA-3614)  Add macOS 11 to platforms

--- a/lib/packaging/sign/dmg.rb
+++ b/lib/packaging/sign/dmg.rb
@@ -1,41 +1,71 @@
 module Pkg::Sign::Dmg
   module_function
 
-  def sign(target_dir = 'pkg')
-    use_identity = "-i #{Pkg::Config.osx_signing_ssh_key}" unless Pkg::Config.osx_signing_ssh_key.nil?
-
-    if Pkg::Config.osx_signing_server =~ /@/
-      host_string = "#{Pkg::Config.osx_signing_server}"
-    else
-      host_string = "#{ENV['USER']}@#{Pkg::Config.osx_signing_server}"
+  def sign(pkg_directory = 'pkg')
+    use_identity = ''
+    unless Pkg::Config.osx_signing_ssh_key.nil?
+      use_identity = "-i #{Pkg::Config.osx_signing_ssh_key}"
     end
+
+    host_string = "#{ENV['USER']}@#{Pkg::Config.osx_signing_server}"
+    host_string = "#{Pkg::Config.osx_signing_server}" if Pkg::Config.osx_signing_server =~ /@/
+
     ssh_host_string = "#{use_identity} #{host_string}"
     rsync_host_string = "-e 'ssh #{use_identity}' #{host_string}"
 
-    work_dir  = "/tmp/#{Pkg::Util.rand_string}"
-    mount     = File.join(work_dir, "mount")
-    signed    = File.join(work_dir, "signed")
-    Pkg::Util::Net.remote_execute(ssh_host_string, "mkdir -p #{mount} #{signed}")
-    dmgs = Dir.glob("#{target_dir}/apple/**/*.dmg")
-    Pkg::Util::Net.rsync_to(dmgs.join(" "), rsync_host_string, work_dir)
-    Pkg::Util::Net.remote_execute(ssh_host_string, %Q[for dmg in #{dmgs.map { |d| File.basename(d, ".dmg") }.join(" ")}; do
-      /usr/bin/hdiutil attach #{work_dir}/$dmg.dmg -mountpoint #{mount} -nobrowse -quiet ;
-      /usr/bin/security -q unlock-keychain -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" ;
-        for pkg in $(ls #{mount}/*.pkg | xargs -n 1 basename); do
-          if /usr/sbin/pkgutil --check-signature #{mount}/$pkg ; then
-            echo "$pkg is already signed, skipping . . ." ;
-            cp #{mount}/$pkg #{signed}/$pkg ;
-          else
-            /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}" --sign "#{Pkg::Config.osx_signing_cert}" #{mount}/$pkg #{signed}/$pkg ;
-          fi
-        done
-      /usr/bin/hdiutil detach #{mount} -quiet ;
-      /bin/rm #{work_dir}/$dmg.dmg ;
-      /usr/bin/hdiutil create -volname $dmg -srcfolder #{signed}/ #{work_dir}/$dmg.dmg ;
-      /bin/rm #{signed}/* ; done])
-    dmgs.each do | dmg |
-      Pkg::Util::Net.rsync_from("#{work_dir}/#{File.basename(dmg)}", rsync_host_string, File.dirname(dmg))
+    remote_working_directory = "/tmp/#{Pkg::Util.rand_string}"
+    dmg_mount_point = File.join(remote_working_directory, "mount")
+    signed_items_directory    = File.join(remote_working_directory, "signed")
+
+    dmgs = Dir.glob("#{pkg_directory}/{apple,mac,osx}/**/*.dmg")
+    if dmgs.empty?
+      $stderr.puts "Error: no dmgs found in #{pkg_directory}/{apple,mac,osx}."
+      exit 1
     end
-    Pkg::Util::Net.remote_execute(ssh_host_string, "if [ -d '#{work_dir}' ]; then rm -rf '#{work_dir}'; fi")
+
+    dmg_basenames = dmgs.map { |d| File.basename(d, '.dmg') }.join(' ')
+
+    sign_package_command = %W[
+      for dmg in #{dmg_basenames}; do
+        /usr/bin/hdiutil attach #{remote_working_directory}/$dmg.dmg
+          -mountpoint #{dmg_mount_point} -nobrowse -quiet ;
+
+        /usr/bin/security -q unlock-keychain
+          -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" ;
+
+        for pkg in #{dmg_mount_point}/*.pkg; do
+          pkg_basename=$(basename $pkg) ;
+          if /usr/sbin/pkgutil --check-signature $pkg ; then
+            echo "Warning: $pkg is already signed, skipping" ;
+            cp $pkg #{signed_items_directory}/$pkg_basename ;
+            continue ;
+          fi ;
+
+          /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}"
+            --sign "#{Pkg::Config.osx_signing_cert}"
+            $pkg #{signed_items_directory}/$pkg_basename ;
+        done ;
+
+        /usr/bin/hdiutil detach #{dmg_mount_point} -quiet ;
+        /bin/rm #{remote_working_directory}/$dmg.dmg ;
+        /usr/bin/hdiutil create -volname $dmg
+          -srcfolder #{signed_items_directory}/ #{remote_working_directory}/$dmg.dmg ;
+        /bin/rm #{signed_items_directory}/* ;
+      done
+    ].join(' ')
+
+    Pkg::Util::Net.remote_execute(ssh_host_string,
+                                  "mkdir -p #{dmg_mount_point} #{signed_items_directory}")
+
+    Pkg::Util::Net.rsync_to(dmgs.join(' '), rsync_host_string, remote_working_directory)
+
+    Pkg::Util::Net.remote_execute(ssh_host_string, sign_package_command)
+
+    dmgs.each do |dmg|
+      Pkg::Util::Net.rsync_from(
+        "#{remote_working_directory}/#{File.basename(dmg)}", rsync_host_string, File.dirname(dmg))
+    end
+
+    Pkg::Util::Net.remote_execute(ssh_host_string, "rm -rf '#{remote_working_directory}'")
   end
 end


### PR DESCRIPTION
Primarily: fix bug that was quietly ignoring signing dmgs that weren't
in the 'apple' directory. Add 'mac' and 'osx' as considerations.

Also, do a good bit of refactoring for clarity to throw errors when
things are amiss.

The Dir.glob is still a big problem that I did not address. The signer
should be told explicitly what to sign rather than have to infer it
from the directory structure.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.