### PR TITLE
(maint) Avoid race conditions pushing gem to rubygems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (maint) Do not throw an error when pushing a gem to rubygems if it already has been pushed.
 
 ## [0.109.2] - 2023-03-07
 ### Changed


### PR DESCRIPTION
In order to avoid re-pushing to rubygems if we have already pushed a version we check the `versions` api. There appears to be a race condition where that API has out-dated infor by the time we go to push. This commit catches the "gem already pushed" error, logs it and will *not* throw it as the intent of the action is already satisfied.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
