### PR TITLE
(RE-13380) Support Apple Notarization for Puppet Packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
 - (PA-3614)  Add macOS 11 to platforms
 - (VANAGON-165) Create methods to replace the need for invoking rake tasks in vanagon. More specifically, methods were made for fetch, load_extras, rpm_repos, deb_repos, ship, ship_to_artifactory, and sign_all.
+- (RE-13380) Added support for Apple Notarization. Sends package to Apple Notarization 
+  service, and then staples notarization ticket to package.
 
 ## [0.104.0] - 2021-11-10
 ### Added

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -120,6 +120,7 @@ module Pkg::Params
                   :nonfinal_svr4_path,
                   :nonfinal_swix_path,
                   :nonfinal_yum_repo_path,
+                  :notarize_osx,
                   :notify,
                   :nuget_host,
                   :nuget_repo_path,
@@ -334,7 +335,8 @@ module Pkg::Params
               { :var => :pe_feature_branch,       :val => false },
               { :var => :pe_release_branch,       :val => false },
               { :var => :s3_ship,                 :val => false },
-              { :var => :apt_releases,            :val => Pkg::Platforms.codenames }]
+              { :var => :apt_releases,            :val => Pkg::Platforms.codenames },
+              { :var => :notarize_osx,            :val => true }]
 
   # These are variables which, over time, we decided to rename or replace. For
   # backwards compatibility, we assign the value of the old/deprecated

--- a/lib/packaging/sign/dmg.rb
+++ b/lib/packaging/sign/dmg.rb
@@ -32,6 +32,29 @@ module Pkg::Sign::Dmg
 
       dmg_basenames = dmgs.map { |d| File.basename(d, '.dmg') }.join(' ')
 
+      notarization_commands = ''
+
+      if Pkg::Config.notarize_osx
+        notarization_commands = %W[
+          notarization_command="xcrun altool --notarize-app --primary-bundle-id "$dmg"
+            -u $PUPPET_APPLE_DEV_EMAIL -p $PUPPET_APPLE_DEV_PW --asc-provider $ASC_PROVIDER
+            --file #{remote_working_directory}/$dmg.dmg" ;
+          UUID=$($notarization_command | grep -Ewo '[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}') ;
+          notarization_info="xcrun altool --notarization-info $UUID -u $PUPPET_APPLE_DEV_EMAIL -p $PUPPET_APPLE_DEV_PW" ;
+          while $notarization_info | grep -q 'in progress'; do
+            echo "Waiting on Apple Notarization Service... sleep 10 and try again..." ;
+            sleep 10 ;
+          done ;
+          if $notarization_info | grep -q 'Package Approved'; then
+            echo "Package approved by apple notarization service. Stapling ticket to package." ;
+            xcrun stapler staple #{remote_working_directory}/$dmg.dmg ;
+          else
+            echo "Package could not be approved by apple notarization service. Exiting signing process..." ;
+            exit 1 ;
+          fi ;
+          ].join(' ')
+      end
+
       sign_package_command = %W[
         for dmg in #{dmg_basenames}; do
           /usr/bin/hdiutil attach #{remote_working_directory}/$dmg.dmg
@@ -58,6 +81,8 @@ module Pkg::Sign::Dmg
           /usr/bin/hdiutil create -volname $dmg
             -srcfolder #{signed_items_directory}/ #{remote_working_directory}/$dmg.dmg ;
           /bin/rm #{signed_items_directory}/* ;
+
+          #{notarization_commands}
         done
       ].join(' ')
 


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
