### PR TITLE
(maint) fix existing_artifacts error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Fixed a bug in the 'artifact already exists' error where the path to the artifact
+  wasn't printing correctly
 
 ## [0.109.0] - 2023-02-28
 ### Changed

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -683,7 +683,7 @@ namespace :pl do
         existing_artifacts = artifactory.artifact_paths(artifact)
         unless existing_artifacts.empty?
           warn "Uploading '#{artifact}' to Artifactory refused. Artifact already exists here: ",
-               existing_artifacts.join(', ')
+               existing_artifacts.map(&:uri).join(', ')
           next
         end
 


### PR DESCRIPTION
Call to #artifact_paths returns Artifact objects, need to extract the
URI from them.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.