### PR TITLE
(RE-13698) Add STABLE_SHIP_TO_GCP to go alongside the nightlies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -843,19 +843,10 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 [Unreleased]: https://github.com/puppetlabs/packaging/compare/0.107.0...HEAD
 [0.107.0]: https://github.com/puppetlabs/packaging/compare/0.106.3...0.107.0
 [0.106.3]: https://github.com/puppetlabs/packaging/compare/0.106.2...0.106.3
 [0.106.2]: https://github.com/puppetlabs/packaging/compare/0.106.1...0.106.2
-=======
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.106.1...HEAD
->>>>>>> (maint) prepare for 0.160.1 release
-=======
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.106.2...HEAD
-[0.106.2]: https://github.com/puppetlabs/packaging/compare/0.106.1...0.106.2
->>>>>>> (maint) Update changelog for 0.106.2 release. (#1160)
 [0.106.1]: https://github.com/puppetlabs/packaging/compare/0.106.0...0.106.1
 [0.106.0]: https://github.com/puppetlabs/packaging/compare/0.105.0...0.106.0
 [0.105.0]: https://github.com/puppetlabs/packaging/compare/0.104.0...0.105.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [0.106.1] - 2022-04-12
 ### Added
-- (RE-13698) Added support to ship nightly debs to apt.repos.puppet.com. Introduced a temporary
-  feature toggle, via the "NIGHTLY_SHIP_TO_GCP" environment variable that will add shipping
-  to GCP as part of the pl:jenkins:ship_nightly task
+- (RE-13698) Added support to ship nightly and stable debs to apt.repos.puppet.com. Introduced
+  feature toggles, via the "NIGHTLY_SHIP_TO_GCP" and "STABLE_SHIP_TO_GCP" environment variables
+  that will add shipping to GCP as part of the pl:jenkins:ship_nightly and pl:jenkins:ship_final
+  tasks
 - (PA-4219) Adds support for macOS 12 Monterey
 - (RE-14627) Add nil handling for no-op promotions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -844,6 +844,7 @@ this is a final version.
 ## Versions <= 0.5.0 do not have a change log entry
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 [Unreleased]: https://github.com/puppetlabs/packaging/compare/0.107.0...HEAD
 [0.107.0]: https://github.com/puppetlabs/packaging/compare/0.106.3...0.107.0
 [0.106.3]: https://github.com/puppetlabs/packaging/compare/0.106.2...0.106.3
@@ -851,6 +852,10 @@ this is a final version.
 =======
 [Unreleased]: https://github.com/puppetlabs/packaging/compare/0.106.1...HEAD
 >>>>>>> (maint) prepare for 0.160.1 release
+=======
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.106.2...HEAD
+[0.106.2]: https://github.com/puppetlabs/packaging/compare/0.106.1...0.106.2
+>>>>>>> (maint) Update changelog for 0.106.2 release. (#1160)
 [0.106.1]: https://github.com/puppetlabs/packaging/compare/0.106.0...0.106.1
 [0.106.0]: https://github.com/puppetlabs/packaging/compare/0.105.0...0.106.0
 [0.105.0]: https://github.com/puppetlabs/packaging/compare/0.104.0...0.105.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [0.106.3] - 2022-05-03
 ### Changed
 - (maint) Update rvm ruby version in remote bundle install to 2.7.5.
+- (RE-13764) Get rvm ruby version from environment variable instead of hard coded in remote
+  bundle install method.
 
 ## [0.106.2] - 2022-05-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- (RE-13698) Added support to ship nightly and stable debs to apt.repos.puppet.com. Introduced
+  feature toggles, via the "NIGHTLY_SHIP_TO_GCP" and "STABLE_SHIP_TO_GCP" environment variables
+  that will add shipping to GCP as part of the pl:jenkins:ship_nightly and pl:jenkins:ship_final
+  tasks
 
 ## [0.107.0] - 2022-06-14
 ### Added
@@ -22,10 +27,6 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [0.106.1] - 2022-04-12
 ### Added
-- (RE-13698) Added support to ship nightly and stable debs to apt.repos.puppet.com. Introduced
-  feature toggles, via the "NIGHTLY_SHIP_TO_GCP" and "STABLE_SHIP_TO_GCP" environment variables
-  that will add shipping to GCP as part of the pl:jenkins:ship_nightly and pl:jenkins:ship_final
-  tasks
 - (PA-4219) Adds support for macOS 12 Monterey
 - (RE-14627) Add nil handling for no-op promotions
 
@@ -840,10 +841,14 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
+<<<<<<< HEAD
 [Unreleased]: https://github.com/puppetlabs/packaging/compare/0.107.0...HEAD
 [0.107.0]: https://github.com/puppetlabs/packaging/compare/0.106.3...0.107.0
 [0.106.3]: https://github.com/puppetlabs/packaging/compare/0.106.2...0.106.3
 [0.106.2]: https://github.com/puppetlabs/packaging/compare/0.106.1...0.106.2
+=======
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.106.1...HEAD
+>>>>>>> (maint) prepare for 0.160.1 release
 [0.106.1]: https://github.com/puppetlabs/packaging/compare/0.106.0...0.106.1
 [0.106.0]: https://github.com/puppetlabs/packaging/compare/0.105.0...0.106.0
 [0.105.0]: https://github.com/puppetlabs/packaging/compare/0.104.0...0.105.0

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -314,6 +314,14 @@ namespace :pl do
       Rake::Task['pl:remote:update_foss_repos'].invoke
       Rake::Task['pl:remote:deploy_final_builds_to_s3'].invoke
       Rake::Task['pl:remote:deploy_to_rsync_server'].invoke
+
+      # This serves as a cheap feature toggle to avoid things not ready to
+      # use it. It should be removed in future versions.
+      if ENV['STABLE_SHIP_TO_GCP']
+        ## apt.repos.puppet.com
+        Rake::Task['pl:stage_stable_debs'].invoke
+        Rake::Task['pl:remote:sync_apt_repo_to_gcp'].invoke
+      end
     end
 
     task :stage_release_packages => "pl:fetch" do


### PR DESCRIPTION
Added support to ship nightly and stable debs to apt.repos.puppet.com. Introduced
feature toggles, via the "NIGHTLY_SHIP_TO_GCP" and "STABLE_SHIP_TO_GCP" environment variables
that will add shipping to GCP as part of the pl:jenkins:ship_nightly and pl:jenkins:ship_final
tasks

This won't switch on until the individual jobs set the environment
variable toggle.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.