### PR TITLE
(maint) revert call to ERB.new for the sake of Ruby 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Fixed
 - (maint) Fixed a bug in the 'artifact already exists' error where the path to the artifact
   wasn't printing correctly
+- (maint) Go back to old ERB.new method call to accommodate Ruby 2.5
 
 ## [0.109.0] - 2023-02-28
 ### Changed

--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -58,7 +58,14 @@ module Pkg::Util::File
 
     def erb_string(erbfile, b = binding)
       template = File.read(erbfile)
-      message  = ERB.new(template, trim_mode: "-")
+
+      # We should be using this but some images are pegged at Ruby <= 2.5; this interface
+      # changed at Ruby 2.6
+      # message  = ERB.new(template, safe_level: nil, trim_mode: '-')
+
+      # rubocop:disable Lint/ErbNewArguments
+      message = ERB.new(template, nil, '-')
+      # rubocop:enable Lint/ErbNewArguments
       message.result(b)
     end
 


### PR DESCRIPTION
Named parameters to ERB.new came in at Ruby 2.6; we're still pegged at
Ruby 2.5 in some places so we need to accommodate them.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.