### PR TITLE
(RE-15086) Clean up RPM signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-15086) Stop forcing rpmsign to use gpg1
 
 ## [0.108.0] - 2022-10-04
 ### Removed

--- a/lib/packaging/sign/rpm.rb
+++ b/lib/packaging/sign/rpm.rb
@@ -1,72 +1,128 @@
 module Pkg::Sign::Rpm
   module_function
 
-  def sign(rpm, sign_flags = nil)
+  # For rpm v4-style signing, we have old (gpg < v2.1) style and new-style
+  # Dispatch those cases.
+  def sign(rpm_path, signing_version = :v4)
+    unless %i[v3 v4].include?(signing_version)
+      fail "Unknown signing version: #{signing_version}. Only ':v3' and ':v4' are supported"
+    end
+
+    if gpg_version_older_than_21?
+      sign_gpg_1(rpm_path, signing_version)
+    else
+      sign_gpg_2(rpm_path, signing_version)
+    end
+  end
+
+  # Support old, old v3 RPM signing
+  def v3_sign(rpm)
+    sign(rpm, :v3)
+  end
+  alias :legacy_sign :v3_sign
+
+  # Construct GPG configuration, then call 'rpm --addsign' with it.
+  def sign_gpg_2(rpm_path, signing_version)
     # To enable support for wrappers around rpm and thus support for gpg-agent
     # rpm signing, we have to be able to tell the packaging repo what binary to
     # use as the rpm signing tool.
-    rpm_executable = ENV['RPM'] || Pkg::Util::Tool.find_tool('rpm')
-
-    # If we're using the gpg agent for rpm signing, we don't want to specify the
-    # input for the passphrase, which is what '--passphrase-fd 3' does. However,
-    # if we're not using the gpg agent, this is required, and is part of the
-    # defaults on modern rpm. The fun part of gpg-agent signing of rpms is
-    # specifying that the gpg check command always return true
-    gpg_check_command = ''
-    input_flag = ''
-    if Pkg::Util.boolean_value(ENV['RPM_GPG_AGENT'])
-      gpg_check_command = "--define '%__gpg_check_password_cmd /bin/true'"
-    else
-      input_flag = "--passphrase-fd 3"
-    end
-
-    # If gpg version is >=2.1, use the gpg1 binary to sign. Otherwise, use the standard sign command.
-    gpg_executable = if gpg_version_greater_than_21?
-                       "%__gpg /usr/bin/gpg1' --define '%__gpg_sign_cmd %{__gpg} gpg1"
-                     else
-                       '%__gpg_sign_cmd %{__gpg} gpg'
-                     end
-
-    # rubocop:disable Lint/NestedPercentLiteral
-    gpg_signing_macro = %W[
-      #{gpg_executable} #{sign_flags} #{input_flag}
-      --batch --no-verbose --no-armor
-      --no-secmem-warning -u %{_gpg_name}
-      -sbo %{__signature_filename} %{__plaintext_filename}
-    ].join(' ')
-    # rubocop:enable Lint/NestedPercentLiteral
+    rpm_executable = Pkg::Util::Tool.find_tool('rpm')
 
     sign_command = %W[
-      #{rpm_executable} #{gpg_check_command}
-      --define '%_gpg_name #{Pkg::Util::Gpg.key}'
-      --define '#{gpg_signing_macro}' --addsign #{rpm}
+      #{rpm_executable} --addsign #{rpm_path}
+      #{define_gpg_name}
+      #{define_gpg_sign_cmd(signing_version)}
     ].join(' ')
 
-    # Try this up to 5 times, to allow for incorrect passwords
-    Pkg::Util::Execution.retry_on_fail(:times => 5) do
-      # This definition of %__gpg_sign_cmd is the default on modern rpm. We
-      # accept extra flags to override certain signing behavior for older
-      # versions of rpm, e.g. specifying V3 signatures instead of V4.
-      Pkg::Util::Execution.capture3(sign_command)
+    Pkg::Util::Execution.capture3(sign_command, true)
+  end
+
+  def sign_gpg_1(rpm_path, signing_version)
+    # This allows for old-style wrapping of rpmsign with an expect script
+    rpm_executable = ENV['RPM'] || Pkg::Util::Tool.find_tool('rpm')
+
+    sign_command = %W[
+      #{rpm_executable} --addsign #{rpm_path}
+      #{define_gpg_check_password_cmd}
+      #{define_gpg_name}
+      #{define_gpg_sign_cmd(signing_version)}
+    ].join(' ')
+    Pkg::Util::Execution.capture3(sign_command, true)
+  end
+
+  def define_gpg_name
+    "--define '%_gpg_name #{Pkg::Util::Gpg.key}'"
+  end
+
+  def define_gpg_sign_cmd(signing_version)
+    "--define '%__gpg_sign_cmd #{gpg_sign_cmd_macro(signing_version)}'"
+  end
+
+  def gpg_sign_cmd_macro(signing_version)
+    gpg_executable = Pkg::Util::Tool.find_tool('gpg')
+
+    # rubocop:disable Lint/NestedPercentLiteral
+    %W[
+      #{gpg_executable} --sign --detach-sign
+      #{signing_version_flags(signing_version)}
+      #{passphrase_fd_flag}
+      --batch --no-armor --no-secmem-warning
+      --local-user %{_gpg_name}
+      --output %{__signature_filename}
+        %{__plaintext_filename}
+    ].join(' ')
+    # rubocop:enable Lint/NestedPercentLiteral
+  end
+
+  def signing_version_flags(signing_version)
+    case signing_version
+    when :v3
+      '--force-v3-sigs --digest-algo=sha1'
+    when :v4
+      ''
+    else
+      fail "Unrecognized signing_version: '#{signing_version}'"
     end
   end
 
-  def legacy_sign(rpm)
-    sign(rpm, "--force-v3-sigs --digest-algo=sha1")
+  def passphrase_fd_flag
+    if Pkg::Util.boolean_value(ENV['RPM_GPG_AGENT'])
+      ''
+    else
+      '--passphrase-fd 3'
+    end
   end
 
-  def has_sig?(rpm)
+  def define_gpg_check_password_cmd
+    if Pkg::Util.boolean_value(ENV['RPM_GPG_AGENT'])
+      "--define '%__gpg_check_password_cmd /bin/true'"
+    else
+      ''
+    end
+  end
+
+
+  def signed?(rpm)
     # This should allow the `Pkg::Util::Gpg.key` method to fail if gpg_key is
     # not set, before shelling out. We also only want the short key, all
     # lowercase, since that's what the `rpm -Kv` output uses.
     key = Pkg::Util::Gpg.key.downcase.chars.last(8).join
     signature_check_output = %x(rpm --checksig --verbose #{rpm})
+
     # If the signing key has not been loaded on the system this is running on,
     # the check will exit 1, even if the rpm is signed, so we can't use capture3,
     # which bails out with non-0 exit codes. Instead, check that the output
     # looks more-or-less how we expect it to.
-    fail "Something went wrong checking the signature of #{rpm}." unless signature_check_output.include? "Header"
-    return signature_check_output.include? "key ID #{key}"
+    unless signature_check_output.include? "Header"
+      fail "Something went wrong checking the signature of #{rpm}."
+    end
+
+    signature_check_output.include? "key ID #{key}"
+  end
+
+  # For backwards compatibility
+  def has_sig?(rpm)
+    signed?(rpm)
   end
 
   def sign_all(rpm_directory)
@@ -97,8 +153,8 @@ module Pkg::Sign::Rpm
       # We don't sign AIX rpms
       next if platform_tag.include?('aix')
 
-      if has_sig? rpm
-        puts "#{rpm} is already signed, skipping . . ."
+      if signed?(rpm)
+        puts "#{rpm} is already signed. Skipping."
         next
       end
 
@@ -113,13 +169,13 @@ module Pkg::Sign::Rpm
     end
 
     unless v3_rpms.empty?
-      puts "Signing legacy (v3) rpms..."
-      legacy_sign(v3_rpms.join(' '))
+      puts "Signing legacy (v3) rpms:"
+      sign(v3_rpms.join(' '), :v3)
     end
 
     unless v4_rpms.empty?
-      puts "Signing modern (v4) rpms..."
-      sign(v4_rpms.join(' '))
+      puts "Signing modern (v4) rpms:"
+      sign(v4_rpms.join(' '), :v4)
     end
 
     # Using the map of paths to basenames, we re-hardlink the rpms we deleted.
@@ -128,16 +184,18 @@ module Pkg::Sign::Rpm
       FileUtils.mkdir_p(File.dirname(link_path))
       # Find paths where the signed rpm has the same basename, but different
       # full path, as the one we need to link.
-      paths_to_link_to = rpms_to_sign.select { |rpm| File.basename(rpm) == rpm_filename && rpm != link_path }
+      paths_to_link_to = rpms_to_sign.select do |rpm|
+        File.basename(rpm) == rpm_filename && rpm != link_path
+      end
       paths_to_link_to.each do |path|
-        FileUtils.ln(path, link_path, :force => true, :verbose => true)
+        FileUtils.ln(path, link_path, force: true, verbose: true)
       end
     end
   end
 
-  def gpg_version_greater_than_21?
-    gpg_version_output = %x(gpg --version)
-    gpg_version = gpg_version_output.split(' ')[2]
-    Gem::Version.new(gpg_version) >= Gem::Version.new('2.1.0')
+  def gpg_version_older_than_21?
+    gpg_executable = Pkg::Util::Tool.find_tool('gpg')
+    gpg_version = %x(#{gpg_executable} --version).split(' ')[2]
+    Gem::Version.new(gpg_version) < Gem::Version.new('2.1.0')
   end
 end

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.3.0'
 
-  gem.add_development_dependency('pry')
-  gem.add_development_dependency('pry-byebug')
   gem.add_development_dependency('rspec', ['~> 2.14.1'])
   gem.add_development_dependency('rubocop', ['~> 0.49'])
 

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -3,91 +3,118 @@ require 'packaging/sign'
 
 describe 'Pkg::Sign' do
   describe 'Pkg::Sign::Rpm' do
-
     before :each do
       allow(Pkg::Config).to receive(:gpg_key).and_return('7F438280EF8D349F')
     end
 
-    describe '#has_sig?' do
+    describe '#signed?' do
       let(:rpm) { 'foo.rpm' }
-      let(:el7_signed_response) { <<-DOC
-Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
-Header SHA1 digest: OK (3cb7e9861e8bc09783a1b6c8d88243a3c16daa81)
-V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
-MD5 digest: OK (d5f06ba2a9053de532326d0659ec0d11)
-DOC
-      }
-      let(:sles12_signed_response) { <<-DOC
-Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
-Header SHA1 digest: OK (e713487cf21ebeb933aefd5ec9211a34603233d2)
-V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
-MD5 digest: OK (3093a09ac39bc17751f913e19ca74432)
-DOC
-      }
-      let(:unsigned_response) { <<-DOC
-Header SHA1 digest: OK (f9404cc95f200568c2dbb1fd24e1119e3e4a40a9)
-MD5 digest: OK (816095f3cee145091c3fa07a0915ce85)
-DOC
-      }
+      let(:el7_signed_response) do
+        <<~DOC
+          Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
+          Header SHA1 digest: OK (3cb7e9861e8bc09783a1b6c8d88243a3c16daa81)
+          V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
+          MD5 digest: OK (d5f06ba2a9053de532326d0659ec0d11)
+        DOC
+      end
+
+      let(:sles12_signed_response) do
+        <<~DOC
+          Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
+          Header SHA1 digest: OK (e713487cf21ebeb933aefd5ec9211a34603233d2)
+          V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
+          MD5 digest: OK (3093a09ac39bc17751f913e19ca74432)
+        DOC
+      end
+
+      let(:unsigned_response) do
+        <<~DOC
+          Header SHA1 digest: OK (f9404cc95f200568c2dbb1fd24e1119e3e4a40a9)
+          MD5 digest: OK (816095f3cee145091c3fa07a0915ce85)
+        DOC
+      end
+
       it 'returns true if rpm has been signed (el7)' do
         allow(Pkg::Sign::Rpm).to receive(:`).and_return(el7_signed_response)
-        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
+        expect(Pkg::Sign::Rpm.signed?(rpm)).to be true
       end
       it 'returns true if rpm has been signed (sles12)' do
         allow(Pkg::Sign::Rpm).to receive(:`).and_return(sles12_signed_response)
-        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
+        expect(Pkg::Sign::Rpm.signed?(rpm)).to be true
       end
       it 'returns false if rpm has not been signed' do
         allow(Pkg::Sign::Rpm).to receive(:`).and_return(unsigned_response)
-        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be false
+        expect(Pkg::Sign::Rpm.signed?(rpm)).to be false
       end
       it 'fails with unexpected output' do
-        allow(Pkg::Sign::Rpm).to receive(:`).and_return('something that is definitely not a normal response')
-        expect { Pkg::Sign::Rpm.has_sig?(rpm) }.to raise_error(RuntimeError, /Something went wrong checking the signature/)
+        allow(Pkg::Sign::Rpm)
+          .to receive(:`)
+          .and_return('something that is definitely not a normal response')
+        expect { Pkg::Sign::Rpm.signed?(rpm) }
+          .to raise_error(RuntimeError, /Something went wrong checking the signature/)
       end
       it 'fails if gpg_key is not set' do
         allow(Pkg::Config).to receive(:gpg_key).and_return(nil)
-        expect { Pkg::Sign::Rpm.has_sig?(rpm) }.to raise_error(RuntimeError, /You need to set `gpg_key` in your build defaults./)
+        expect { Pkg::Sign::Rpm.signed?(rpm) }
+          .to raise_error(RuntimeError, /You need to set `gpg_key` in your build defaults./)
       end
     end
 
     describe '#sign_all' do
       let(:rpm_directory) { Dir.mktmpdir }
-      let(:rpms_not_to_sign) { [
-        "#{rpm_directory}/aix/7.1/PC1/ppc/puppet-agent-5.5.3-1.aix7.1.ppc.rpm",
-      ] }
-      let(:v3_rpms) { [
-        "#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm",
-      ] }
-      let(:v4_rpms) { [
-        "#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm",
-      ] }
+      let(:rpms_not_to_sign) do
+        ["#{rpm_directory}/aix/7.1/PC1/ppc/puppet-agent-5.5.3-1.aix7.1.ppc.rpm"]
+      end
+
+      let(:v3_rpms) do
+        ["#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm"]
+      end
+
+      let(:v4_rpms) do
+        ["#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm"]
+      end
+
       let(:rpms) { rpms_not_to_sign + v3_rpms + v4_rpms }
-      let(:already_signed_rpms) { [
-        "#{rpm_directory}/el/6/PC1/x86_64/puppet-agent-5.5.3-1.el6.x86_64.rpm",
-      ] }
-      let(:noarch_rpms) { [
-        "#{rpm_directory}/el/6/puppet5/i386/puppetserver-5.3.3-1.el6.noarch.rpm",
-        "#{rpm_directory}/el/6/puppet5/x86_64/puppetserver-5.3.3-1.el6.noarch.rpm",
-        "#{rpm_directory}/el/7/puppet5/i386/puppetserver-5.3.3-1.el7.noarch.rpm",
-        "#{rpm_directory}/el/7/puppet5/x86_64/puppetserver-5.3.3-1.el7.noarch.rpm",
-        "#{rpm_directory}/sles/12/puppet5/i386/puppetserver-5.3.3-1.sles12.noarch.rpm",
-        "#{rpm_directory}/sles/12/puppet5/x86_64/puppetserver-5.3.3-1.sles12.noarch.rpm"
-      ] }
+
+      let(:already_signed_rpms) do
+        ["#{rpm_directory}/el/6/PC1/x86_64/puppet-agent-5.5.3-1.el6.x86_64.rpm"]
+      end
+
+      let(:noarch_rpms) do
+        [
+          "#{rpm_directory}/el/6/puppet5/i386/puppetserver-5.3.3-1.el6.noarch.rpm",
+          "#{rpm_directory}/el/6/puppet5/x86_64/puppetserver-5.3.3-1.el6.noarch.rpm",
+          "#{rpm_directory}/el/7/puppet5/i386/puppetserver-5.3.3-1.el7.noarch.rpm",
+          "#{rpm_directory}/el/7/puppet5/x86_64/puppetserver-5.3.3-1.el7.noarch.rpm",
+          "#{rpm_directory}/sles/12/puppet5/i386/puppetserver-5.3.3-1.sles12.noarch.rpm",
+          "#{rpm_directory}/sles/12/puppet5/x86_64/puppetserver-5.3.3-1.sles12.noarch.rpm"
+        ]
+      end
 
       it 'signs both v3 and v4 rpms' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms)
         rpms.each do |rpm|
-          allow(Pkg::Sign::Rpm).to receive(:has_sig?).and_return(false)
+          allow(Pkg::Sign::Rpm).to receive(:signed?).and_return(false)
         end
-        expect(Pkg::Sign::Rpm).to receive(:legacy_sign).with(v3_rpms.join(' '))
-        expect(Pkg::Sign::Rpm).to receive(:sign).with(v4_rpms.join(' '))
+
+        v3_items = v3_rpms.length
+        v4_items = v4_rpms.length
+
+        expect(Pkg::Sign::Rpm)
+          .to receive(:sign)
+          .with(v3_rpms.join(' '), :v3)
+          .exactly(v3_items).times
+        expect(Pkg::Sign::Rpm)
+          .to receive(:sign)
+          .with(v4_rpms.join(' '), :v4)
+          .exactly(v4_items).times
+
         Pkg::Sign::Rpm.sign_all(rpm_directory)
       end
 
       it 'does not sign AIX rpms' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms_not_to_sign)
-        allow(Pkg::Sign::Rpm).to receive(:has_sig?)
+        allow(Pkg::Sign::Rpm).to receive(:signed?)
         expect(Pkg::Sign::Rpm).to_not receive(:legacy_sign)
         expect(Pkg::Sign::Rpm).to_not receive(:sign)
         Pkg::Sign::Rpm.sign_all(rpm_directory)
@@ -96,7 +123,7 @@ DOC
       it 'does not sign already-signed rpms' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(already_signed_rpms)
         already_signed_rpms.each do |rpm|
-          allow(Pkg::Sign::Rpm).to receive(:has_sig?).and_return(true)
+          allow(Pkg::Sign::Rpm).to receive(:signed?).and_return(true)
         end
         expect(Pkg::Sign::Rpm).to_not receive(:legacy_sign)
         expect(Pkg::Sign::Rpm).to_not receive(:sign)
@@ -106,9 +133,9 @@ DOC
       it 'deletes and relinks rpms with the same basename' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(noarch_rpms)
         allow(Pkg::Sign::Rpm).to receive(:sign)
-        allow(Pkg::Sign::Rpm).to receive(:has_sig?)
-        expect(FileUtils).to receive(:rm).exactly(noarch_rpms.count/2).times
-        expect(FileUtils).to receive(:ln).exactly(noarch_rpms.count/2).times
+        allow(Pkg::Sign::Rpm).to receive(:signed?)
+        expect(FileUtils).to receive(:rm).exactly(noarch_rpms.count / 2).times
+        expect(FileUtils).to receive(:ln).exactly(noarch_rpms.count / 2).times
         Pkg::Sign::Rpm.sign_all(rpm_directory)
       end
 


### PR DESCRIPTION
RPM signing works with GPG >=1 now, so stop evading it. In the old case
where /usr/bin/gpg is still gpg1, this will continue to work.

Clean up some organic code drift to isolate specific responsibility


Please add all notable changes to the "Unreleased" section of the CHANGELOG.