### PR TITLE
(maint) make 'nightlies.puppet.com' consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.99.81] - 2021-09-17
 ### Added
 - (PA-3768) Add RedHat 8 FIPS to platforms
+
+### Fixed
+- Fix confusion between nightlies.puppet.com and nightlies.puppetlabs.com
 
 ## [0.99.80] - 2021-08-17
 ### Added
@@ -750,7 +755,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.80...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.99.81...HEAD
+[0.99.81]: https://github.com/puppetlabs/packaging/compare/0.99.80...0.99.81
 [0.99.80]: https://github.com/puppetlabs/packaging/compare/0.99.79...0.99.80
 [0.99.79]: https://github.com/puppetlabs/packaging/compare/0.99.78...0.99.79
 [0.99.78]: https://github.com/puppetlabs/packaging/compare/0.99.77...0.99.78

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -93,7 +93,7 @@ DOC
         # The repo configs have Pkg::Config.builds_server used in them, but that
         # is internal, so we need to replace it with our public server. We also
         # want them only to see repos, and not signed repos, since the host is
-        # called nightlies.puppetlabs.com. Here we replace those values in each
+        # called nightlies.puppet.com. Here we replace those values in each
         # config with the desired value.
         Dir.glob("#{local_target}/repo_configs/**/*").select { |t_config| File.file?(t_config) }.each do |config|
           new_contents = File.read(config).gsub(Pkg::Config.builds_server, target_host).gsub(/#{target_prefix}_repos/, "repos")

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -224,9 +224,9 @@ namespace :pl do
       end
     end
 
-    desc "Sync nightlies.puppetlabs.com from #{Pkg::Config.staging_server} to AWS S3"
+    desc "Sync nightlies.puppet.com from #{Pkg::Config.staging_server} to AWS S3"
     task :deploy_nightlies_to_s3 => 'pl:fetch' do
-      sync_command = "#{S3_REPO_SYNC} nightlies.puppetlabs.com"
+      sync_command = "#{S3_REPO_SYNC} nightlies.puppet.com"
       puts "Syncing nightly builds from #{Pkg::Config.staging_server} to AWS S3"
       Pkg::Util::Execution.retry_on_fail(times: 3) do
         Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, sync_command)


### PR DESCRIPTION
Confusion between nightlies.puppetlabs.com and nightlies.puppet.com caused a
breakage in s3_repo sync. Clean up and unify on 'nightlies.puppet.com'


Please add all notable changes to the "Unreleased" section of the CHANGELOG.