### PR TITLE
(maint) Don't ship .sha1 files to Artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Updated ship.rake to not ship .sha1 files to Artifactory. Artifactory has its own
+  checksum method and handing it .sha1 files confuses it.
 
 ## [0.105.0] - 2022-01-06
 ### Removed


### PR DESCRIPTION
Shipping '.sha1' files to Artifactory confuses it terribly. Don't ship them.
Artifactory maintains its own checksums.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.