### PR TITLE
(maint) Update rvm ruby version in remote bundle install to 2.7.5 and prep for 0.106.3 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.106.3] - 2022-05-03
+### Changed
+- (maint) Update rvm ruby version in remote bundle install to 2.7.5.
+
 ## [0.106.2] - 2022-05-02
 ### Changed
 - (RE-14611) Change msi sign method to use the gcp msi signer
@@ -829,7 +833,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.106.2...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.106.3...HEAD
+[0.106.3]: https://github.com/puppetlabs/packaging/compare/0.106.2...0.106.3
 [0.106.2]: https://github.com/puppetlabs/packaging/compare/0.106.1...0.106.2
 [0.106.1]: https://github.com/puppetlabs/packaging/compare/0.106.0...0.106.1
 [0.106.0]: https://github.com/puppetlabs/packaging/compare/0.105.0...0.106.0

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -394,7 +394,7 @@ module Pkg::Util::Net
     end
 
     def remote_bundle_install_command
-      rvm_ruby_version = ENV['RVM_RUBY_VERSION'] || '2.5.9'
+      rvm_ruby_version = ENV['RVM_RUBY_VERSION'] || '2.7.5'
       export_packaging_location = "export PACKAGING_LOCATION='#{ENV['PACKAGING_LOCATION']}';" if ENV['PACKAGING_LOCATION'] && !ENV['PACKAGING_LOCATION'].empty?
       export_vanagon_location = "export VANAGON_LOCATION='#{ENV['VANAGON_LOCATION']}';" if ENV['VANAGON_LOCATION'] && !ENV['VANAGON_LOCATION'].empty?
       "source /usr/local/rvm/scripts/rvm; rvm use ruby-#{rvm_ruby_version}; #{export_packaging_location} #{export_vanagon_location} bundle install --path .bundle/gems ;"


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
