### PR TITLE
(maint) Removes several deprecated platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Removed
+
+- (maint) Removes deprecated platforms (Debian 9, Fedora 32 and 34, Ubuntu 16.04)
+
 ## [0.107.2] - 2022-09-20
 ### Changed
 - (maint) Move GCP bucket names for MSI signing to params.

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -21,14 +21,6 @@ module Pkg
       },
 
       'debian' => {
-        '9' => {
-          codename: 'stretch',
-          architectures: ['amd64', 'i386'],
-          source_architecture: 'source',
-          package_format: 'deb',
-          source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
         '10' => {
           codename: 'buster',
           architectures: ['amd64', 'i386'],
@@ -83,22 +75,6 @@ module Pkg
       },
 
       'fedora' => {
-        '32' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
-        '34' => {
-          architectures: ['x86_64'],
-          source_architecture: 'SRPMS',
-          package_format: 'rpm',
-          source_package_formats: ['src.rpm'],
-          signature_format: 'v4',
-          repo: true,
-        },
         '36' => {
           architectures: ['x86_64'],
           source_architecture: 'SRPMS',
@@ -187,22 +163,6 @@ module Pkg
       },
 
       'ubuntu' => {
-        '14.04' => {
-          codename: 'trusty',
-          architectures: ['amd64', 'i386'],
-          source_architecture: 'source',
-          package_format: 'deb',
-          source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
-        '16.04' => {
-          codename: 'xenial',
-          architectures: ['amd64', 'i386', 'ppc64el'],
-          source_architecture: 'source',
-          package_format: 'deb',
-          source_package_formats: DEBIAN_SOURCE_FORMATS,
-          repo: true,
-        },
         '18.04' => {
           codename: 'bionic',
           architectures: ['amd64', 'ppc64el', 'aarch64'],

--- a/spec/lib/packaging/artifactory_spec.rb
+++ b/spec/lib/packaging/artifactory_spec.rb
@@ -16,10 +16,10 @@ describe 'artifactory.rb' do
         :repo_config => "../repo_configs/rpm/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-el-6-x86_64.repo",
         :additional_artifacts => ["./el/6/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm"],
       },
-      'ubuntu-16.04-amd64' => {
-        :artifact => "./deb/xenial/PC1/puppet-agent_5.3.1.34.gf65f9ef-1xenial_amd64.deb",
-        :repo_config => "../repo_configs/deb/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-xenial.list",
-        :additional_artifacts => ["./deb/xenial/PC1/puppet-agent-extras_5.3.1.34.gf65f9ef-1xenial_amd64.deb"],
+      'ubuntu-18.04-amd64' => {
+        :artifact => "./deb/bionic/PC1/puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb",
+        :repo_config => "../repo_configs/deb/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-bionic.list",
+        :additional_artifacts => ["./deb/bionic/PC1/puppet-agent-extras_5.3.1.34.gf65f9ef-1bionic_amd64.deb"],
       },
       'debian-10-amd64' => {
         :artifact => "./deb/buster/PC1/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb",
@@ -61,13 +61,13 @@ describe 'artifactory.rb' do
       :package_name => 'path/to/a/el/6/package/puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm',
       :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm', 'puppet-agent-extras-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm']
     },
-    'ubuntu-16.04-amd64' => {
+    'ubuntu-18.04-amd64' => {
       :toplevel_repo => 'debian__local',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/ubuntu-16.04",
-      :codename => 'xenial',
+      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/ubuntu-18.04",
+      :codename => 'bionic',
       :arch => 'amd64',
-      :package_name => 'path/to/a/xenial/package/puppet-agent_5.3.1.34.gf65f9ef-1xenial_amd64.deb',
-      :all_package_names => ['puppet-agent_5.3.1.34.gf65f9ef-1xenial_amd64.deb', 'puppet-agent-extras_5.3.1.34.gf65f9ef-1xenial_amd64.deb']
+      :package_name => 'path/to/a/bionic/package/puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb',
+      :all_package_names => ['puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb', 'puppet-agent-extras_5.3.1.34.gf65f9ef-1bionic_amd64.deb']
     },
     'debian-10-amd64' => {
       :toplevel_repo => 'debian__local',

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -205,7 +205,7 @@ describe "Pkg::Config" do
     platform_tags = [
       'osx-10.15-x86_64',
       'osx-11-x86_64',
-      'ubuntu-16.04-i386',
+      'ubuntu-18.04-amd64',
       'el-6-x86_64',
       'el-7-ppc64le',
       'sles-12-x86_64',
@@ -214,7 +214,7 @@ describe "Pkg::Config" do
     artifacts = \
       "./artifacts/apple/10.15/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.osx10.15.dmg\n" \
       "./artifacts/apple/11/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.osx11.dmg\n" \
-      "./artifacts/deb/xenial/PC1/puppet-agent_5.3.2-1xenial_i386.deb\n" \
+      "./artifacts/deb/bionic/PC1/puppet-agent_5.3.2-1bionic_amd64.deb\n" \
       "./artifacts/el/6/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.el6.x86_64.rpm\n" \
       "./artifacts/el/7/PC1/ppc64le/puppet-agent-5.3.2-1.el7.ppc64le.rpm\n" \
       "./artifacts/sles/12/PC1/x86_64/puppet-agent-5.3.2-1.sles12.x86_64.rpm"
@@ -223,7 +223,7 @@ describe "Pkg::Config" do
       "./artifacts/aix/7.1/PC1/ppc/puppet-agent-5.3.2-1.aix7.1.ppc.rpm"
 
     fedora_artifacts = \
-      "./artifacts/fedora/32/PC1/x86_64/puppet-agent-5.3.2-1.fc32.x86_64.rpm"
+      "./artifacts/fedora/36/PC1/x86_64/puppet-agent-5.3.2-1.fc36.x86_64.rpm"
 
     windows_artifacts = \
       "./artifacts/windows/puppet-agent-x64.msi\n" \
@@ -237,17 +237,17 @@ describe "Pkg::Config" do
       "./artifacts/solaris/11/PC1/puppet-agent@5.3.2,5.11-1.sparc.p5p\n" \
       "./artifacts/solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz"
 
-    stretch_artifacts = \
-      "./artifacts/deb/stretch/PC1/puppet-agent-dbgsym_5.3.2-1stretch_i386.deb\n" \
-      "./artifacts/deb/stretch/PC1/puppet-agent_5.3.2-1stretch_i386.deb\n" \
-      "./artifacts/deb/stretch/PC1/puppet-agent_5.3.2.658.gc79ef9a-1stretch_amd64.deb\n" \
-      "./artifacts/deb/stretch/PC1/puppet-agent-dbgsym_5.3.2.658.gc79ef9a-1stretch_amd64.deb"
+    buster_artifacts = \
+      "./artifacts/deb/buster/PC1/puppet-agent-dbgsym_5.3.2-1buster_i386.deb\n" \
+      "./artifacts/deb/buster/PC1/puppet-agent_5.3.2-1buster_i386.deb\n" \
+      "./artifacts/deb/buster/PC1/puppet-agent_5.3.2.658.gc79ef9a-1buster_amd64.deb\n" \
+      "./artifacts/deb/buster/PC1/puppet-agent-dbgsym_5.3.2.658.gc79ef9a-1buster_amd64.deb"
 
     artifacts_not_matching_project = \
-      "./artifacts/deb/xenial/pe-postgresql-contrib_2019.1.9.6.12-1xenial_amd64.deb\n" \
-      "./artifacts/deb/xenial/pe-postgresql-devel_2019.1.9.6.12-1xenial_amd64.deb\n" \
-      "./artifacts/deb/xenial/pe-postgresql-server_2019.1.9.6.12-1xenial_amd64.deb\n" \
-      "./artifacts/deb/xenial/pe-postgresql_2019.1.9.6.12-1xenial_amd64.deb"
+      "./artifacts/deb/bionic/pe-postgresql-contrib_2019.1.9.6.12-1bionic_amd64.deb\n" \
+      "./artifacts/deb/bionic/pe-postgresql-devel_2019.1.9.6.12-1bionic_amd64.deb\n" \
+      "./artifacts/deb/bionic/pe-postgresql-server_2019.1.9.6.12-1bionic_amd64.deb\n" \
+      "./artifacts/deb/bionic/pe-postgresql_2019.1.9.6.12-1bionic_amd64.deb"
     project = 'puppet-agent'
     ref = '5.3.2'
 
@@ -280,8 +280,8 @@ describe "Pkg::Config" do
     it "should not use 'f' in fedora platform tags" do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(fedora_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data).to include('fedora-32-x86_64')
-      expect(data).not_to include('fedora-f32-x86_64')
+      expect(data).to include('fedora-36-x86_64')
+      expect(data).not_to include('fedora-f36-x86_64')
     end
 
     it "should collect packages whose extname differ from package_format" do
@@ -300,19 +300,19 @@ describe "Pkg::Config" do
     end
 
     it "should not collect debug packages" do
-      allow(Pkg::Util::Net).to receive(:remote_execute).and_return(stretch_artifacts, nil)
+      allow(Pkg::Util::Net).to receive(:remote_execute).and_return(buster_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data['debian-9-amd64']).to include(:artifact => './deb/stretch/PC1/puppet-agent_5.3.2.658.gc79ef9a-1stretch_amd64.deb')
+      expect(data['debian-10-amd64']).to include(:artifact => './deb/buster/PC1/puppet-agent_5.3.2.658.gc79ef9a-1buster_amd64.deb')
     end
 
     it "should collect packages that don't match the project name" do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(artifacts_not_matching_project, nil)
       data = Pkg::Config.platform_data
-      expect(data['ubuntu-16.04-amd64']).to include(:artifact => './deb/xenial/pe-postgresql-contrib_2019.1.9.6.12-1xenial_amd64.deb')
-      expect(data['ubuntu-16.04-amd64'][:additional_artifacts].size).to eq(3)
-      expect(data['ubuntu-16.04-amd64'][:additional_artifacts]).to include('./deb/xenial/pe-postgresql-devel_2019.1.9.6.12-1xenial_amd64.deb')
-      expect(data['ubuntu-16.04-amd64'][:additional_artifacts]).to include('./deb/xenial/pe-postgresql-server_2019.1.9.6.12-1xenial_amd64.deb')
-      expect(data['ubuntu-16.04-amd64'][:additional_artifacts]).to include('./deb/xenial/pe-postgresql_2019.1.9.6.12-1xenial_amd64.deb')
+      expect(data['ubuntu-18.04-amd64']).to include(:artifact => './deb/bionic/pe-postgresql-contrib_2019.1.9.6.12-1bionic_amd64.deb')
+      expect(data['ubuntu-18.04-amd64'][:additional_artifacts].size).to eq(3)
+      expect(data['ubuntu-18.04-amd64'][:additional_artifacts]).to include('./deb/bionic/pe-postgresql-devel_2019.1.9.6.12-1bionic_amd64.deb')
+      expect(data['ubuntu-18.04-amd64'][:additional_artifacts]).to include('./deb/bionic/pe-postgresql-server_2019.1.9.6.12-1bionic_amd64.deb')
+      expect(data['ubuntu-18.04-amd64'][:additional_artifacts]).to include('./deb/bionic/pe-postgresql_2019.1.9.6.12-1bionic_amd64.deb')
     end
 
     it "should use 'ppc' instead of 'power' in aix paths" do

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -6,7 +6,7 @@ describe "Pkg::Deb::Repo" do
   let(:project)       { "deb_repos" }
   let(:ref)           { "1234abcd" }
   let(:base_url)      { "http://#{builds_server}/#{project}/#{ref}" }
-  let(:cows)          { ["xenial", "trusty", "stretch", ""] }
+  let(:cows)          { ["bionic", "focal", "buster", ""] }
   let(:wget_results)  { cows.map {|cow| "#{base_url}/repos/apt/#{cow}" }.join("\n") }
   let(:wget_garbage)  { "\n and an index\nhttp://somethingelse.com/robots" }
   let(:repo_configs)  { cows.reject {|cow| cow.empty?}.map {|dist| "pkg/repo_configs/deb/pl-#{project}-#{ref}-#{dist}.list" } }
@@ -72,7 +72,7 @@ describe "Pkg::Deb::Repo" do
 
   describe "#repo_creation_command" do
     let(:prefix) { "thing" }
-    let(:artifact_directory) { ["/a/b/c/xenial"] }
+    let(:artifact_directory) { ["/a/b/c/bionic"] }
 
     it "returns a command to make repos" do
       command = Pkg::Deb::Repo.repo_creation_command(prefix, artifact_directory)
@@ -85,7 +85,7 @@ describe "Pkg::Deb::Repo" do
   describe "#create_repos" do
     let(:command) { "/usr/bin/make some repos" }
     let(:artifact_directory) { "/tmp/dir/thing" }
-    let(:pkg_directories) { ['place/to/deb/xenial', 'other/deb/trusty'] }
+    let(:pkg_directories) { ['place/to/deb/bionic', 'other/deb/focal'] }
 
     it "generates repo configs remotely and then ships them" do
       File.stub(:join) {artifact_directory}

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -5,11 +5,11 @@ describe 'Pkg::Paths' do
     arch_transformations = {
       ['pkg/el-8-x86_64/puppet-agent-6.9.0-1.el8.x86_64.rpm', 'el', '8'] => 'x86_64',
       ['pkg/el/8/puppet6/aarch64/puppet-agent-6.5.0.3094.g16b6fa6f-1.el8.aarch64.rpm', 'el', '8'] => 'aarch64',
-      ['artifacts/fedora/32/puppet6/x86_64/puppet-agent-6.9.0-1.fc32.x86_64.rpm', 'fedora', '32'] => 'x86_64',
-      ['pkg/ubuntu-16.04-amd64/puppet-agent_4.99.0-1xenial_amd64.deb', 'ubuntu', '16.04'] => 'amd64',
+      ['artifacts/fedora/36/puppet6/x86_64/puppet-agent-6.9.0-1.fc32.x86_64.rpm', 'fedora', '36'] => 'x86_64',
+      ['pkg/ubuntu-18.04-amd64/puppet-agent_4.99.0-1bionic_amd64.deb', 'ubuntu', '18.04'] => 'amd64',
       ['artifacts/deb/focal/puppet6/puppet-agent_6.5.0.3094.g16b6fa6f-1focal_arm64.deb', 'ubuntu', '20.04'] => 'aarch64',
 
-      ['artifacts/ubuntu-16.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz', 'ubuntu', '16.04'] => 'source',
+      ['artifacts/ubuntu-18.04-i386/puppetserver_5.0.1-0.1SNAPSHOT.2017.07.27T2346puppetlabs1.debian.tar.gz', 'ubuntu', '18.04'] => 'source',
       ['artifacts/el/6/PC1/SRPMS/puppetserver-5.0.1.master-0.1SNAPSHOT.2017.08.18T0951.el6.src.rpm', 'el', '6'] => 'SRPMS'
     }
     arch_transformations.each do |path_array, arch|
@@ -23,7 +23,7 @@ describe 'Pkg::Paths' do
   describe '#tag_from_artifact_path' do
     path_tranformations = {
       'pkg/el-7-x86_64/puppet-agent-5.5.22-1.el8.x86_64.rpm' => 'el-7-x86_64',
-      'pkg/ubuntu-20.04-amd64/puppet-agent_5.5.22-1xenial_amd64.deb' => 'ubuntu-20.04-amd64',
+      'pkg/ubuntu-20.04-amd64/puppet-agent_5.5.22-1bionic_amd64.deb' => 'ubuntu-20.04-amd64',
       'pkg/windows/puppet-agent-5.5.22-x86.msi' => 'windows-2012-x86',
       'artifacts/el/6/products/x86_64/pe-r10k-2.5.4.3-1.el6.x86_64.rpm' => 'el-6-x86_64',
       'pkg/pe/rpm/el-6-i386/pe-puppetserver-2017.3.0.3-1.el6.noarch.rpm' => 'el-6-i386',
@@ -35,7 +35,7 @@ describe 'Pkg::Paths' do
       'pkg/apple/11/puppet6/x86_64/puppet-agent-6.19.0-1.osx11.dmg' => 'osx-11-x86_64',
       'pkg/windows/puppet-agent-1.9.0-x86.msi' => 'windows-2012-x86',
       'pkg/pe/rpm/el-6-i386/pe-puppetserver-2017.3.0.3-1.el6.src.rpm' => 'el-6-SRPMS',
-      'pkg/pe/deb/xenial/pe-puppetserver_2017.3.0.3-1puppet1.orig.tar.gz' => 'ubuntu-16.04-source',
+      'pkg/pe/deb/bionic/pe-puppetserver_2017.3.0.3-1puppet1.orig.tar.gz' => 'ubuntu-18.04-source',
       'pkg/puppet-agent-5.1.0.79.g782e03c.gem' => nil,
       'pkg/puppet-agent-5.1.0.7.g782e03c.tar.gz' => nil,
     }
@@ -276,11 +276,11 @@ describe 'Pkg::Paths' do
         .to eq(fake_apt_repo_path)
     end
     it 'returns nonfinal_yum_repo_path for nonfinal rpms' do
-      expect(Pkg::Paths.remote_repo_base('fedora-34-x86_64', nonfinal: true))
+      expect(Pkg::Paths.remote_repo_base('fedora-36-x86_64', nonfinal: true))
         .to eq(fake_yum_nightly_repo_path)
     end
     it 'returns nonfinal_apt_repo_path for nonfinal debs' do
-      expect(Pkg::Paths.remote_repo_base('debian-9-amd64', nonfinal: true))
+      expect(Pkg::Paths.remote_repo_base('debian-10-amd64', nonfinal: true))
         .to eq(fake_apt_nightly_repo_path)
     end
     it 'fails if neither tag nor package_format is provided' do
@@ -309,8 +309,8 @@ describe 'Pkg::Paths' do
         allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository/apt')
         expect(Pkg::Paths.apt_package_base_path('ubuntu-18.04-amd64', 'puppet6', 'puppet-agent'))
           .to eq('/opt/repository/apt/pool/bionic/puppet6/p/puppet-agent')
-        expect(Pkg::Paths.apt_package_base_path('debian-9-amd64', 'puppet6', 'bolt-server'))
-          .to eq('/opt/repository/apt/pool/stretch/puppet6/b/bolt-server')
+        expect(Pkg::Paths.apt_package_base_path('debian-10-amd64', 'puppet6', 'bolt-server'))
+          .to eq('/opt/repository/apt/pool/buster/puppet6/b/bolt-server')
 
 
       end
@@ -364,16 +364,16 @@ describe 'Pkg::Paths' do
           .to eq("#{yum_repo_path}/#{repo_name}-release-sles-12.noarch.rpm")
       end
       it 'returns the appropriate link path for deb release packages' do
-        expect(Pkg::Paths.release_package_link_path('ubuntu-16.04-amd64'))
-          .to eq("#{apt_repo_path}/#{repo_name}-release-xenial.deb")
+        expect(Pkg::Paths.release_package_link_path('ubuntu-18.04-amd64'))
+          .to eq("#{apt_repo_path}/#{repo_name}-release-bionic.deb")
       end
       it 'returns the appropriate link path for nonfinal rpm release packages' do
         expect(Pkg::Paths.release_package_link_path('el-7-x86_64', true))
           .to eq("#{nonfinal_yum_repo_path}/#{nonfinal_repo_name}-release-el-7.noarch.rpm")
       end
       it 'returns the appropriate link path for nonfinal deb release packages' do
-        expect(Pkg::Paths.release_package_link_path('debian-9-i386', true))
-          .to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-stretch.deb")
+        expect(Pkg::Paths.release_package_link_path('debian-10-amd64', true))
+          .to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-buster.deb")
       end
       it 'returns nil for package formats that do not have release packages' do
         expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -36,16 +36,12 @@ describe 'Pkg::Platforms' do
 
   describe '#codenames' do
     it 'should return all codenames for a given platform' do
-      codenames = ['focal', 'bionic', 'bullseye', 'buster', 'stretch', 'trusty', 'xenial', 'jammy']
+      codenames = ['focal', 'bionic', 'bullseye', 'buster', 'jammy']
       expect(Pkg::Platforms.codenames).to match_array(codenames)
     end
   end
 
   describe '#codename_to_platform_version' do
-    it 'should return the platform and version corresponding to a given codename' do
-      expect(Pkg::Platforms.codename_to_platform_version('xenial')).to eq(['ubuntu', '16.04'])
-    end
-
     it 'should return the platform and version corresponding to a given codename' do
       expect(Pkg::Platforms.codename_to_platform_version('jammy')).to eq(['ubuntu', '22.04'])
     end
@@ -62,18 +58,18 @@ describe 'Pkg::Platforms' do
   end
 
   describe '#arches_for_codename' do
-    it 'should return an array of arches corresponding to a given codename' do
-      expect(Pkg::Platforms.arches_for_codename('xenial')).to match_array(['amd64', 'i386', 'ppc64el'])
+    it 'should return an array of architectures corresponding to a given codename' do
+      expect(Pkg::Platforms.arches_for_codename('bionic')).to match_array(['amd64', 'aarch64', 'ppc64el'])
     end
 
-    it 'should be able to include source archietectures' do
-      expect(Pkg::Platforms.arches_for_codename('xenial', true)).to match_array(["amd64", "i386", "ppc64el", "source"])
+    it 'should be able to include source architectures' do
+      expect(Pkg::Platforms.arches_for_codename('bionic', true)).to match_array(["amd64", "aarch64", "ppc64el", "source"])
     end
   end
 
   describe '#codename_to_tags' do
     it 'should return an array of platform tags corresponding to a given codename' do
-      expect(Pkg::Platforms.codename_to_tags('xenial')).to match_array(['ubuntu-16.04-i386', 'ubuntu-16.04-amd64', "ubuntu-16.04-ppc64el"])
+      expect(Pkg::Platforms.codename_to_tags('bionic')).to match_array(['ubuntu-18.04-aarch64', 'ubuntu-18.04-amd64', "ubuntu-18.04-ppc64el"])
     end
   end
 
@@ -131,17 +127,17 @@ describe 'Pkg::Platforms' do
 
   describe '#parse_platform_tag' do
     test_cases = {
-      'debian-9-amd64' => ['debian', '9', 'amd64'],
+      'debian-10-amd64' => ['debian', '10', 'amd64'],
       'windows-2012-x86' => ['windows', '2012', 'x86'],
       'windowsfips-2012-x64' => ['windowsfips', '2012', 'x64'],
       'el-7-x86_64' => ['el', '7', 'x86_64'],
       'el-6' => ['el', '6', ''],
-      'xenial-amd64' => ['ubuntu', '16.04', 'amd64'],
-      'xenial' => ['ubuntu', '16.04', ''],
+      'bionic-amd64' => ['ubuntu', '18.04', 'amd64'],
+      'bionic' => ['ubuntu', '18.04', ''],
       'windows-2012' => ['windows', '2012', ''],
       'redhatfips-7-x86_64' => ['redhatfips', '7', 'x86_64'],
       'el-7-SRPMS' => ['el', '7', 'SRPMS'],
-      'ubuntu-16.04-source' => ['ubuntu', '16.04', 'source'],
+      'ubuntu-18.04-source' => ['ubuntu', '18.04', 'source'],
     }
 
     fail_cases = [

--- a/spec/lib/packaging/util/ship_spec.rb
+++ b/spec/lib/packaging/util/ship_spec.rb
@@ -52,7 +52,7 @@ describe '#Pkg::Util::Ship' do
     pkg/sles/12/puppet6/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm
     pkg/sles/15/puppet6/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm
     pkg/apple/10.15/puppet6/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg
-    pkg/fedora/32/puppet6/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
+    pkg/fedora/36/puppet6/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
     pkg/windows/puppet-agent-6.19.0-x64.msi
     pkg/windows/puppet-agent-6.19.0-x86.msi
     pkg/windowsfips/puppet-agent-6.19.0-x64.msi
@@ -71,7 +71,7 @@ describe '#Pkg::Util::Ship' do
     pkg/puppet6/sles/12/x86_64/puppet-agent-6.19.0-1.sles12.x86_64.rpm
     pkg/puppet6/sles/15/x86_64/puppet-agent-6.19.0-1.sles15.x86_64.rpm
     pkg/mac/puppet6/10.15/x86_64/puppet-agent-6.19.0-1.osx10.15.dmg
-    pkg/puppet6/fedora/32/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
+    pkg/puppet6/fedora/36/x86_64/puppet-agent-6.19.0-1.fc32.x86_64.rpm
     pkg/windows/puppet6/puppet-agent-6.19.0-x64.msi
     pkg/windows/puppet6/puppet-agent-6.19.0-x86.msi
     pkg/windowsfips/puppet6/puppet-agent-6.19.0-x64.msi


### PR DESCRIPTION
Debian 9 (PA-4570), Fedora 32 (PA-4269) and 34 (PA-4278), and Ubuntu 16.04 (PA-4511) are all in the process of being deprecated from puppet-agent. This commit removes all of those platforms from lib/packaging/platforms.rb

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
