### PR TITLE
Revert "(RE-13941) Take yet another swing at new apt repo shipping"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 notifications:
   email: false
 rvm:
-  - 2.4.1
   - 2.5.9
   - 2.6.8
   - 2.7.4
@@ -15,5 +14,7 @@ env:
 
 matrix:
   exclude:
+    - rvm: 2.3.8
+      env: "CHECK='rubocop -D'"
     - rvm: 2.4.1
       env: "CHECK='rubocop -D'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+## [0.103.0] - 2021-10-14
+### Changed
+- Reverted 0.102.0 because of unanticipated side-effects of base Ruby upgrade from
+  2.0.0
 
 ## [0.102.0] - 2021-10-13
 ### Added

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.email    = 'info@puppetlabs.com'
   gem.homepage = 'http://github.com/puppetlabs/packaging'
 
-  gem.required_ruby_version = '>= 2.3.0'
+  gem.required_ruby_version = '>= 2.5.0'
 
   gem.add_development_dependency('pry-byebug')
   gem.add_development_dependency('rspec', ['~> 2.14.1'])


### PR DESCRIPTION
Because of existing packaging usage, upgrading required Ruby from 2.0.0
to 2.3.0 resulted in bundle errors for those bundles that included a
vendored Ruby.

Backing out those changes to reconsider our packaging upgrade strategy.

This reverts commit 4053f89bef507af75c132795e37977b455d5c169.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.