### PR TITLE
(maint) Update artifactory gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Added
-(RE-13698) Added support to ship nightly debs to apt.repos.puppet.com. Introduced a temporary
+- (RE-13698) Added support to ship nightly debs to apt.repos.puppet.com. Introduced a temporary
   feature toggle, via the "NIGHTLY_SHIP_TO_GCP" environment variable that will add shipping
   to GCP as part of the pl:jenkins:ship_nightly task
+
+### Changed
+- (maint) Change to dependency of the Artifactory gem to ~> 3.0; 2.0 is very, very old.
 
 ## [0.106.0] - 2022-01-24
 ### Fixed

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('pry')
 
   gem.add_runtime_dependency('apt_stage_artifacts')
-  gem.add_runtime_dependency('artifactory', ['~> 2'])
+  gem.add_runtime_dependency('artifactory', ['~> 3'])
   gem.add_runtime_dependency('csv', ['3.1.5'])
   gem.add_runtime_dependency('release-metrics')
   gem.add_runtime_dependency('rake', ['>= 12.3'])


### PR DESCRIPTION
~> 2.0 was very old. ~> 3.0 is much better.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.