### PR TITLE
(RE-15086) rpmsign: don't pass `--passphrase-fd 3` with gpg >= 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Fixed
-- (maint) Pkg::Rpm::Repo.ship_repo_configs was not detecting the condition with no repos
-  to ship. This was causing a confusing error message later.
-
 ### Changed
 - (maint) Updated the spec tests in repo_spec to use the newer 'expect' syntax.
 
+### Fixed
+- (maint) Pkg::Rpm::Repo.ship_repo_configs was not detecting the condition with no repos
+  to ship. This was causing a confusing error message later.
+- (RE-15086) Don't pass `--passphrase-fd 3` with gpg >= 2.1; it's no longer provided there.
 
 ## [0.108.1] - 2022-01-04
 ### Changed


### PR DESCRIPTION
With GPG >= 2.1, there is no longer an expect process sending
passphrases on FD 3, so don't have rpmsign / gpg look for it there.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.