### PR TITLE
(maint) tidy up solaris package signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Added
-(RE-13698) Added support to ship nightly debs to apt.repos.puppet.com. Introduced a temporary
+- (RE-13698) Added support to ship nightly debs to apt.repos.puppet.com. Introduced a temporary
   feature toggle, via the "NIGHTLY_SHIP_TO_GCP" environment variable that will add shipping
   to GCP as part of the pl:jenkins:ship_nightly task
+
+### Changed
+- Allow support for user@host for ssh to the solaris signing server
 
 ## [0.106.0] - 2022-01-24
 ### Fixed

--- a/lib/packaging/sign/ips.rb
+++ b/lib/packaging/sign/ips.rb
@@ -1,57 +1,88 @@
 module Pkg::Sign::Ips
   module_function
 
-  def sign(target_dir = 'pkg')
-    use_identity = "-i #{Pkg::Config.ips_signing_ssh_key}" unless Pkg::Config.ips_signing_ssh_key.nil?
+  def sign(packages_root = 'pkg')
+    identity_spec = ''
+    unless Pkg::Config.ips_signing_ssh_key.nil?
+      identity_spec = "-i #{Pkg::Config.ips_signing_ssh_key}"
+    end
 
-    ssh_host_string = "#{use_identity} #{ENV['USER']}@#{Pkg::Config.ips_signing_server}"
-    rsync_host_string = "-e 'ssh #{use_identity}' #{ENV['USER']}@#{Pkg::Config.ips_signing_server}"
+    signing_server_spec = Pkg::Config.ips_signing_server
+    unless Pkg::Config.ips_signing_server.match(%r{.+@.+})
+      signing_server_spec = "#{ENV['USER']}@#{Pkg::Config.ips_signing_server}"
+    end
 
-    p5ps = Dir.glob("#{target_dir}/solaris/11/**/*.p5p")
+    ssh_host_spec = "#{identity_spec} #{signing_server_spec}"
+    rsync_host_spec = "-e 'ssh #{identity_spec}' #{signing_server_spec}"
 
-    p5ps.each do |p5p|
+    packages = Dir.glob("#{packages_root}/solaris/11/**/*.p5p")
+
+    packages.each do |package|
       work_dir     = "/tmp/#{Pkg::Util.rand_string}"
       unsigned_dir = "#{work_dir}/unsigned"
       repo_dir     = "#{work_dir}/repo"
       signed_dir   = "#{work_dir}/pkgs"
+      package_name = File.basename(package)
 
-      Pkg::Util::Net.remote_execute(ssh_host_string, "mkdir -p #{repo_dir} #{unsigned_dir} #{signed_dir}")
-      Pkg::Util::Net.rsync_to(p5p, rsync_host_string, unsigned_dir)
+      Pkg::Util::Net.remote_execute(
+        ssh_host_spec,
+        "mkdir -p #{repo_dir} #{unsigned_dir} #{signed_dir}"
+      )
+      Pkg::Util::Net.rsync_to(package, rsync_host_spec, unsigned_dir)
 
       # Before we can get started with signing packages we need to create a repo
-      Pkg::Util::Net.remote_execute(ssh_host_string, "sudo -E /usr/bin/pkgrepo create #{repo_dir}")
-      Pkg::Util::Net.remote_execute(ssh_host_string, "sudo -E /usr/bin/pkgrepo set -s #{repo_dir} publisher/prefix=puppetlabs.com")
-      # And import all the packages into the repo.
-      Pkg::Util::Net.remote_execute(ssh_host_string, "sudo -E /usr/bin/pkgrecv -s #{unsigned_dir}/#{File.basename(p5p)} -d #{repo_dir} '*'")
-      # We are going to hard code the values for signing cert locations for now.
-      # This autmation will require an update to actually become reusable, but
-      # for now these values will stay this way so solaris signing will stop
-      # failing. Please update soon. 06/23/16
-      #
-      #            - Sean P. McDonald
-      #
+      Pkg::Util::Net.remote_execute(ssh_host_spec, "sudo -E /usr/bin/pkgrepo create #{repo_dir}")
+      Pkg::Util::Net.remote_execute(
+        ssh_host_spec,
+        "sudo -E /usr/bin/pkgrepo set -s #{repo_dir} publisher/prefix=puppetlabs.com"
+      )
+
+      # Import all the packages into the repo.
+      Pkg::Util::Net.remote_execute(
+        ssh_host_spec,
+        "sudo -E /usr/bin/pkgrecv -s #{unsigned_dir}/#{package_name} -d #{repo_dir} '*'"
+      )
+
       # We sign the entire repo
+      # Paths to the  .pem files should live elsewhere rather than hardcoded here.
       sign_cmd = "sudo -E /usr/bin/pkgsign -c /root/signing/signing_cert_2020.pem \
                   -i /root/signing/Thawte_SHA256_Code_Signing_CA.pem \
                   -i /root/signing/Thawte_Primary_Root_CA.pem \
                   -k /root/signing/signing_key_2020.pem \
                   -s 'file://#{work_dir}/repo' '*'"
-      puts "About to sign #{p5p} with #{sign_cmd} in #{work_dir}"
-      Pkg::Util::Net.remote_execute(ssh_host_string, sign_cmd.squeeze(' '))
-      # pkgrecv with -a will pull packages out of the repo, so we need to do that too to actually get the packages we signed
-      Pkg::Util::Net.remote_execute(ssh_host_string, "sudo -E /usr/bin/pkgrecv -d #{signed_dir}/#{File.basename(p5p)} -a -s #{repo_dir} '*'")
+      puts "Signing #{package} with #{sign_cmd} in #{work_dir}"
+      Pkg::Util::Net.remote_execute(ssh_host_spec, sign_cmd.squeeze(' '))
+
+      # pkgrecv with -a will pull packages out of the repo, so we need
+      # to do that too to actually get the packages we signed
+      Pkg::Util::Net.remote_execute(
+        ssh_host_spec,
+        "sudo -E /usr/bin/pkgrecv -d #{signed_dir}/#{package_name} -a -s #{repo_dir} '*'"
+      )
       begin
         # lets make sure we actually signed something?
         # **NOTE** if we're repeatedly trying to sign the same version this
         # might explode because I don't know how to reset the IPS cache.
         # Everything is amazing.
-        Pkg::Util::Net.remote_execute(ssh_host_string, "sudo -E /usr/bin/pkg contents -m -g #{signed_dir}/#{File.basename(p5p)} '*' | grep '^signature '")
+        Pkg::Util::Net.remote_execute(
+          ssh_host_spec,
+          "sudo -E /usr/bin/pkg contents -m -g #{signed_dir}/#{package_name} '*' " \
+          "| grep '^signature '")
       rescue RuntimeError
-        raise "Looks like #{File.basename(p5p)} was not signed correctly, quitting!"
+        raise "Error: #{package_name} was not signed correctly."
       end
-      # and pull the packages back.
-      Pkg::Util::Net.rsync_from("#{signed_dir}/#{File.basename(p5p)}", rsync_host_string, File.dirname(p5p))
-      Pkg::Util::Net.remote_execute(ssh_host_string, "if [ -e '#{work_dir}' ] ; then sudo rm -r '#{work_dir}' ; fi")
+
+      # Pull the packages back.
+      Pkg::Util::Net.rsync_from(
+        "#{signed_dir}/#{package_name}",
+        rsync_host_spec,
+        File.dirname(package)
+      )
+
+      Pkg::Util::Net.remote_execute(
+        ssh_host_spec,
+        "if [ -e '#{work_dir}' ] ; then sudo rm -r '#{work_dir}' ; fi"
+      )
     end
   end
 end


### PR DESCRIPTION
This is a mild refactoring to possibly prep for the removal of 'sudo'
during Solaris package signing.

Mostly cleaned up long-lines and renamed a few variables to be clearer
about their purpose.

Also made provisions for ips_signing_server to contain a username much
like the other signers do.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.