### PR TITLE
(PE-32530) fix mac OS 11 signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Added
 - Add macOS 11 arm64 to platforms hash
+- (PE-32530) update sign_dmg to handle multiple architectures
 
 ## [0.99.78] - 2021-06-21
 ### Added

--- a/lib/packaging/sign/dmg.rb
+++ b/lib/packaging/sign/dmg.rb
@@ -12,60 +12,68 @@ module Pkg::Sign::Dmg
 
     ssh_host_string = "#{use_identity} #{host_string}"
     rsync_host_string = "-e 'ssh #{use_identity}' #{host_string}"
+    archs =  Dir.glob("#{pkg_directory}/{apple,mac,osx}/**/{x86_64,arm64}").map { |el| el.split('/').last }
 
-    remote_working_directory = "/tmp/#{Pkg::Util.rand_string}"
-    dmg_mount_point = File.join(remote_working_directory, "mount")
-    signed_items_directory    = File.join(remote_working_directory, "signed")
-
-    dmgs = Dir.glob("#{pkg_directory}/{apple,mac,osx}/**/*.dmg")
-    if dmgs.empty?
-      $stderr.puts "Error: no dmgs found in #{pkg_directory}/{apple,mac,osx}."
+    if archs.empty?
+      $stderr.puts "Error: no architectures found in #{pkg_directory}/{apple,mac,osx}"
       exit 1
     end
 
-    dmg_basenames = dmgs.map { |d| File.basename(d, '.dmg') }.join(' ')
+    archs.each do |arch|
+      remote_working_directory = "/tmp/#{Pkg::Util.rand_string}/#{arch}"
+      dmg_mount_point = File.join(remote_working_directory, "mount")
+      signed_items_directory    = File.join(remote_working_directory, "signed")
 
-    sign_package_command = %W[
-      for dmg in #{dmg_basenames}; do
-        /usr/bin/hdiutil attach #{remote_working_directory}/$dmg.dmg
-          -mountpoint #{dmg_mount_point} -nobrowse -quiet ;
+      dmgs = Dir.glob("#{pkg_directory}/{apple,mac,osx}/**/#{arch}/*.dmg")
+      if dmgs.empty?
+        $stderr.puts "Error: no dmgs found in #{pkg_directory}/{apple,mac,osx} for #{arch} architecture."
+        exit 1
+      end
 
-        /usr/bin/security -q unlock-keychain
-          -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" ;
+      dmg_basenames = dmgs.map { |d| File.basename(d, '.dmg') }.join(' ')
 
-        for pkg in #{dmg_mount_point}/*.pkg; do
-          pkg_basename=$(basename $pkg) ;
-          if /usr/sbin/pkgutil --check-signature $pkg ; then
-            echo "Warning: $pkg is already signed, skipping" ;
-            cp $pkg #{signed_items_directory}/$pkg_basename ;
-            continue ;
-          fi ;
+      sign_package_command = %W[
+        for dmg in #{dmg_basenames}; do
+          /usr/bin/hdiutil attach #{remote_working_directory}/$dmg.dmg
+            -mountpoint #{dmg_mount_point} -nobrowse -quiet ;
 
-          /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}"
-            --sign "#{Pkg::Config.osx_signing_cert}"
-            $pkg #{signed_items_directory}/$pkg_basename ;
-        done ;
+          /usr/bin/security -q unlock-keychain
+            -p "#{Pkg::Config.osx_signing_keychain_pw}" "#{Pkg::Config.osx_signing_keychain}" ;
 
-        /usr/bin/hdiutil detach #{dmg_mount_point} -quiet ;
-        /bin/rm #{remote_working_directory}/$dmg.dmg ;
-        /usr/bin/hdiutil create -volname $dmg
-          -srcfolder #{signed_items_directory}/ #{remote_working_directory}/$dmg.dmg ;
-        /bin/rm #{signed_items_directory}/* ;
-      done
-    ].join(' ')
+          for pkg in #{dmg_mount_point}/*.pkg; do
+            pkg_basename=$(basename $pkg) ;
+            if /usr/sbin/pkgutil --check-signature $pkg ; then
+              echo "Warning: $pkg is already signed, skipping" ;
+              cp $pkg #{signed_items_directory}/$pkg_basename ;
+              continue ;
+            fi ;
 
-    Pkg::Util::Net.remote_execute(ssh_host_string,
-                                  "mkdir -p #{dmg_mount_point} #{signed_items_directory}")
+            /usr/bin/productsign --keychain "#{Pkg::Config.osx_signing_keychain}"
+              --sign "#{Pkg::Config.osx_signing_cert}"
+              $pkg #{signed_items_directory}/$pkg_basename ;
+          done ;
 
-    Pkg::Util::Net.rsync_to(dmgs.join(' '), rsync_host_string, remote_working_directory)
+          /usr/bin/hdiutil detach #{dmg_mount_point} -quiet ;
+          /bin/rm #{remote_working_directory}/$dmg.dmg ;
+          /usr/bin/hdiutil create -volname $dmg
+            -srcfolder #{signed_items_directory}/ #{remote_working_directory}/$dmg.dmg ;
+          /bin/rm #{signed_items_directory}/* ;
+        done
+      ].join(' ')
 
-    Pkg::Util::Net.remote_execute(ssh_host_string, sign_package_command)
+      Pkg::Util::Net.remote_execute(ssh_host_string,
+                                    "mkdir -p #{dmg_mount_point} #{signed_items_directory}")
 
-    dmgs.each do |dmg|
-      Pkg::Util::Net.rsync_from(
-        "#{remote_working_directory}/#{File.basename(dmg)}", rsync_host_string, File.dirname(dmg))
+      Pkg::Util::Net.rsync_to(dmgs.join(' '), rsync_host_string, remote_working_directory)
+
+      Pkg::Util::Net.remote_execute(ssh_host_string, sign_package_command)
+
+      dmgs.each do |dmg|
+        Pkg::Util::Net.rsync_from(
+          "#{remote_working_directory}/#{File.basename(dmg)}", rsync_host_string, File.dirname(dmg))
+      end
+
+      Pkg::Util::Net.remote_execute(ssh_host_string, "rm -rf '#{remote_working_directory}'")
     end
-
-    Pkg::Util::Net.remote_execute(ssh_host_string, "rm -rf '#{remote_working_directory}'")
   end
 end


### PR DESCRIPTION
Updated the signing method for dmgs to take into
account the package archtecture when moving and
signing packages on the remote host.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
