### PR TITLE
Add support for signing rpms with gpg >= 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
   feature toggles, via the "NIGHTLY_SHIP_TO_GCP" and "STABLE_SHIP_TO_GCP" environment variables
   that will add shipping to GCP as part of the pl:jenkins:ship_nightly and pl:jenkins:ship_final
   tasks
+- Added support for signing RPMs using gpg >= 2.1
 
 ## [0.107.0] - 2022-06-14
 ### Added

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -79,6 +79,7 @@ module Pkg::Params
                   gemversion
                   gpg_key
                   gpg_name
+                  gpg_legacy_hosts
                   homepage
                   internal_gem_host
                   ips_build_host
@@ -231,6 +232,7 @@ module Pkg::Params
               { :var => :gem_host,                :envvar => :GEM_HOST },
               { :var => :gpg_key,                 :envvar => :GPG_KEY },
               { :var => :gpg_name,                :envvar => :GPG_NAME },
+              { :var => :gpg_legacy_hosts,        :envvar => :GPG_LEGACY_HOSTS, :type => :array },
               { :var => :ips_host,                :envvar => :IPS_HOST },
               { :var => :ips_inter_cert,          :envvar => :IPS_INTER_CERT },
               { :var => :ips_path,                :envvar => :IPS_PATH },

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -9,7 +9,7 @@ module Pkg::Sign::Rpm
 
     # on gpg >= 2.1 you need to specify the pinentry mode and not specify the
     # batch option to get prompted for a passphrase
-    input_flag = "--pinentry-mode loopback --no-tty"
+    input_flag = "--pinentry-mode loopback --no-tty --batch"
     gpg_check_command = ''
     gpg_legacy_hosts = Pkg::Config.gpg_legacy_hosts || []
 

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -9,8 +9,7 @@ module Pkg::Sign::Rpm
 
     # on gpg >= 2.1 you need to specify the pinentry mode and not specify the
     # batch option to get prompted for a passphrase
-    #input_flag = "--pinentry-mode loopback --no-tty --batch"
-    input_flag = "--no-tty --batch"
+    input_flag = "--pinentry-mode loopback --no-tty --batch"
     gpg_check_command = ''
     gpg_legacy_hosts = Pkg::Config.gpg_legacy_hosts || []
 

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -16,12 +16,12 @@ module Pkg::Sign::Rpm
     # on gpg < 2.1 you need to specify --passphrase-fd 3 to get prompted for
     # the passphrase
     if gpg_legacy_hosts.include?(Pkg::Config.signing_server)
-      input_flag = "--passphrase-fd 3"
+      input_flag = "--passphrase-fd 3 --batch"
     end
 
     if Pkg::Util.boolean_value(ENV['RPM_GPG_AGENT'])
       gpg_check_command = "--define '%__gpg_check_password_cmd /bin/true'"
-      input_flag = "#{input_flag} --batch"
+      #input_flag = "#{input_flag} --batch"
     end
 
     # Try this up to 5 times, to allow for incorrect passwords

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -9,7 +9,8 @@ module Pkg::Sign::Rpm
 
     # on gpg >= 2.1 you need to specify the pinentry mode and not specify the
     # batch option to get prompted for a passphrase
-    input_flag = "--pinentry-mode loopback --no-tty --batch"
+    #input_flag = "--pinentry-mode loopback --no-tty --batch"
+    input_flag = "--no-tty --batch"
     gpg_check_command = ''
     gpg_legacy_hosts = Pkg::Config.gpg_legacy_hosts || []
 

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -9,7 +9,7 @@ module Pkg::Sign::Rpm
 
     # on gpg >= 2.1 you need to specify the pinentry mode and not specify the
     # batch option to get prompted for a passphrase
-    input_flag = "--pinentry-mode loopback"
+    input_flag = "--pinentry-mode loopback --no-tty"
     gpg_check_command = ''
     gpg_legacy_hosts = Pkg::Config.gpg_legacy_hosts || []
 

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -29,7 +29,7 @@ module Pkg::Sign::Rpm
       # This definition of %__gpg_sign_cmd is the default on modern rpm. We
       # accept extra flags to override certain signing behavior for older
       # versions of rpm, e.g. specifying V3 signatures instead of V4.
-      Pkg::Util::Execution.capture3("#{rpm_command} #{gpg_check_command} --define '%_gpg_name #{Pkg::Util::Gpg.key}' --define '%__gpg /usr/bin/gpg' --define '%__gpg_sign_cmd %{__gpg} gpg #{sign_flags} #{input_flag} --no-verbose --no-armor --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}' --addsign #{rpm}")
+      Pkg::Util::Execution.capture3("#{rpm_command} #{gpg_check_command} --define '%_gpg_name #{Pkg::Util::Gpg.key}' --define '%__gpg /usr/bin/gpg' --define '%__gpg_sign_cmd %{__gpg} gpg #{sign_flags} #{input_flag} --no-armor --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}' --addsign #{rpm}")
     end
   end
 

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -16,12 +16,12 @@ module Pkg::Sign::Rpm
     # on gpg < 2.1 you need to specify --passphrase-fd 3 to get prompted for
     # the passphrase
     if gpg_legacy_hosts.include?(Pkg::Config.signing_server)
-      input_flag = "--passphrase-fd 3 --batch"
+      input_flag = "--passphrase-fd 3"
     end
 
     if Pkg::Util.boolean_value(ENV['RPM_GPG_AGENT'])
       gpg_check_command = "--define '%__gpg_check_password_cmd /bin/true'"
-      input_flag = "--batch --no-tty"
+      input_flag = "#{input_flag} --batch"
     end
 
     # Try this up to 5 times, to allow for incorrect passwords

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -9,7 +9,7 @@ module Pkg::Sign::Rpm
 
     # on gpg >= 2.1 you need to specify the pinentry mode and not specify the
     # batch option to get prompted for a passphrase
-    input_flag = "--pinentry-mode loopback --no-tty --batch"
+    input_flag = "--pinentry-mode loopback --no-tty"
     gpg_check_command = ''
     gpg_legacy_hosts = Pkg::Config.gpg_legacy_hosts || []
 

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -21,7 +21,7 @@ module Pkg::Sign::Rpm
 
     if Pkg::Util.boolean_value(ENV['RPM_GPG_AGENT'])
       gpg_check_command = "--define '%__gpg_check_password_cmd /bin/true'"
-      input_flag = "--batch"
+      input_flag = "--batch --no-tty"
     end
 
     # Try this up to 5 times, to allow for incorrect passwords


### PR DESCRIPTION
gpg < 2.1 and gpg <= 2.1 require different and incompatible options to prompt a user for a passphrase when signing rpms. This checks the list of legacy gpg hosts (<2.1) to determine which command to run.
