### PR TITLE
(maint) better 'artifact exists' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (maint) make the 'artifact already exists' error more informative.
 
 ## [0.108.1] - 2022-01-04
 ### Changed

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -192,18 +192,23 @@ module Pkg
       properties_hash
     end
 
-    # Basic method to check if a package exists on artifactory
+    # Return a list of artifact paths for package. Returns empty array if none.
+    def artifact_paths(package)
+      check_authorization
+      Artifactory::Resource::Artifact.search(
+        name: File.basename(package),
+        artifactory_uri: @artifactory_uri
+      )
+    end
+
+    # Check if a package exists on artifactory
     # @param package [String] The full relative path to the package to be
     #   checked, relative from the current working directory
-    # Return true if package already exists on artifactory
+    # Return true if package already exists on artifactory.
+    # #artifact_paths, above, is more useful since it will inform where they are.
+    # This is kept for backward compatibility.
     def package_exists_on_artifactory?(package)
-      check_authorization
-      artifact = Artifactory::Resource::Artifact.search(name: File.basename(package), :artifactory_uri => @artifactory_uri)
-      if artifact.empty?
-        return false
-      else
-        return true
-      end
+      artifact_paths(package).any?
     end
 
     # @param package [String] The full relative path to the package to be

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -680,8 +680,10 @@ namespace :pl do
         end
 
         # Don't deploy if the package already exists
-        if artifactory.package_exists_on_artifactory?(artifact)
-          warn "Attempt to upload '#{artifact}' failed. Package already exists."
+        existing_artifacts = artifactory.artifact_paths(artifact)
+        unless existing_artifacts.empty?
+          warn "Uploading '#{artifact}' to Artifactory refused. Artifact already exists here: ",
+               existing_artifacts.join(', ')
           next
         end
 


### PR DESCRIPTION
When we check for an existing artifact on Artifactory, we tell the user that it exists but give no indication as to where.

Fix that to be more informative.



Please add all notable changes to the "Unreleased" section of the CHANGELOG.