### PR TITLE
(RE-13698) Ship nightly debs to apt.repos.puppet.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+(RE-13698) Added support to ship nightly debs to apt.repos.puppet.com. Introduced a temporary
+  feature toggle, via the "NIGHTLY_SHIP_TO_GCP" environment variable that will add shipping
+  to GCP as part of the pl:jenkins:ship_nightly task
 
 ## [0.106.0] - 2022-01-24
 ### Fixed


### PR DESCRIPTION
Introduce a feature toggle, in the form of an environment variable
"NIGHTLY_SHIP_TO_GCP" that will allow nightly debs to be shipped to apt.repos.puppet.com


Please add all notable changes to the "Unreleased" section of the CHANGELOG.