### PR TITLE
(RE-13698) Add apt.repos.puppet.com shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-13698) Resume work on new apt.repos.puppet.com shipping
 
 ## [0.108.0] - 2022-10-04
 ### Removed

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -50,7 +50,7 @@ module Pkg::Rpm::Repo
         next if path.include? 'aix'
         cmd << "if [ -d #{path}  ]; then "
         cmd << "pushd #{path} && "
-        cmd << '$createrepo --checksum=sha --checkts --update --delta-workers=0 --database . && '
+        cmd << '$createrepo --checksum=sha --checkts --update --workers=0 --database . && '
         cmd << 'popd ; '
         cmd << 'fi ;'
       end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -302,10 +302,10 @@ namespace :pl do
 
       # This serves as a cheap feature toggle to avoid things not ready to
       # use it. It should be removed in future versions.
-      if ENV['NIGHTLY_SHIP_TO_GCP']
+      if ENV['SHIP_TO_APT_REPOS_PUPPET_COM']
         ## apt.repos.puppet.com
         Rake::Task['pl:stage_nightly_debs'].invoke
-        Rake::Task['pl:remote:sync_apt_repo_to_gcp'].invoke
+        Rake::Task['pl:remote:sync_apt_repo_to_s3'].invoke
       end
     end
 
@@ -317,10 +317,10 @@ namespace :pl do
 
       # This serves as a cheap feature toggle to avoid things not ready to
       # use it. It should be removed in future versions.
-      if ENV['STABLE_SHIP_TO_GCP']
+      if ENV['SHIP_TO_APT_REPOS_PUPPET_COM']
         ## apt.repos.puppet.com
         Rake::Task['pl:stage_stable_debs'].invoke
-        Rake::Task['pl:remote:sync_apt_repo_to_gcp'].invoke
+        Rake::Task['pl:remote:sync_apt_repo_to_s3'].invoke
       end
     end
 

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -9,7 +9,7 @@ namespace :pl do
     desc "Update '#{Pkg::Config.repo_name}' yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_yum_repo: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
-      $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
+      puts "Run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       next unless Pkg::Util.ask_yes_or_no
 
       Pkg::Repo.update_repo(
@@ -26,7 +26,7 @@ namespace :pl do
     desc "Update all final yum repositories on '#{Pkg::Config.yum_staging_server}'"
     task update_all_final_yum_repos: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository/Rakefile mk_repo'
-      $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
+      puts "Run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       next unless Pkg::Util.ask_yes_or_no
 
       Pkg::Repo.update_repo(
@@ -43,7 +43,7 @@ namespace :pl do
     desc "Update '#{Pkg::Config.nonfinal_repo_name}' nightly yum repository on '#{Pkg::Config.yum_staging_server}'"
     task update_nightlies_yum_repo: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository-nightlies/Rakefile mk_repo'
-      $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
+      puts "Run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       next unless Pkg::Util.ask_yes_or_no
 
       Pkg::Repo.update_repo(
@@ -60,7 +60,7 @@ namespace :pl do
     desc "Update all nightly yum repositories on '#{Pkg::Config.yum_staging_server}'"
     task update_all_nightlies_yum_repos: 'pl:fetch' do
       command = Pkg::Config.yum_repo_command || 'rake -f /opt/repository-nightlies/Rakefile mk_repo'
-      $stdout.puts "Really run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
+      puts "Run remote repo update on '#{Pkg::Config.yum_staging_server}'? [y,n]"
       next unless Pkg::Util.ask_yes_or_no
 
       Pkg::Repo.update_repo(
@@ -78,7 +78,7 @@ namespace :pl do
 
     desc "Update remote apt repository on '#{Pkg::Config.apt_signing_server}'"
     task update_apt_repo: 'pl:fetch' do
-      $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
+      puts "Run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       next unless Pkg::Util.ask_yes_or_no
 
       Pkg::Repo.update_repo(
@@ -95,7 +95,7 @@ namespace :pl do
 
     desc "Update nightlies apt repository on '#{Pkg::Config.apt_signing_server}'"
     task update_nightlies_apt_repo: 'pl:fetch' do
-      $stdout.puts "Really run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
+      puts "Run remote repo update on '#{Pkg::Config.apt_signing_server}'? [y,n]"
       next unless Pkg::Util.ask_yes_or_no
 
       Pkg::Repo.update_repo(
@@ -125,7 +125,7 @@ namespace :pl do
     desc "Update remote ips repository on #{Pkg::Config.ips_host}"
     task :update_ips_repo => 'pl:fetch' do
       if Dir['pkg/ips/pkgs/**/*'].empty? && Dir['pkg/solaris/11/**/*'].empty?
-        $stdout.puts "Error: there aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11."
+        puts "Error: there aren't any p5p packages in pkg/ips/pkgs or pkg/solaris/11."
         next
       end
 
@@ -154,87 +154,99 @@ namespace :pl do
 
     desc "Move dmg repos from #{Pkg::Config.dmg_staging_server} to #{Pkg::Config.dmg_host}"
     task deploy_dmg_repo: 'pl:fetch' do
-      puts "Really run remote rsync to deploy OS X repos from #{Pkg::Config.dmg_staging_server} to #{Pkg::Config.dmg_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.dmg_path, target_host: Pkg::Config.dmg_host, extra_flags: ['--update'])
-          Pkg::Util::Net.remote_execute(Pkg::Config.dmg_staging_server, cmd)
-        end
+      puts "Run remote rsync to deploy OS X repos from #{Pkg::Config.dmg_staging_server} to " \
+           "#{Pkg::Config.dmg_host}? [y,n]"
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        cmd = Pkg::Util::Net.rsync_cmd(
+          Pkg::Config.dmg_path, target_host: Pkg::Config.dmg_host, extra_flags: ['--update']
+        )
+        Pkg::Util::Net.remote_execute(Pkg::Config.dmg_staging_server, cmd)
       end
     end
 
     desc "Move swix repos from #{Pkg::Config.swix_staging_server} to #{Pkg::Config.swix_host}"
     task deploy_swix_repo: 'pl:fetch' do
-      puts "Really run remote rsync to deploy Arista repos from #{Pkg::Config.swix_staging_server} to #{Pkg::Config.swix_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.swix_path, target_host: Pkg::Config.swix_host, extra_flags: ['--update'])
-          Pkg::Util::Net.remote_execute(Pkg::Config.swix_staging_server, cmd)
-        end
+      puts "Run remote rsync to deploy Arista repos from #{Pkg::Config.swix_staging_server} to " \
+           "#{Pkg::Config.swix_host}? [y,n]"
+      next unless Pkg::Util.ask_yes_or_no
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        cmd = Pkg::Util::Net.rsync_cmd(
+          Pkg::Config.swix_path, target_host: Pkg::Config.swix_host, extra_flags: ['--update']
+        )
+        Pkg::Util::Net.remote_execute(Pkg::Config.swix_staging_server, cmd)
       end
     end
 
     desc "Move tar repos from #{Pkg::Config.tar_staging_server} to #{Pkg::Config.tar_host}"
     task deploy_tar_repo: 'pl:fetch' do
-      puts "Really run remote rsync to deploy source tarballs from #{Pkg::Config.tar_staging_server} to #{Pkg::Config.tar_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        files = Dir.glob("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*")
-        if files.empty?
-          puts 'There are no tarballs to ship'
-        else
-          Pkg::Util::Execution.retry_on_fail(times: 3) do
-            cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.tarball_path, target_host: Pkg::Config.tar_host, extra_flags: ['--update'])
-            Pkg::Util::Net.remote_execute(Pkg::Config.tar_staging_server, cmd)
-          end
-        end
+      puts "Run remote rsync to deploy source tarballs from #{Pkg::Config.tar_staging_server} to " \
+           "#{Pkg::Config.tar_host}? [y,n]"
+      next unless Pkg::Util.ask_yes_or_no
+
+      files = Dir.glob("pkg/#{Pkg::Config.project}-#{Pkg::Config.version}.tar.gz*")
+      if files.empty?
+        puts 'There are no tarballs to ship'
+        next
+      end
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        cmd = Pkg::Util::Net.rsync_cmd(
+          Pkg::Config.tarball_path, target_host: Pkg::Config.tar_host, extra_flags: ['--update']
+        )
+        Pkg::Util::Net.remote_execute(Pkg::Config.tar_staging_server, cmd)
       end
     end
 
     desc "Move MSI repos from #{Pkg::Config.msi_staging_server} to #{Pkg::Config.msi_host}"
     task deploy_msi_repo: 'pl:fetch' do
-      puts "Really run remote rsync to deploy source MSIs from #{Pkg::Config.msi_staging_server} to #{Pkg::Config.msi_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        files = Dir.glob('pkg/windows/**/*.msi')
-        if files.empty?
-          puts 'There are no MSIs to ship'
-        else
-          Pkg::Util::Execution.retry_on_fail(times: 3) do
-            cmd = Pkg::Util::Net.rsync_cmd(Pkg::Config.msi_path, target_host: Pkg::Config.msi_host, extra_flags: ['--update'])
-            Pkg::Util::Net.remote_execute(Pkg::Config.msi_staging_server, cmd)
-          end
-        end
+      puts "Run remote rsync to deploy source MSIs from #{Pkg::Config.msi_staging_server} to " \
+           "#{Pkg::Config.msi_host}? [y,n]"
+      next unless Pkg::Util.ask_yes_or_no
+      files = Dir.glob('pkg/windows/**/*.msi')
+      if files.empty?
+        puts 'There are no MSIs to ship'
+        next
+      end
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        cmd = Pkg::Util::Net.rsync_cmd(
+          Pkg::Config.msi_path, target_host: Pkg::Config.msi_host, extra_flags: ['--update']
+        )
+        Pkg::Util::Net.remote_execute(Pkg::Config.msi_staging_server, cmd)
       end
     end
 
     desc "Move signed deb repos from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}"
     task deploy_apt_repo: 'pl:fetch' do
-      puts "Really run remote rsync to deploy Debian repos from #{Pkg::Config.apt_signing_server} to #{Pkg::Config.apt_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          Pkg::Deb::Repo.deploy_repos(
-            Pkg::Config.apt_repo_path,
-            Pkg::Config.apt_repo_staging_path,
-            Pkg::Config.apt_signing_server,
-            Pkg::Config.apt_host,
-            ENV['DRYRUN']
-          )
-        end
+      puts "Run remote rsync to deploy Debian repos from #{Pkg::Config.apt_signing_server} to " \
+           "#{Pkg::Config.apt_host}? [y,n]"
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Deb::Repo.deploy_repos(
+          Pkg::Config.apt_repo_path,
+          Pkg::Config.apt_repo_staging_path,
+          Pkg::Config.apt_signing_server,
+          Pkg::Config.apt_host,
+          ENV['DRYRUN']
+        )
       end
     end
 
     desc "Copy rpm repos from #{Pkg::Config.yum_staging_server} to #{Pkg::Config.yum_host}"
     task deploy_yum_repo: 'pl:fetch' do
-      puts "Really run remote rsync to deploy yum repos from #{Pkg::Config.yum_staging_server} " \
+      puts "Run remote rsync to deploy yum repos from #{Pkg::Config.yum_staging_server} " \
            "to #{Pkg::Config.yum_host}? [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(times: 3) do
-          Pkg::Rpm::Repo.deploy_repos(
-            Pkg::Config.yum_repo_path,
-            Pkg::Config.yum_staging_server,
-            Pkg::Config.yum_host,
-            ENV['DRYRUN']
-          )
-        end
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Rpm::Repo.deploy_repos(
+          Pkg::Config.yum_repo_path,
+          Pkg::Config.yum_staging_server,
+          Pkg::Config.yum_host,
+          ENV['DRYRUN']
+        )
       end
     end
 
@@ -320,15 +332,19 @@ namespace :pl do
     desc "Sync yum and apt from #{Pkg::Config.staging_server} to rsync servers"
     task :deploy_to_rsync_server => 'pl:fetch' do
       # This task must run after the S3 sync has run, or else /opt/repo-s3-stage won't be up-to-date
-      puts "Really run rsync to sync apt and yum from #{Pkg::Config.staging_server} to rsync servers? Only say yes if the S3 sync task has run. [y,n]"
-      if Pkg::Util.ask_yes_or_no
-        Pkg::Util::Execution.retry_on_fail(:times => 3) do
-          Pkg::Config.rsync_servers.each do |rsync_server|
-            ['apt', 'yum'].each do |repo|
-              # Don't --delete so that folks using archived packages can continue to do so
-              command = "sudo su - rsync --command 'rsync --verbose -a --exclude '*.html' /opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/ rsync@#{rsync_server}:/opt/repository/#{repo}'"
-              Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, command)
-            end
+      puts "Rsync apt and yum from #{Pkg::Config.staging_server} to rsync servers? ",
+           "Do this only if the S3 sync task has run. [y,n]"
+      next unless Pkg::Util.ask_yes_or_no
+
+      Pkg::Util::Execution.retry_on_fail(times: 3) do
+        Pkg::Config.rsync_servers.each do |rsync_server|
+          ['apt', 'yum'].each do |repo|
+            rsync_from = "/opt/repo-s3-stage/repositories/#{repo}.puppetlabs.com/"
+            rsync_to = "rsync@#{rsync_server}:/opt/repository/#{repo}"
+            # Don't --delete so that folks using archived packages can continue to do so
+            rsync_command = "sudo su - rsync --command " \
+                      "'rsync --verbose -a --exclude '*.html' #{rsync_from} #{rsync_to}'"
+            Pkg::Util::Net.remote_execute(Pkg::Config.staging_server, rsync_command)
           end
         end
       end
@@ -396,82 +412,86 @@ namespace :pl do
 
   desc 'Ship built gem to rubygems.org, internal Gem mirror, and public file server'
   task ship_gem: 'pl:fetch' do
-    # We want to ship a Gem only for projects that build gems, so
+    # We want to ship a Gem only for projects that build gems
     # all of the Gem shipping tasks are wrapped in an `if`.
-    if Pkg::Config.build_gem
-      # Even if a project builds a gem, if it uses the odd_even or zero-based
-      # strategies, we only want to ship final gems because otherwise a
-      # development gem would be preferred over the last final gem
-      if Pkg::Util::Version.final?
-        FileList['pkg/*.gem'].each do |gem_file|
-          puts 'This will ship to an internal gem mirror, a public file server, and rubygems.org'
-          puts "Do you want to start shipping the rubygem '#{gem_file}'?"
-          next unless Pkg::Util.ask_yes_or_no
+    next unless Pkg::Config.build_gem
 
-          Rake::Task['pl:ship_gem_to_rubygems'].execute(file: gem_file)
-        end
-
-        Rake::Task['pl:ship_gem_to_downloads'].invoke
-      else
-        warn 'Not shipping development gem using odd_even strategy for the sake of your users.'
-      end
+    # Even if a project builds a gem, if it uses the odd_even or zero-based
+    # strategies, we only want to ship final gems because otherwise a
+    # development gem would be preferred over the last final gem
+    unless Pkg::Util::Version.final?
+      warn 'Not shipping development gem using odd_even strategy.'
     end
+
+    FileList['pkg/*.gem'].each do |gem_file|
+      puts 'This will ship to an internal gem mirror, a public file server, and rubygems.org'
+      puts "Ship the rubygem '#{gem_file}'?"
+      next unless Pkg::Util.ask_yes_or_no
+
+      Rake::Task['pl:ship_gem_to_rubygems'].execute(file: gem_file)
+    end
+
+    Rake::Task['pl:ship_gem_to_downloads'].invoke
   end
 
   desc 'Ship built gem to internal Gem mirror and public nightlies file server'
   task ship_nightly_gem: 'pl:fetch' do
-    # We want to ship a Gem only for projects that build gems, so
-    # all of the Gem shipping tasks are wrapped in an `if`.
-    if Pkg::Config.build_gem
-      fail 'Value `Pkg::Config.gem_host` not defined, skipping nightly ship' unless Pkg::Config.gem_host
-      fail 'Value `Pkg::Config.nonfinal_gem_path` not defined, skipping nightly ship' unless Pkg::Config.nonfinal_gem_path
+    # We want to ship a Gem only for projects that build gems
+    next unless Pkg::Config.build_gem
 
-      FileList['pkg/*.gem'].each do |gem_file|
-        Pkg::Gem.ship_to_internal_mirror(gem_file)
-      end
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.nonfinal_gem_path, platform_independent: true)
-      end
+    unless Pkg::Config.gem_host
+      fail 'Value `Pkg::Config.gem_host` not defined, skipping nightly ship'
+    end
+
+    unless Pkg::Config.nonfinal_gem_path
+      fail 'Value `Pkg::Config.nonfinal_gem_path` not defined, skipping nightly ship'
+    end
+
+    FileList['pkg/*.gem'].each do |gem_file|
+      Pkg::Gem.ship_to_internal_mirror(gem_file)
+    end
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.nonfinal_gem_path, platform_independent: true)
     end
   end
 
   desc 'Ship built gem to rubygems.org'
   task :ship_gem_to_rubygems, [:file] => 'pl:fetch' do |_t, args|
-    puts "Do you want to ship #{args[:file]} to rubygems.org?"
-    if Pkg::Util.ask_yes_or_no
-      puts "Shipping gem #{args[:file]} to rubygems.org"
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Gem.ship_to_rubygems(args[:file])
-      end
+    puts "Ship #{args[:file]} to rubygems.org?"
+    next unless Pkg::Util.ask_yes_or_no
+
+    puts "Shipping gem #{args[:file]} to rubygems.org"
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Gem.ship_to_rubygems(args[:file])
     end
   end
 
   desc "Ship built gems to public Downloads server (#{Pkg::Config.gem_host})"
   task :ship_gem_to_downloads => 'pl:fetch' do
-    if Pkg::Config.gem_host && Pkg::Config.gem_path
-      Pkg::Util::Execution.retry_on_fail(times: 3) do
-        Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)
-      end
-    else
-      warn 'Value `Pkg::Config.gem_host` not defined; skipping shipping to public Download server'
+    unless Pkg::Config.gem_host && Pkg::Config.gem_path
+      warn 'Value `Pkg::Config.gem_host` not defined; skipping shipping to public download server'
+      next
+    end
+
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_gem('pkg', Pkg::Config.gem_path, platform_independent: true)
     end
   end
 
   desc "Ship svr4 packages to #{Pkg::Config.svr4_host}"
   task :ship_svr4 do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
-      if File.directory?("pkg/solaris/10")
-        Pkg::Util::Ship.ship_svr4('pkg', Pkg::Config.svr4_path)
-      end
+    next unless File.directory?("pkg/solaris/10")
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_svr4('pkg', Pkg::Config.svr4_path)
     end
   end
 
   desc "Ship p5p packages to #{Pkg::Config.p5p_host}"
   task :ship_p5p do
-    Pkg::Util::Execution.retry_on_fail(:times => 3) do
-      if File.directory?("pkg/solaris/11")
-        Pkg::Util::Ship.ship_p5p('pkg', Pkg::Config.p5p_path)
-      end
+    next unless File.directory?("pkg/solaris/11")
+
+    Pkg::Util::Execution.retry_on_fail(times: 3) do
+      Pkg::Util::Ship.ship_p5p('pkg', Pkg::Config.p5p_path)
     end
   end
 
@@ -501,19 +521,24 @@ namespace :pl do
 
   desc "ship tarball and signature to #{Pkg::Config.tar_staging_server}"
   task ship_tar: 'pl:fetch' do
-    if Pkg::Config.build_tar
-      Pkg::Util::Ship.ship_tar('pkg', Pkg::Config.tarball_path, excludes: ['signing_bundle', 'packaging-bundle'], platform_independent: true)
-    end
+    next unless Pkg::Config.build_tar
+
+    Pkg::Util::Ship.ship_tar(
+      'pkg', Pkg::Config.tarball_path,
+      excludes: ['signing_bundle', 'packaging-bundle'],
+      platform_independent: true
+    )
   end
 
   desc "ship Windows nuget packages to #{Pkg::Config.nuget_host}"
   task ship_nuget: 'pl:fetch' do
     packages = Dir['pkg/**/*.nupkg']
     if packages.empty?
-      $stdout.puts "There aren't any nuget packages in pkg/windows. Maybe something went wrong?"
-    else
-      Pkg::Nuget.ship(packages)
+      puts "There are no nuget packages in pkg/windows."
+      next
     end
+
+    Pkg::Nuget.ship(packages)
   end
 
   desc "Ship MSI packages to #{Pkg::Config.msi_staging_server}"
@@ -525,7 +550,9 @@ namespace :pl do
   desc "Ship nightly MSI packages to #{Pkg::Config.msi_staging_server}"
   task ship_nightly_msi: 'pl:fetch' do
     path = Pkg::Paths.remote_repo_base(package_format: 'msi', nonfinal: true)
-    Pkg::Util::Ship.ship_msi('pkg', path, excludes: ["#{Pkg::Config.project}-x(86|64).msi"], nonfinal: true)
+    Pkg::Util::Ship.ship_msi('pkg', path,
+                             excludes: ["#{Pkg::Config.project}-x(86|64).msi"],
+                             nonfinal: true)
   end
 
   desc "Add #{Pkg::Config.project} version #{Pkg::Config.ref} to release-metrics"
@@ -572,20 +599,31 @@ namespace :pl do
     ssh_errs = []
     gpg_errs = []
 
-    if ENV['TEAM']
-      unless ENV['TEAM'] == 'release'
-        errs << "TEAM environment variable is #{ENV['TEAM']}. It should be 'release'"
-      end
-    else
-      errs << 'TEAM environment variable is not set. This should be set to release'
+    unless ENV['TEAM']
+      errs << '"TEAM" environment variable is not set. This should be set to "release"'
     end
+
+    if ENV['TEAM'] && ENV['TEAM'] != 'release'
+      errs << "\"TEAM\" environment variable is \"#{ENV['TEAM']}\". It should be \"release\""
+    end
+
     # Check SSH access to the staging servers
-    ssh_errs << Pkg::Util::Net.check_host_ssh(Pkg::Util.filter_configs('staging_server').values.uniq)
+    ssh_errs << Pkg::Util::Net.check_host_ssh(
+      Pkg::Util.filter_configs('staging_server').values.uniq
+    )
+
     # Check SSH access to the signing servers, with some windows special-ness
-    ssh_errs << Pkg::Util::Net.check_host_ssh(Pkg::Util.filter_configs('signing_server').values.uniq - [Pkg::Config.msi_signing_server])
+    ssh_errs << Pkg::Util::Net.check_host_ssh(
+      Pkg::Util.filter_configs('signing_server').values.uniq - [Pkg::Config.msi_signing_server]
+    )
+
     ssh_errs << Pkg::Util::Net.check_host_ssh("Administrator@#{Pkg::Config.msi_signing_server}")
+
     # Check SSH access to the final shipped hosts
-    ssh_errs << Pkg::Util::Net.check_host_ssh(Pkg::Util.filter_configs('^(?!.*(?=build|internal)).*_host$').values.uniq)
+    ssh_errs << Pkg::Util::Net.check_host_ssh(
+      Pkg::Util.filter_configs('^(?!.*(?=build|internal)).*_host$').values.uniq
+    )
+
     ssh_errs.flatten!
     unless ssh_errs.empty?
       ssh_errs.each do |host|
@@ -618,7 +656,8 @@ namespace :pl do
         )
       end
     rescue StandardError
-      errs << "Unlocking the OSX keychain failed! Check the password in your .bashrc on #{Pkg::Config.osx_signing_server}"
+      errs << "Unlocking the OSX keychain failed! " \
+              "Check the password in your .bashrc on #{Pkg::Config.osx_signing_server}"
     end
 
     if Pkg::Config.build_gem
@@ -635,12 +674,13 @@ namespace :pl do
 
     puts "\n\n"
     if errs.empty?
-      puts 'Hooray! You should be good for shipping!'
-    else
-      puts "Found #{errs.length} issues:"
-      errs.each do |err|
-        puts " * #{err}"
-      end
+      puts 'ship_check succeeded.'
+      next
+    end
+
+    puts "Found #{errs.length} issues:"
+    errs.each do |err|
+      puts " * #{err}"
     end
   end
 


### PR DESCRIPTION
Also back away from previous efforts to put apt.repos.puppet.com on
Google cloud.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.