### PR TITLE
(RE-14105) (RE-14075) (RE-14108) (RE-14111) (RE-14114) Platform removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Removed
+- EOL Platform support removals
+  - (RE-14105) EL 5
+  - (RE-14075) Debian 8
+  - (RE-14108) Fedora 30
+  - (RE-14111) Fedora 31
+  - (RE-14114) OSX 10.14
+  - (maint) OSX 10.13
+  - (maint) Ubuntu 18.10
+
+### Added
+- (PA-3614)  Add macOS 11 to platforms
 - (VANAGON-165) Create methods to replace the need for invoking rake tasks in vanagon. More specifically, methods were made for fetch, load_extras, rpm_repos, deb_repos, ship, ship_to_artifactory, and sign_all.
 
 ## [0.104.0] - 2021-11-10

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -22,14 +22,6 @@ module Pkg
       },
 
       'debian' => {
-        '8' => {
-          codename: 'jessie',
-          architectures: ['amd64', 'i386', 'powerpc'],
-          source_architecture: 'source',
-          package_format: 'deb',
-          source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
         '9' => {
           codename: 'stretch',
           architectures: ['amd64', 'i386'],
@@ -57,14 +49,6 @@ module Pkg
       },
 
       'el' => {
-        '5' => {
-          architectures: ['x86_64', 'i386'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v3',
-          repo: true,
-        },
         '6' => {
           architectures: ['x86_64', 'i386'],
           source_architecture: 'SRPMS',
@@ -92,22 +76,6 @@ module Pkg
       },
 
       'fedora' => {
-        '30' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        '31' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
         '32' => {
           architectures: ['x86_64'],
           source_architecture: 'SRPMS',
@@ -127,16 +95,6 @@ module Pkg
       },
 
       'osx' => {
-        '10.13' => {
-          architectures: ['x86_64'],
-          package_format: 'dmg',
-          repo: false,
-        },
-        '10.14' => {
-          architectures: ['x86_64'],
-          package_format: 'dmg',
-          repo: false,
-        },
         '10.15' => {
           architectures: ['x86_64'],
           package_format: 'dmg',
@@ -228,14 +186,6 @@ module Pkg
         '18.04' => {
           codename: 'bionic',
           architectures: ['amd64', 'ppc64el', 'aarch64'],
-          source_architecture: 'source',
-          package_format: 'deb',
-          source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
-        '18.10' => {
-          codename: 'cosmic',
-          architectures: ['amd64', 'ppc64el'],
           source_architecture: 'source',
           package_format: 'deb',
           source_package_formats: DEBIAN_SOURCE_FORMATS,

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -223,7 +223,7 @@ describe "Pkg::Config" do
       "./artifacts/aix/7.1/PC1/ppc/puppet-agent-5.3.2-1.aix7.1.ppc.rpm"
 
     fedora_artifacts = \
-      "./artifacts/fedora/31/PC1/x86_64/puppet-agent-5.3.2-1.fc31.x86_64.rpm"
+      "./artifacts/fedora/32/PC1/x86_64/puppet-agent-5.3.2-1.fc32.x86_64.rpm"
 
     windows_artifacts = \
       "./artifacts/windows/puppet-agent-x64.msi\n" \
@@ -280,8 +280,8 @@ describe "Pkg::Config" do
     it "should not use 'f' in fedora platform tags" do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(fedora_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data).to include('fedora-31-x86_64')
-      expect(data).not_to include('fedora-f31-x86_64')
+      expect(data).to include('fedora-32-x86_64')
+      expect(data).not_to include('fedora-f32-x86_64')
     end
 
     it "should collect packages whose extname differ from package_format" do

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -6,7 +6,7 @@ describe "Pkg::Deb::Repo" do
   let(:project)       { "deb_repos" }
   let(:ref)           { "1234abcd" }
   let(:base_url)      { "http://#{builds_server}/#{project}/#{ref}" }
-  let(:cows)          { ["xenial", "jessie", "trusty", "stretch", ""] }
+  let(:cows)          { ["xenial", "trusty", "stretch", ""] }
   let(:wget_results)  { cows.map {|cow| "#{base_url}/repos/apt/#{cow}" }.join("\n") }
   let(:wget_garbage)  { "\n and an index\nhttp://somethingelse.com/robots" }
   let(:repo_configs)  { cows.reject {|cow| cow.empty?}.map {|dist| "pkg/repo_configs/deb/pl-#{project}-#{ref}-#{dist}.list" } }

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -5,12 +5,11 @@ describe 'Pkg::Paths' do
     arch_transformations = {
       ['pkg/el-8-x86_64/puppet-agent-6.9.0-1.el8.x86_64.rpm', 'el', '8'] => 'x86_64',
       ['pkg/el/8/puppet6/aarch64/puppet-agent-6.5.0.3094.g16b6fa6f-1.el8.aarch64.rpm', 'el', '8'] => 'aarch64',
-      ['artifacts/fedora/32/puppet6/x86_64/puppet-agent-6.9.0-1.fc30.x86_64.rpm', 'fedora', '32'] => 'x86_64',
+      ['artifacts/fedora/32/puppet6/x86_64/puppet-agent-6.9.0-1.fc32.x86_64.rpm', 'fedora', '32'] => 'x86_64',
       ['pkg/ubuntu-16.04-amd64/puppet-agent_4.99.0-1xenial_amd64.deb', 'ubuntu', '16.04'] => 'amd64',
       ['artifacts/deb/focal/puppet6/puppet-agent_6.5.0.3094.g16b6fa6f-1focal_arm64.deb', 'ubuntu', '20.04'] => 'aarch64',
 
       ['artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz', 'ubuntu', '16.04'] => 'source',
-      ['artifacts/deb/jessie/PC1/puppetserver_5.0.1.master.orig.tar.gz', 'debian', '8'] => 'source',
       ['artifacts/el/6/PC1/SRPMS/puppetserver-5.0.1.master-0.1SNAPSHOT.2017.08.18T0951.el6.src.rpm', 'el', '6'] => 'SRPMS'
     }
     arch_transformations.each do |path_array, arch|
@@ -273,7 +272,7 @@ describe 'Pkg::Paths' do
         .to eq(fake_apt_repo_path)
     end
     it 'returns nonfinal_yum_repo_path for nonfinal rpms' do
-      expect(Pkg::Paths.remote_repo_base('fedora-31-x86_64', nonfinal: true))
+      expect(Pkg::Paths.remote_repo_base('fedora-34-x86_64', nonfinal: true))
         .to eq(fake_yum_nightly_repo_path)
     end
     it 'returns nonfinal_apt_repo_path for nonfinal debs' do

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -26,7 +26,7 @@ describe 'Pkg::Platforms' do
 
   describe '#versions_for_platform' do
     it 'should return all supported versions for a given platform' do
-      expect(Pkg::Platforms.versions_for_platform('el')).to match_array(['5', '6', '7', '8'])
+      expect(Pkg::Platforms.versions_for_platform('el')).to match_array(['6', '7', '8'])
     end
 
     it 'should raise an error if given a nonexistent platform' do
@@ -36,7 +36,7 @@ describe 'Pkg::Platforms' do
 
   describe '#codenames' do
     it 'should return all codenames for a given platform' do
-      codenames = ['focal', 'bionic', 'bullseye', 'buster', 'cosmic', 'jessie', 'stretch', 'trusty', 'xenial']
+      codenames = ['focal', 'bionic', 'bullseye', 'buster', 'stretch', 'trusty', 'xenial']
       expect(Pkg::Platforms.codenames).to match_array(codenames)
     end
   end
@@ -101,12 +101,12 @@ describe 'Pkg::Platforms' do
       it 'should return a hash of platform info' do
         expect(Pkg::Platforms.platform_lookup(platform)).to be_instance_of(Hash)
       end
-  
+
       it 'should include at least arch and package format keys' do
         expect(Pkg::Platforms.platform_lookup(platform).keys).to include(:architectures)
         expect(Pkg::Platforms.platform_lookup(platform).keys).to include(:package_format)
       end
-    end 
+    end
   end
 
   describe '#get_attribute' do
@@ -166,7 +166,7 @@ describe 'Pkg::Platforms' do
 
   describe '#generic_platform_tag' do
     it 'fails for unsupported platforms' do
-      expect { Pkg::Platforms.generic_platform_tag('butts') }.to raise_error
+      expect { Pkg::Platforms.generic_platform_tag('noplatform') }.to raise_error
     end
 
     it 'returns a supported platform tag containing the supplied platform' do

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -17,13 +17,6 @@ V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
 MD5 digest: OK (d5f06ba2a9053de532326d0659ec0d11)
 DOC
       }
-      let(:el5_signed_response) { <<-DOC
-Header V3 RSA/SHA1 signature: NOKEY, key ID ef8d349f
-Header SHA1 digest: OK (12ea7bd578097a3aecc5deb8ada6aca6147d68e3)
-V3 RSA/SHA1 signature: NOKEY, key ID ef8d349f
-MD5 digest: OK (27353c6153068a3c9902fcb4ad5b8b92)
-DOC
-      }
       let(:sles12_signed_response) { <<-DOC
 Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
 Header SHA1 digest: OK (e713487cf21ebeb933aefd5ec9211a34603233d2)
@@ -38,10 +31,6 @@ DOC
       }
       it 'returns true if rpm has been signed (el7)' do
         allow(Pkg::Sign::Rpm).to receive(:`).and_return(el7_signed_response)
-        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
-      end
-      it 'returns true if rpm has been signed (el5)' do
-        allow(Pkg::Sign::Rpm).to receive(:`).and_return(el5_signed_response)
         expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
       end
       it 'returns true if rpm has been signed (sles12)' do
@@ -68,7 +57,6 @@ DOC
         "#{rpm_directory}/aix/7.1/PC1/ppc/puppet-agent-5.5.3-1.aix7.1.ppc.rpm",
       ] }
       let(:v3_rpms) { [
-        "#{rpm_directory}/el/5/PC1/i386/puppet-agent-5.5.3-1.el5.i386.rpm",
         "#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm",
       ] }
       let(:v4_rpms) { [

--- a/spec/lib/packaging/util/ship_spec.rb
+++ b/spec/lib/packaging/util/ship_spec.rb
@@ -51,7 +51,6 @@ describe '#Pkg::Util::Ship' do
     pkg/sles/12/puppet6/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm
     pkg/sles/12/puppet6/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm
     pkg/sles/15/puppet6/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm
-    pkg/apple/10.14/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg
     pkg/apple/10.15/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg
     pkg/fedora/32/puppet6/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
     pkg/windows/puppet-agent-6.19.0-x64.msi
@@ -71,7 +70,6 @@ describe '#Pkg::Util::Ship' do
     pkg/puppet6/sles/12/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm
     pkg/puppet6/sles/12/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm
     pkg/puppet6/sles/15/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm
-    pkg/mac/puppet6/10.14/x86_64/puppet-agent-6.19.0-1.osx10.14.dmg
     pkg/mac/puppet6/10.15/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg
     pkg/puppet6/fedora/32/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
     pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi


### PR DESCRIPTION
This removes el5, debian 8, ubuntu 18.10, osx 10.13, osx 10.14, fedora
30, and fedora 31 from the supported platform hash.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
