### PR TITLE
(maint) call file_exists in Pkg::Util::File

### DIFF
--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -44,7 +44,7 @@ module Pkg::Gem
         puts "#{file} has already been shipped to rubygems, skipping."
         return
       end
-      Pkg::Util::File.file_exist?("#{ENV['HOME']}/.gem/credentials", :required => true)
+      Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
       gem_push_command = "gem push #{file}"
       gem_push_command << " --host #{options[:host]}" if options[:host]
       gem_push_command << " --key #{options[:key]}" if options[:key]


### PR DESCRIPTION
This was changed to `file_exist?` as part of the ruby 3.2 compatibility effort, but since this calls a packaging method there was no need to update it here.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
