### PR TITLE
(RE-12419) Add GCP sync to 'deploy' task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Added
 - (PA-3870) Add Ubuntu 18.04 aarch64 to platforms hash
+- (RE-12419) Add pl:remote:sync_apt_repo_to_gcp task for new APT repo
 
 ## [0.99.79] - 2021-07-27
 ### Added

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -236,8 +236,8 @@ namespace :pl do
     desc "Sync signed apt repos from #{Pkg::Config.apt_signing_server} to Google Cloud Platform"
     task :sync_apt_repo_to_gcp => 'pl:fetch' do
       target_site = 'apt.repos.puppetlabs.com'
-      sync_command_puppet_6 = "#{GCP_REPO_SYNC} apt.repos.puppet.com puppet_6"
-      sync_command_puppet_7 = "#{GCP_REPO_SYNC} apt.repos.puppet.com puppet_7"
+      sync_command_puppet_6 = "#{GCP_REPO_SYNC} apt.repos.puppet.com puppet6"
+      sync_command_puppet_7 = "#{GCP_REPO_SYNC} apt.repos.puppet.com puppet7"
       print "Sync apt repos from #{Pkg::Config.apt_signing_server} to #{target_site}? [y,n] "
       next unless Pkg::Util.ask_yes_or_no
       puts


### PR DESCRIPTION
Create an analogous task to :deploy_apt_repo_to_s3, named :deploy_apt_repo_to_gcp, for syncing APT repos to GCP.
    
Allow for both ':deploy_apt_repo_to_gcp' to follow existing naming conventions and ':sync_apt_repo_to_gcp' which is more consistent with the rest of the code/interface.
    
Do some minor cleaning of the other 'deploy_<foo>_to_s3' tasks.
