### PR TITLE
(RE-15738) Give macos `hdiutil create` a size

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5.9', '2.7.6' ]
+        ruby: [ '2.7', '3.1', '3.2'  ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,283 +1,117 @@
 ---
+
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 3.0
+  SuggestExtensions: false
   Exclude:
-    - '**/*.erb'
-    - 'spec/**/*'
-    - 'vendor/**/*'
-    - 'examples/**/*'
-    - 'lib/vanagon/platform/defaults/*'
+  - '**/*.erb'
+  - 'spec/**/*'
+  - 'vendor/**/*'
+
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: false
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
+Gemspec/RequireMFA:
+  Enabled: false
 
 Gemspec/RequiredRubyVersion:
   Enabled: false
 
-Lint/ElseLayout:
-  Enabled: true
-
-Lint/UnreachableCode:
-  Enabled: true
-
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: true
-
-# MAYBE useful - no return inside ensure block.
-Lint/EnsureReturn:
-  Enabled: true
-
-# MAYBE useful - errors when rescue {} happens.
-Lint/SuppressedException:
-  Enabled: true
-
-Lint/ShadowingOuterLocalVariable:
-  Enabled: true
-
-# Can catch complicated strings.
-Lint/LiteralInInterpolation:
-  Enabled: true
-
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-  IndentationWidth: 2
-
-# DISABLED really useless. Detects return as last statement.
-Style/RedundantReturn:
-  Enabled: false
-
-Style/MutableConstant:
-  Enabled: false
-
-Lint/AmbiguousOperator:
-  Enabled: true
-
-# DISABLED since for all the checked, we are basically checking nil
-# TODO: Change the checking so that if the variable being assigned to has
-# a value ALREADY, then raise an error.
-Lint/AssignmentInCondition:
-  Enabled: false
-
-# DISABLED - not useful
-Layout/SpaceBeforeComment:
-  Enabled: false
-
-# DISABLED - not useful
-Style/HashSyntax:
-  Enabled: false
-
-# USES: as shortcut for non nil&valid checking a = x() and a.empty?
-# DISABLED - not useful
-Style/AndOr:
-  Enabled: false
-
-# DISABLED - not useful
-Style/RedundantSelf:
-  Enabled: false
-
-# DISABLED - not useful
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
-Metrics/AbcSize:
-  Enabled: false
-
-Naming/VariableNumber:
-  Enabled: false
-
-
-# DISABLED - not useful
-Style/WhileUntilModifier:
-  Enabled: false
-
-Style/FormatStringToken:
-  Enabled: false
-
-# DISABLED - the offender is just haskell envy
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
-Security/Eval:
-  Enabled: true
-
-# DISABLED
-Layout/BlockAlignment:
-  Enabled: false
-
-# DISABLED
-Layout/DefEndAlignment:
-  Enabled: false
-
-# DISABLED
-Layout/EndAlignment:
-  Enabled: false
-
-# DISABLED
-Layout/ConditionPosition:
-  Enabled: false
-
-# DISABLED
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
-# DISABLED
-Lint/DeprecatedClassMethods:
-  Enabled: false
-
-# DISABLED
-Lint/Loop:
-  Enabled: false
-
-# DISABLED
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
-
-Lint/RescueException:
-  Enabled: false
-
-Lint/RedundantStringCoercion:
-  Enabled: false
-
-Lint/UnusedBlockArgument:
-  Enabled: false
-
-Lint/UnusedMethodArgument:
-  Enabled: false
-
-Lint/UselessAccessModifier:
-  Enabled: true
-
-Lint/UselessAssignment:
-  Enabled: true
-
-Lint/Void:
-  Enabled: true
-
 Layout/AccessModifierIndentation:
-  Enabled: false
-
-Naming/AccessorMethodName:
-  Enabled: false
-
-Style/Alias:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Layout/ArrayAlignment:
-  Enabled: false
-
-Layout/HashAlignment:
-  Enabled: false
-
-Layout/ParameterAlignment:
-  Enabled: false
-
-Metrics/BlockNesting:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: false
-
-Style/AsciiComments:
-  Enabled: false
-
-Style/Attr:
-  Enabled: false
-
-Style/CaseEquality:
-  Enabled: false
-
-Layout/CaseIndentation:
-  Enabled: false
-
-Style/CharacterLiteral:
-  Enabled: false
-
-Style/AccessModifierDeclarations:
-  Enabled: false
-
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
-Style/RedundantCondition:
-  Enabled: false
-
-Style/SafeNavigation:
-  Enabled: false
-
-Naming/MethodParameterName:
-  Enabled: false
-
-Naming/RescuedExceptionsVariableName:
-  Enabled: false
-
-Naming/ClassAndModuleCamelCase:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-Style/ClassCheck:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Style/ClassMethods:
-  Enabled: false
-
-Style/ClassVars:
-  Enabled: false
-
-Style/WhenThen:
-  Enabled: false
-
-# DISABLED - not useful
-Style/WordArray:
-  Enabled: false
-
-Style/RedundantPercentQ:
   Enabled: false
 
 Layout/ArgumentAlignment:
   Enabled: false
 
+Layout/ArrayAlignment:
+  Enabled: false
+
+Layout/BeginEndAlignment:
+  Enabled: true
+
+Layout/BlockAlignment:
+  Enabled: false
+
+Layout/CaseIndentation:
+  Enabled: false
+
+Layout/CommentIndentation:
+  Enabled: false
+
+Layout/ConditionPosition:
+  Enabled: false
+
+Layout/DefEndAlignment:
+  Enabled: false
+
+Layout/DotPosition:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/EmptyLines:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/FirstArrayElementIndentation:
+  Enabled: false
+
+Layout/FirstHashElementIndentation:
+  Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/IndentationConsistency:
+  Enabled: true
+
 Layout/IndentationStyle:
   Enabled: false
 
-Layout/SpaceBeforeSemicolon:
-  Enabled: true
-
-Layout/TrailingEmptyLines:
-  Enabled: false
-
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
-Layout/SpaceInsideParens:
+Layout/IndentationWidth:
   Enabled: true
 
 Layout/LeadingCommentSpace:
   Enabled: false
 
-Layout/SpaceBeforeFirstArg:
+Layout/LineContinuationLeadingSpace:
   Enabled: true
+
+Layout/LineContinuationSpacing:
+  Enabled: true
+
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: true
+
+Layout/LineLength:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  IndentationWidth: 2
+
+Layout/ParameterAlignment:
+  Enabled: false
 
 Layout/SpaceAfterColon:
   Enabled: true
 
 Layout/SpaceAfterComma:
-  Enabled: true
-
-Layout/SpaceAroundKeyword:
   Enabled: true
 
 Layout/SpaceAfterMethodName:
@@ -292,93 +126,473 @@ Layout/SpaceAfterSemicolon:
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Layout/SpaceAroundOperators:
   Enabled: true
 
 Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+
 Layout/SpaceBeforeComma:
   Enabled: true
 
-Style/CollectionMethods:
+Layout/SpaceBeforeComment:
   Enabled: false
 
-Layout/CommentIndentation:
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/TrailingEmptyLines:
   Enabled: false
 
-Style/ColonMethodCall:
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Lint/AmbiguousAssignment:
+  Enabled: true
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+
+Lint/AmbiguousRange:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-Style/CommentAnnotation:
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
+Lint/ConstantOverwrittenInRescue:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: false
+
+Lint/DeprecatedClassMethods:
+  Enabled: false
+
+Lint/DeprecatedConstants:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/DuplicateBranch:
+  Enabled: false
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateMagicComment:
+  Enabled: true
+
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+
+Lint/DuplicateRequire:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyBlock:
+  Enabled: true
+
+Lint/EmptyClass:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/EmptyFile:
+  Enabled: true
+
+Lint/EmptyInPattern:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/HashCompareByIdentity:
+  Enabled: true
+
+Lint/IdentityComparison:
+  Enabled: true
+
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  Enabled: true
+
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Enabled: false
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+
+Lint/NonAtomicFileOperation:
+  Enabled: true
+
+Lint/NumberedParameterAssignment:
+  Enabled: true
+
+Lint/OrAssignmentToConstant:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/RedundantDirGlobSort:
+  Enabled: true
+
+Lint/RedundantSafeNavigation:
+  Enabled: true
+
+Lint/RedundantStringCoercion:
+  Enabled: false
+
+Lint/RefinementImportMethods:
+  Enabled: true
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RequireRangeParentheses:
+  Enabled: true
+
+Lint/RequireRelativeSelfPath:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: false
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Lint/SuppressedException:
+  Enabled: true
+
+Lint/SymbolConversion:
+  Enabled: false
+
+Lint/ToEnumArguments:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+
+Lint/TripleQuotes:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnexpectedBlockArity:
+  Enabled: true
+
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UselessAccessModifier:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/UselessMethodDefinition:
+  Enabled: true
+
+Lint/UselessRescue:
+  Enabled: true
+
+Lint/UselessRuby2Keywords:
+  Enabled: true
+
+Lint/UselessTimes:
+  Enabled: true
+
+Lint/Void:
+  Enabled: true
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
   Enabled: false
 
 Metrics/CyclomaticComplexity:
   Enabled: false
 
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: true
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+Naming/BlockForwarding:
+  Enabled: true
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: false
+
 Naming/ConstantName:
   Enabled: false
 
-Style/Documentation:
+Naming/MethodName:
+  Enabled: false
+
+Naming/MethodParameterName:
+  Enabled: false
+
+Naming/PredicateName:
+  Enabled: false
+
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Security/CompoundHash:
+  Enabled: true
+
+Security/Eval:
+  Enabled: true
+
+Security/IoMethods:
+  Enabled: false
+
+Style/AccessModifierDeclarations:
+  Enabled: false
+
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/Alias:
+  Enabled: false
+
+Style/AndOr:
+  Enabled: false
+
+Style/ArgumentsForwarding:
+  Enabled: true
+
+Style/ArrayIntersect:
+  Enabled: true
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Attr:
+  Enabled: false
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/CaseLikeIf:
+  Enabled: false
+
+Style/CharacterLiteral:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ClassEqualityComparison:
+  Enabled: true
+
+Style/ClassMethods:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Style/CollectionCompact:
+  Enabled: true
+
+Style/CollectionMethods:
+  Enabled: false
+
+Style/ColonMethodCall:
+  Enabled: false
+
+Style/CombinableLoops:
+  Enabled: false
+
+Style/CommandLiteral:
+  EnforcedStyle: percent_x
+
+Style/CommentAnnotation:
+  Enabled: false
+
+Style/ComparableClamp:
+  Enabled: true
+
+Style/ConcatArrayLiterals:
+  Enabled: true
+
+Style/ConditionalAssignment:
   Enabled: false
 
 Style/DefWithParentheses:
   Enabled: false
 
-Layout/DotPosition:
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
+
+Style/Documentation:
   Enabled: false
 
-# DISABLED - used for converting to bool
 Style/DoubleNegation:
   Enabled: false
 
 Style/EachWithObject:
   Enabled: false
 
-Layout/EmptyLineBetweenDefs:
-  Enabled: false
-
-Layout/FirstArrayElementIndentation:
-  Enabled: false
-
-Layout/FirstHashElementIndentation:
-  Enabled: false
-
-Layout/IndentationConsistency:
+Style/EmptyHeredoc:
   Enabled: true
-
-Layout/IndentationWidth:
-  Enabled: true
-
-Layout/EmptyLines:
-  Enabled: false
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: false
 
 Style/EmptyLiteral:
   Enabled: false
 
-Layout/LineLength:
+Style/Encoding:
   Enabled: false
 
-Style/MethodCallWithoutArgsParentheses:
+Style/EndlessMethod:
   Enabled: true
 
-Style/MethodDefParentheses:
+Style/EnvHome:
+  Enabled: false
+
+Style/EvenOdd:
   Enabled: true
 
-Style/LineEndConcatenation:
-  Enabled: false
-
-Layout/TrailingWhitespace:
+Style/ExplicitBlockArgument:
   Enabled: true
 
-Style/StringLiterals:
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/FetchEnvVar:
   Enabled: false
 
-Style/TrailingCommaInArguments:
+Style/FileRead:
+  Enabled: true
+
+Style/FileWrite:
   Enabled: false
+
+Style/For:
+  Enabled: true
+
+Style/FormatString:
+  Enabled: true
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/GlobalStdStream:
+  Enabled: true
 
 Style/GlobalVars:
   Enabled: false
@@ -386,20 +600,248 @@ Style/GlobalVars:
 Style/GuardClause:
   Enabled: false
 
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+Style/HashConversion:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashExcept:
+  Enabled: true
+
+Style/HashLikeCase:
+  Enabled: true
+
+Style/HashSyntax:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Style/IfUnlessModifier:
   Enabled: false
+
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+
+Style/IfWithSemicolon:
+  Enabled: true
+
+Style/InPatternThen:
+  Enabled: true
+
+Style/KeywordParametersOrder:
+  Enabled: true
+
+Style/Lambda:
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Enabled: false
+
+Style/MagicCommentFormat:
+  Enabled: true
+
+Style/MapCompactWithConditionalBlock:
+  Enabled: true
+
+Style/MapToHash:
+  Enabled: true
+
+Style/MapToSet:
+  Enabled: true
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/MinMaxComparison:
+  Enabled: true
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: true
 
 Style/MultilineIfThen:
   Enabled: true
 
+Style/MultilineInPatternThen:
+  Enabled: true
+
+Style/MultilineTernaryOperator:
+  Enabled: true
+
+Style/MutableConstant:
+  Enabled: false
+
 Style/NegatedIf:
+  Enabled: true
+
+Style/NegatedIfElseCondition:
   Enabled: true
 
 Style/NegatedWhile:
   Enabled: true
 
+Style/NestedFileDirname:
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Enabled: true
+
 Style/Next:
   Enabled: false
+
+Style/NilComparison:
+  Enabled: true
+
+Style/NilLambda:
+  Enabled: true
+
+Style/NonNilCheck:
+  Enabled: true
+
+Style/Not:
+  Enabled: true
+
+Style/NumberedParameters:
+  Enabled: true
+
+Style/NumberedParametersLimit:
+  Enabled: true
+
+Style/NumericLiteralPrefix:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: true
+
+Style/ObjectThen:
+  Enabled: true
+
+Style/OneLineConditional:
+  Enabled: true
+
+Style/OpenStructUse:
+  Enabled: true
+
+Style/OperatorMethodCall:
+  Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: true
+
+Style/PercentLiteralDelimiters:
+  Enabled: true
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/Proc:
+  Enabled: true
+
+Style/QuotedSymbols:
+  Enabled: true
+
+Style/RaiseArgs:
+  Enabled: true
+
+Style/RedundantArgument:
+  Enabled: false
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantBegin:
+  Enabled: true
+
+Style/RedundantCondition:
+  Enabled: false
+
+Style/RedundantConstantBase:
+  Enabled: false
+
+Style/RedundantDoubleSplatHashBraces:
+  Enabled: true
+
+Style/RedundantEach:
+  Enabled: true
+
+Style/RedundantException:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
+Style/RedundantHeredocDelimiterQuotes:
+  Enabled: true
+
+Style/RedundantInitialize:
+  Enabled: true
+
+Style/RedundantPercentQ:
+  Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/RedundantReturn:
+  Enabled: false
+
+Style/RedundantSelf:
+  Enabled: false
+
+Style/RedundantSelfAssignment:
+  Enabled: true
+
+Style/RedundantSelfAssignmentBranch:
+  Enabled: true
+
+Style/RedundantStringEscape:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/RescueModifier:
+  Enabled: true
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/SelectByRegexp:
+  Enabled: false
+
+Style/SelfAssignment:
+  Enabled: true
+
+Style/Semicolon:
+  Enabled: true
+
+Style/SignalException:
+  Enabled: false
+
+Style/SingleArgumentDig:
+  Enabled: true
 
 Style/SingleLineBlockParams:
   Enabled: false
@@ -407,7 +849,34 @@ Style/SingleLineBlockParams:
 Style/SingleLineMethods:
   Enabled: false
 
+Style/SlicingWithRange:
+  Enabled: false
+
+Style/SoleNestedConditional:
+  Enabled: false
+
 Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/StringChars:
+  Enabled: true
+
+Style/StringConcatenation:
+  Enabled: true
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/SwapValues:
+  Enabled: true
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 Style/TrivialAccessors:
@@ -419,125 +888,14 @@ Style/UnlessElse:
 Style/VariableInterpolation:
   Enabled: true
 
+Style/WhenThen:
+  Enabled: false
+
 Style/WhileUntilDo:
   Enabled: true
 
-Style/EvenOdd:
-  Enabled: true
-
-Style/For:
-  Enabled: true
-
-Style/Lambda:
+Style/WhileUntilModifier:
   Enabled: false
 
-Naming/MethodName:
-  Enabled: false
-
-Style/MultilineTernaryOperator:
-  Enabled: true
-
-Style/NestedTernaryOperator:
-  Enabled: true
-
-Style/NilComparison:
-  Enabled: true
-
-Style/FormatString:
-  Enabled: true
-
-Style/MultilineBlockChain:
-  Enabled: true
-
-Style/Semicolon:
-  Enabled: true
-
-Style/SignalException:
-  Enabled: false
-
-Style/NonNilCheck:
-  Enabled: true
-
-Style/Not:
-  Enabled: true
-
-Style/NumericLiterals:
-  Enabled: true
-
-Style/OneLineConditional:
-  Enabled: true
-
-Naming/BinaryOperatorParameterName:
-  Enabled: true
-
-Style/ParenthesesAroundCondition:
-  Enabled: true
-
-Style/PercentLiteralDelimiters:
-  Enabled: true
-
-Style/PerlBackrefs:
-  Enabled: false
-
-Naming/PredicateName:
-  Enabled: false
-
-Style/RedundantException:
-  Enabled: true
-
-Style/SelfAssignment:
-  Enabled: true
-
-Style/Proc:
-  Enabled: true
-
-Style/RaiseArgs:
-  Enabled: true
-
-Style/RedundantBegin:
-  Enabled: true
-
-Style/RescueModifier:
-  Enabled: true
-
-Style/RegexpLiteral:
-  Enabled: false
-
-Lint/UnderscorePrefixedVariableName:
-  Enabled: true
-
-Metrics/ParameterLists:
-  Enabled: true
-
-Lint/RequireParentheses:
-  Enabled: true
-
-Style/ModuleFunction:
-  Enabled: false
-
-Lint/Debugger:
-  Enabled: false
-
-Style/IfWithSemicolon:
-  Enabled: true
-
-Style/Encoding:
-  Enabled: false
-
-Style/CommandLiteral:
-  EnforcedStyle: percent_x
-
-# We have a few modules that are much larger than the default limit even when
-# we don't count the comments. This isn't worth it to keep enabled.
-Metrics/ModuleLength:
-  Enabled: false
-
-# I have no idea why, but it's complaining that we aren't using octal notation
-# correctly when specifying file permissions. I have no idea how to resolve the
-# complaint without disabling this cop. File permissions are not defined with
-# octal notation. The complaint makes no sense.
-Style/NumericLiteralPrefix:
-  Enabled: false
-
-Style/ConditionalAssignment:
+Style/WordArray:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,7 +883,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.109.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.109.1...HEAD
+[0.109.1]: https://github.com/puppetlabs/packaging/compare/0.109.0...0.109.1
 [0.109.0]: https://github.com/puppetlabs/packaging/compare/0.108.2...0.109.0
 [0.108.2]: https://github.com/puppetlabs/packaging/compare/0.108.1...0.108.2
 [0.108.1]: https://github.com/puppetlabs/packaging/compare/0.108.0...0.108.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Changed
 - (maint) make the 'artifact already exists' error more informative.
+- (maint) refactor rspec examples for Ruby 3.x compatibility.
+- (maint) Rubocop compliance changes.
 
 ## [0.108.2] - 2023-02-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.109.2] - 2023-03-07
 ### Changed
 - (maint) Updated #update_ips_repo to be more resilient around location of p5p files.
 
@@ -885,7 +887,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.109.1...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.109.2...HEAD
+[0.109.2]: https://github.com/puppetlabs/packaging/compare/0.109.1...0.109.2
 [0.109.1]: https://github.com/puppetlabs/packaging/compare/0.109.0...0.109.1
 [0.109.0]: https://github.com/puppetlabs/packaging/compare/0.108.2...0.109.0
 [0.108.2]: https://github.com/puppetlabs/packaging/compare/0.108.1...0.108.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.109.1] - 2023-03-01
 ### Fixed
 - (maint) Fixed a bug in the 'artifact already exists' error where the path to the artifact
   wasn't printing correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Removed
-- (RE-15200) Removed Red Hat 7 (aarch64) from PLATFORM_INFO
 
 ## [0.109.2] - 2023-03-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Fixed
 - (maint) Fixed a bug in the 'artifact already exists' error where the path to the artifact
   wasn't printing correctly
+- (maint) Go back to old ERB.new method call to accommodate Ruby 2.5
 
 ## [0.109.0] - 2023-02-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Removed
+- (RE-15200) Removed Red Hat 7 (aarch64) from PLATFORM_INFO
 
 ## [0.109.2] - 2023-03-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.109.0] - 2023-02-28
 ### Changed
 - (maint) make the 'artifact already exists' error more informative.
 - (maint) refactor rspec examples for Ruby 3.x compatibility.
@@ -875,7 +877,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.108.2...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.109.0...HEAD
+[0.109.0]: https://github.com/puppetlabs/packaging/compare/0.108.2...0.109.0
 [0.108.2]: https://github.com/puppetlabs/packaging/compare/0.108.1...0.108.2
 [0.108.1]: https://github.com/puppetlabs/packaging/compare/0.108.0...0.108.1
 [0.108.0]: https://github.com/puppetlabs/packaging/compare/0.107.2...0.108.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Fixed a bug in the 'artifact already exists' error where the path to the artifact
+  wasn't printing correctly
 
 ## [0.109.0] - 2023-02-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (maint) Updated #update_ips_repo to be more resilient around location of p5p files.
 
 ## [0.109.1] - 2023-03-01
 ### Fixed

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -236,7 +236,7 @@ module Pkg
     # @return [String] The contents of the YAML file
     def retrieve_yaml_data(pkg, ref)
       yaml_url = "#{@artifactory_uri}/#{DEFAULT_REPO_TYPE}/#{DEFAULT_REPO_BASE}/#{pkg}/#{ref}/#{ref}.yaml"
-      URI.open(yaml_url, &:read)
+      URI.parse(yaml_url).read
     rescue StandardError
       raise "Failed to load YAML data for #{pkg} at #{ref} from #{yaml_url}!"
     end

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -5,8 +5,8 @@ module Pkg
   #   have it set via accessors, and serialize it back to yaml for easy transport.
   #
   class Config
-    require 'packaging/config/params.rb'
-    require 'packaging/config/validations.rb'
+    require 'packaging/config/params'
+    require 'packaging/config/validations'
     require 'yaml'
 
     class << self
@@ -79,7 +79,7 @@ module Pkg
                           Pkg::Util::Net.check_host_ssh([self.builds_server]).empty?
 
         dir = "/opt/jenkins-builds/#{self.project}/#{self.ref}"
-        cmd = "if [ -s \"#{dir}/artifacts\" ]; then cd #{dir};"\
+        cmd = "if [ -s \"#{dir}/artifacts\" ]; then cd #{dir};" \
               "find ./artifacts -mindepth 2 -type f; fi"
         artifacts, = Pkg::Util::Net.remote_execute(
           self.builds_server,
@@ -132,12 +132,12 @@ module Pkg
 
           case package_format
           when 'deb'
-            repo_config = "../repo_configs/deb/pl-#{self.project}-#{self.ref}-"\
+            repo_config = "../repo_configs/deb/pl-#{self.project}-#{self.ref}-" \
                           "#{Pkg::Platforms.get_attribute(tag, :codename)}.list"
           when 'rpm'
             # Using original_tag here to not break legacy fedora repo targets
             unless tag.include? 'aix'
-              repo_config = "../repo_configs/rpm/pl-#{self.project}-"\
+              repo_config = "../repo_configs/rpm/pl-#{self.project}-" \
                             "#{self.ref}-#{original_tag}.repo"
             end
           when 'swix', 'svr4', 'ips', 'dmg', 'msi'

--- a/lib/packaging/config/validations.rb
+++ b/lib/packaging/config/validations.rb
@@ -4,7 +4,7 @@ module Pkg
       # As a validation, this one is kindof lame but is intended as a seed pattern for possibly
       # more robust ones.
       def not_empty?(value)
-        value.to_s.empty? ? false : true
+        value.to_s.any?
       end
     end
   end

--- a/lib/packaging/config/validations.rb
+++ b/lib/packaging/config/validations.rb
@@ -4,7 +4,7 @@ module Pkg
       # As a validation, this one is kindof lame but is intended as a seed pattern for possibly
       # more robust ones.
       def not_empty?(value)
-        value.to_s.any?
+        !value.to_s.empty?
       end
     end
   end

--- a/lib/packaging/deb/repo.rb
+++ b/lib/packaging/deb/repo.rb
@@ -93,7 +93,7 @@ module Pkg::Deb::Repo
 
       artifact_paths.each do |path|
         platform_tag = Pkg::Paths.tag_from_artifact_path(path)
-        platform, version, = Pkg::Platforms. parse_platform_tag(platform_tag)
+        platform, version, = Pkg::Platforms.parse_platform_tag(platform_tag)
         codename = Pkg::Platforms.codename_for_platform_version(platform, version)
         arches = Pkg::Platforms.arches_for_codename(codename)
 
@@ -224,10 +224,10 @@ SignWith: #{Pkg::Config.gpg_key}"
 
       options << '--dry-run' if dryrun
       options << path
-      if !destination.nil?
-        options << "#{destination}:#{dest_path.parent}"
-      else
+      if destination.nil?
         options << dest_path.parent.to_s
+      else
+        options << "#{destination}:#{dest_path.parent}"
       end
       options.join("\s")
     end

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -44,7 +44,7 @@ module Pkg::Gem
         puts "#{file} has already been shipped to rubygems, skipping."
         return
       end
-      Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
+      Pkg::Util::File.file_exist?("#{ENV['HOME']}/.gem/credentials", :required => true)
       gem_push_command = "gem push #{file}"
       gem_push_command << " --host #{options[:host]}" if options[:host]
       gem_push_command << " --key #{options[:key]}" if options[:key]

--- a/lib/packaging/gem.rb
+++ b/lib/packaging/gem.rb
@@ -44,7 +44,7 @@ module Pkg::Gem
         puts "#{file} has already been shipped to rubygems, skipping."
         return
       end
-      Pkg::Util::File.file_exist?("#{ENV['HOME']}/.gem/credentials", :required => true)
+      Pkg::Util::File.file_exists?("#{ENV['HOME']}/.gem/credentials", :required => true)
       gem_push_command = "gem push #{file}"
       gem_push_command << " --host #{options[:host]}" if options[:host]
       gem_push_command << " --key #{options[:key]}" if options[:key]

--- a/lib/packaging/nuget.rb
+++ b/lib/packaging/nuget.rb
@@ -23,7 +23,7 @@ module Pkg::Nuget
       form_data = ["-H 'Authorization: Basic #{authentication}'", "-f"]
       packages.each do |pkg|
         puts "Working on package #{pkg}"
-        projname, version = File.basename(pkg).match(/^(.*)-([\d+\.]+)\.nupkg$/).captures
+        projname, version = File.basename(pkg).match(/^(.*)-([\d+.]+)\.nupkg$/).captures
         package_form_data = ["--upload-file #{pkg}"]
         package_path = "#{projname}/#{version}/#{File.basename(pkg)}"
         stdout = ''

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -318,7 +318,8 @@ module Pkg::Paths
 
     # For repos prior to puppet7, the puppet version was part of the repository
     # For example: /opt/repository/apt/pool/bionic/puppet6/p/puppet-agent
-    if %w[puppet7 puppet7-nightly
+    if %w[puppet8 puppet8-nightly
+          puppet7 puppet7-nightly
           puppet6 puppet6-nightly
           puppet5 puppet5-nightly
           puppet puppet-nightly

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -23,7 +23,7 @@ module Pkg::Paths
   # Given a path to an artifact, divine the appropriate platform tag associated
   # with the artifact and path
   def tag_from_artifact_path(path)
-    platform = Pkg::Platforms.supported_platforms.find { |p| path =~ /(\/|\.)#{p}[^\.]/ }
+    platform = Pkg::Platforms.supported_platforms.find { |p| path =~ /(\/|\.)#{p}[^.]/ }
     platform = 'windowsfips' if path =~ /windowsfips/
 
     codename = Pkg::Platforms.codenames.find { |c| path =~ /\/#{c}/ }
@@ -349,7 +349,7 @@ module Pkg::Paths
   def debian_component_from_path(path)
     # substitute '.' and '/' since those aren't valid characters for debian components
     matches = path.match(/(\d+\.\d+|master|main)\/(\w+)/)
-    regex_for_substitution = /[\.\/]/
+    regex_for_substitution = /[.\/]/
     fail "Error: Could not determine Debian Component from path #{path}" if matches.nil?
     base_component = matches[1]
     component_qualifier = matches[2]

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -49,7 +49,7 @@ module Pkg
           repo: true,
         },
         '7' => {
-          architectures: ['x86_64', 'ppc64le'],
+          architectures: ['x86_64', 'ppc64le', 'aarch64'],
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -49,7 +49,7 @@ module Pkg
           repo: true,
         },
         '7' => {
-          architectures: ['x86_64', 'ppc64le', 'aarch64'],
+          architectures: ['x86_64', 'ppc64le'],
           source_architecture: 'SRPMS',
           package_format: 'rpm',
           source_package_formats: ['src.rpm'],

--- a/lib/packaging/sign/dmg.rb
+++ b/lib/packaging/sign/dmg.rb
@@ -32,6 +32,14 @@ module Pkg::Sign::Dmg
 
       dmg_basenames = dmgs.map { |d| File.basename(d, '.dmg') }.join(' ')
 
+      # (See: RE-15379) Refactor opportunity; we really shouldn't do this this way.
+      # When it works, it's fine, but diagnosing problems when we or Apple change
+      # the details is a pain. We should either have a script on the signing machine
+      # that does this work OR we should ship a script to the signing directory that
+      # can be modified/repeated when problems arise.
+      #
+      # Note especially, the '-size 200m' hack in the 'hdiutil create' command. This
+      # is useful but arbitrary at the moment and could cause problems in the future.
       sign_package_command = %W[
         for dmg in #{dmg_basenames}; do
           /usr/bin/hdiutil attach #{remote_working_directory}/$dmg.dmg
@@ -55,7 +63,7 @@ module Pkg::Sign::Dmg
 
           /usr/bin/hdiutil detach #{dmg_mount_point} -quiet ;
           /bin/rm #{remote_working_directory}/$dmg.dmg ;
-          /usr/bin/hdiutil create -volname $dmg
+          /usr/bin/hdiutil create -volname $dmg -size 200m
             -srcfolder #{signed_items_directory}/ #{remote_working_directory}/$dmg.dmg ;
           /bin/rm #{signed_items_directory}/* ;
         done

--- a/lib/packaging/sign/msi.rb
+++ b/lib/packaging/sign/msi.rb
@@ -66,14 +66,12 @@ module Pkg::Sign::Msi
 
     # Download the signed msis
     msis.each do |msi|
-      begin
-        signed_msi = signed_bucket.file(signed_msis[msi])
-        signed_msi.download(msi)
-      rescue StandardError => e
-        delete_tosign_msis(tosign_bucket, msis)
-        delete_signed_msis(signed_bucket, signed_msis)
-        fail "There was an error retrieving the signed msi:#{msi}.\n#{e}"
-      end
+      signed_msi = signed_bucket.file(signed_msis[msi])
+      signed_msi.download(msi)
+    rescue StandardError => e
+      delete_tosign_msis(tosign_bucket, msis)
+      delete_signed_msis(signed_bucket, signed_msis)
+      fail "There was an error retrieving the signed msi:#{msi}.\n#{e}"
     end
 
     # Cleanup buckets

--- a/lib/packaging/util/execution.rb
+++ b/lib/packaging/util/execution.rb
@@ -71,7 +71,7 @@ module Pkg::Util::Execution
             break
           rescue StandardError => err
             puts "An error was encountered evaluating block. Retrying.."
-            exception = err.to_s + "\n" + err.backtrace.join("\n")
+            exception = "#{err.to_s}\n#{err.backtrace.join("\n")}"
           end
         end
       else

--- a/lib/packaging/util/ezbake.rb
+++ b/lib/packaging/util/ezbake.rb
@@ -15,7 +15,7 @@ module Pkg::Util::EZbake
         )
       end
 
-      if File.exists?(ezbake_yaml)
+      if File.exist?(ezbake_yaml)
         FileUtils.cp(
           ezbake_yaml,
           File.join(target_directory, "#{Pkg::Config.ref}.ezbake.manifest.yaml")

--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -58,7 +58,14 @@ module Pkg::Util::File
 
     def erb_string(erbfile, b = binding)
       template = File.read(erbfile)
-      message  = ERB.new(template, trim_mode: "-")
+
+      # We should be using this but some images are pegged at Ruby <= 2.5; this interface
+      # changed at Ruby 2.6
+      # message  = ERB.new(template, safe_level: nil, trim_mode: '-')
+
+      # rubocop:disable Lint/ErbNewArguments
+      message = ERB.new(template, nil, '-')
+      # rubocop:enable Lint/ErbNewArguments
       message.result(b)
     end
 

--- a/lib/packaging/util/file.rb
+++ b/lib/packaging/util/file.rb
@@ -58,7 +58,7 @@ module Pkg::Util::File
 
     def erb_string(erbfile, b = binding)
       template = File.read(erbfile)
-      message  = ERB.new(template, nil, "-")
+      message  = ERB.new(template, trim_mode: "-")
       message.result(b)
     end
 
@@ -98,7 +98,7 @@ module Pkg::Util::File
       Dir.chdir(Pkg::Config.project_root) do
         file_patterns.each do |pattern|
           if File.directory?(pattern) and !Pkg::Util::File.empty_dir?(pattern)
-            install << Dir[pattern + "/**/*"]
+            install << Dir["#{pattern}/**/*"]
           else
             install << Dir[pattern]
           end
@@ -146,8 +146,8 @@ module Pkg::Util::File
       team_data_branch = Pkg::Config.team
 
       if Pkg::Config.build_pe
-        project_data_branch = 'pe-' + project_data_branch unless project_data_branch =~ /^pe-/
-        team_data_branch = 'pe-' + team_data_branch unless team_data_branch =~ /^pe-/
+        project_data_branch = "pe-#{project_data_branch}" unless project_data_branch =~ /^pe-/
+        team_data_branch = "pe-#{team_data_branch}" unless team_data_branch =~ /^pe-/
       end
 
       # Remove .packaging directory from old-style extras loading
@@ -189,7 +189,6 @@ module Pkg::Util::File
     # PL Release team
     def load_extras(temp_directory)
       unless ENV['PARAMS_FILE'] && ENV['PARAMS_FILE'] != ''
-        temp_directory = temp_directory
         raise "load_extras requires a directory containing extras data" if temp_directory.nil?
         Pkg::Config.config_from_yaml("#{temp_directory}/#{Pkg::Config.builder_data_file}")
 
@@ -200,4 +199,3 @@ module Pkg::Util::File
     end
   end
 end
-

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -7,7 +7,7 @@ module Pkg::Util::Net
     def fetch_uri(uri, target)
       require 'open-uri'
       if Pkg::Util::File.file_writable?(File.dirname(target))
-        File.open(target, 'w') { |f| f.puts(URI.open(uri).read) }
+        File.open(target, 'w') { |f| f.puts(URI.parse(uri).read) }
       end
     end
 
@@ -33,11 +33,9 @@ module Pkg::Util::Net
     def check_host_ssh(hosts)
       errs = []
       Array(hosts).flatten.each do |host|
-        begin
-          remote_execute(host, 'exit', { extra_options: '-oBatchMode=yes' })
-        rescue StandardError
-          errs << host
-        end
+        remote_execute(host, 'exit', { extra_options: '-oBatchMode=yes' })
+      rescue StandardError
+        errs << host
       end
       return errs
     end
@@ -51,12 +49,10 @@ module Pkg::Util::Net
     def check_host_gpg(hosts, gpg)
       errs = []
       Array(hosts).flatten.each do |host|
-        begin
-          remote_execute(host, "gpg --list-secret-keys #{gpg} > /dev/null 2&>1",
-                         { extra_options: '-oBatchMode=yes' })
-        rescue StandardError
-          errs << host
-        end
+        remote_execute(host, "gpg --list-secret-keys #{gpg} > /dev/null 2&>1",
+                       { extra_options: '-oBatchMode=yes' })
+      rescue StandardError
+        errs << host
       end
       return errs
     end

--- a/lib/packaging/util/ship.rb
+++ b/lib/packaging/util/ship.rb
@@ -377,7 +377,7 @@ module Pkg::Util::Ship
       FileUtils.cp(ezbake_manifest, File.join(local_directory, "#{Pkg::Config.ref}.ezbake.manifest"))
     end
     ezbake_yaml = File.join("ext", "ezbake.manifest.yaml")
-    if File.exists?(ezbake_yaml)
+    if File.exist?(ezbake_yaml)
       FileUtils.cp(ezbake_yaml, File.join(local_directory, "#{Pkg::Config.ref}.ezbake.manifest.yaml"))
     end
 

--- a/lib/packaging/util/tool.rb
+++ b/lib/packaging/util/tool.rb
@@ -18,7 +18,7 @@ module Pkg::Util::Tool
           exts.each do |ext|
             locationext = File.expand_path(location + ext)
 
-            return '"' + locationext + '"' if FileTest.executable?(locationext)
+            return "\"#{locationext}\"" if FileTest.executable?(locationext)
           end
         end
 

--- a/lib/packaging/util/version.rb
+++ b/lib/packaging/util/version.rb
@@ -93,7 +93,7 @@ module Pkg::Util::Version
       end
 
       if new_version.include?('dirty')
-        new_version = new_version.sub(/\.?dirty/, '') + 'dirty'
+        new_version = "#{new_version.sub(/\.?dirty/, '')}dirty"
       end
 
       new_version.split('-')
@@ -143,9 +143,11 @@ module Pkg::Util::Version
     #
     def versionbump(workdir = nil)
       version = ENV['VERSION'] || Pkg::Config.version.to_s.strip
-      new_version = '"' + version + '"'
+      new_version = "\"#{version}\""
 
+      # rubocop:disable Style/StringConcatenation
       version_file = "#{workdir ? workdir + '/' : ''}#{Pkg::Config.version_file}"
+      # rubocop:enable Style/StringConcatenation
 
       # Read the previous version file in...
       contents = IO.read(version_file)
@@ -160,7 +162,7 @@ module Pkg::Util::Version
       puts "Updating #{old_version} to #{new_version} in #{version_file}"
       if contents =~ /@DEVELOPMENT_VERSION@/
         contents.gsub!('@DEVELOPMENT_VERSION@', version)
-      elsif contents =~ /version\s*=\s*[\'"]DEVELOPMENT[\'"]/
+      elsif contents =~ /version\s*=\s*['"]DEVELOPMENT['"]/
         contents.gsub!(/version\s*=\s*['"]DEVELOPMENT['"]/, "version = '#{version}'")
       elsif contents =~ /VERSION = #{old_version}/
         contents.gsub!("VERSION = #{old_version}", "VERSION = #{new_version}")
@@ -179,8 +181,8 @@ module Pkg::Util::Version
     #
     # @param json_data [hash] json data hash containing the ref to check
     def report_json_tags(json_data)
-      puts 'component: ' + File.basename(json_data['url'])
-      puts 'ref: ' + json_data['ref'].to_s
+      puts "component: #{File.basename(json_data['url'])}"
+      puts "ref: #{json_data['ref'].to_s}"
       if Pkg::Util::Git.remote_tagged?(json_data['url'], json_data['ref'].to_s)
         tagged = 'Tagged? [ Yes ]'
       else

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -5,22 +5,23 @@ Gem::Specification.new do |gem|
   gem.version = %x(git describe --tags).gsub('-', '.').chomp
   gem.date    = Date.today.to_s
 
-  gem.summary = "Puppet Labs' packaging automation"
-  gem.description = "Packaging automation written in Rake and Ruby. Easily build native packages for most platforms with a few data files and git."
+  gem.summary = 'Puppet by Perforce packaging automation'
+  gem.description = 'Packaging automation for Puppet FOSS projects'
   gem.license = "Apache-2.0"
 
-  gem.authors  = ['Puppet Labs']
-  gem.email    = 'info@puppetlabs.com'
+  gem.authors  = ['Puppet By Perforce']
+  gem.email    = 'release@puppet.com'
   gem.homepage = 'http://github.com/puppetlabs/packaging'
 
   gem.required_ruby_version = '>= 2.3.0'
 
-  gem.add_development_dependency('rspec', ['~> 2.14.1'])
-  gem.add_development_dependency('rubocop', ['~> 0.49'])
+  gem.add_development_dependency('debug', '>= 1.0.0')
+  gem.add_development_dependency('rspec')
+  gem.add_development_dependency('rubocop')
 
   gem.add_runtime_dependency('apt_stage_artifacts')
   gem.add_runtime_dependency('artifactory', ['~> 3'])
-  gem.add_runtime_dependency('csv', ['3.1.5'])
+  gem.add_runtime_dependency('csv', ['>= 3.1.5'])
   gem.add_runtime_dependency('googleauth')
   gem.add_runtime_dependency('google-cloud-storage')
   gem.add_runtime_dependency('rake', ['>= 12.3'])

--- a/spec/lib/packaging/config_spec.rb
+++ b/spec/lib/packaging/config_spec.rb
@@ -2,216 +2,216 @@
 require 'spec_helper'
 require 'yaml'
 
-describe "Pkg::Config" do
+CONFIGURATION_KEYS = %i[
+  apt_archive_path
+  apt_archive_repo_command
+  apt_host
+  apt_releases
+  apt_repo_path
+  apt_repo_url
+  apt_repo_name
+  apt_repo_command
+  author
+  benchmark
+  build_date
+  build_defaults
+  build_dmg
+  build_doc
+  build_gem
+  build_ips
+  build_msi
+  build_pe
+  build_tar
+  builder_data_file
+  bundle_platforms
+  certificate_pem
+  cows
+  db_table
+  deb_build_host
+  deb_build_mirrors
+  debversion
+  debug
+  default_cow
+  default_mock
+  description
+  dmg_path
+  downloads_archive_path
+  email
+  files
+  final_mocks
+  freight_archive_path
+  freight_conf
+  gem_default_executables
+  gem_dependencies
+  gem_description
+  gem_devel_dependencies
+  gem_development_dependencies
+  gem_excludes
+  gem_executables
+  gem_files
+  gem_forge_project
+  gem_host
+  gem_license
+  gem_name
+  gem_path
+  gem_platform_dependencies
+  gem_rdoc_options
+  gem_require_path
+  gem_required_ruby_version
+  gem_required_rubygems_version
+  gem_runtime_dependencies
+  gem_summary
+  gem_test_files
+  gemversion
+  gpg_key
+  gpg_name
+  homepage
+  ips_build_host
+  ips_host
+  ips_inter_cert
+  ips_package_host
+  ips_path
+  ips_repo
+  ips_store
+  jenkins_build_host
+  jenkins_packaging_job
+  jenkins_repo_path
+  metrics
+  metrics_url
+  msi_name
+  name
+  nonfinal_apt_repo_command
+  nonfinal_apt_repo_path
+  nonfinal_apt_repo_staging_path
+  nonfinal_dmg_path
+  nonfinal_gem_path
+  nonfinal_ips_path
+  nonfinal_msi_path
+  nonfinal_p5p_path
+  nonfinal_repo_name
+  nonfinal_repo_link_target
+  nonfinal_svr4_path
+  nonfinal_swix_path
+  nonfinal_yum_repo_path
+  notify
+  project
+  origversion
+  osx_build_host
+  packager
+  packaging_repo
+  packaging_root
+  packaging_url
+  pbuild_conf
+  pe_name
+  pe_version
+  pg_major_version
+  pre_tar_task
+  pre_tasks
+  privatekey_pem
+  random_mockroot
+  rc_mocks
+  release
+  rpm_build_host
+  rpmrelease
+  rpmversion
+  ref
+  repo_name
+  short_ref
+  sign_tar
+  signing_server
+  summary
+  svr4_host
+  svr4_path
+  swix_path
+  tar_excludes
+  tar_host
+  tarball_path
+  team
+  templates
+  update_version_file
+  version
+  version_file
+  version_strategy
+  yum_archive_path
+  yum_host
+  yum_repo_path
+  yum_repo_name
+  yum_repo_command
+]
 
-  Build_Params = [:apt_archive_path,
-                  :apt_archive_repo_command,
-                  :apt_host,
-                  :apt_releases,
-                  :apt_repo_path,
-                  :apt_repo_url,
-                  :apt_repo_name,
-                  :apt_repo_command,
-                  :author,
-                  :benchmark,
-                  :build_date,
-                  :build_defaults,
-                  :build_dmg,
-                  :build_doc,
-                  :build_gem,
-                  :build_ips,
-                  :build_msi,
-                  :build_pe,
-                  :build_tar,
-                  :builder_data_file,
-                  :bundle_platforms,
-                  :certificate_pem,
-                  :cows,
-                  :db_table,
-                  :deb_build_host,
-                  :deb_build_mirrors,
-                  :debversion,
-                  :debug,
-                  :default_cow,
-                  :default_mock,
-                  :description,
-                  :dmg_path,
-                  :downloads_archive_path,
-                  :email,
-                  :files,
-                  :final_mocks,
-                  :freight_archive_path,
-                  :freight_conf,
-                  :gem_default_executables,
-                  :gem_dependencies,
-                  :gem_description,
-                  :gem_devel_dependencies,
-                  :gem_development_dependencies,
-                  :gem_excludes,
-                  :gem_executables,
-                  :gem_files,
-                  :gem_forge_project,
-                  :gem_host,
-                  :gem_license,
-                  :gem_name,
-                  :gem_path,
-                  :gem_platform_dependencies,
-                  :gem_rdoc_options,
-                  :gem_require_path,
-                  :gem_required_ruby_version,
-                  :gem_required_rubygems_version,
-                  :gem_runtime_dependencies,
-                  :gem_summary,
-                  :gem_test_files,
-                  :gemversion,
-                  :gpg_key,
-                  :gpg_name,
-                  :homepage,
-                  :ips_build_host,
-                  :ips_host,
-                  :ips_inter_cert,
-                  :ips_package_host,
-                  :ips_path,
-                  :ips_repo,
-                  :ips_store,
-                  :jenkins_build_host,
-                  :jenkins_packaging_job,
-                  :jenkins_repo_path,
-                  :metrics,
-                  :metrics_url,
-                  :msi_name,
-                  :name,
-                  :nonfinal_apt_repo_command,
-                  :nonfinal_apt_repo_path,
-                  :nonfinal_apt_repo_staging_path,
-                  :nonfinal_dmg_path,
-                  :nonfinal_gem_path,
-                  :nonfinal_ips_path,
-                  :nonfinal_msi_path,
-                  :nonfinal_p5p_path,
-                  :nonfinal_repo_name,
-                  :nonfinal_repo_link_target,
-                  :nonfinal_svr4_path,
-                  :nonfinal_swix_path,
-                  :nonfinal_yum_repo_path,
-                  :notify,
-                  :project,
-                  :origversion,
-                  :osx_build_host,
-                  :packager,
-                  :packaging_repo,
-                  :packaging_root,
-                  :packaging_url,
-                  :pbuild_conf,
-                  :pe_name,
-                  :pe_version,
-                  :pg_major_version,
-                  :pre_tar_task,
-                  :pre_tasks,
-                  :privatekey_pem,
-                  :random_mockroot,
-                  :rc_mocks,
-                  :release,
-                  :rpm_build_host,
-                  :rpmrelease,
-                  :rpmversion,
-                  :ref,
-                  :repo_name,
-                  :short_ref,
-                  :sign_tar,
-                  :signing_server,
-                  :summary,
-                  :svr4_host,
-                  :svr4_path,
-                  :swix_path,
-                  :tar_excludes,
-                  :tar_host,
-                  :tarball_path,
-                  :team,
-                  :templates,
-                  :update_version_file,
-                  :version,
-                  :version_file,
-                  :version_strategy,
-                  :yum_archive_path,
-                  :yum_host,
-                  :yum_repo_path,
-                  :yum_repo_name,
-                  :yum_repo_command,
-  ]
-
-  describe "#new" do
-    Build_Params.each do |param|
-      it "should have r/w accessors for #{param}" do
-        Pkg::Config.should respond_to(param)
-        Pkg::Config.should respond_to("#{param.to_s}=")
+describe 'Pkg::Config' do
+  describe '#new' do
+    CONFIGURATION_KEYS.each do |configuration_key|
+      it "should have r/w accessors for #{configuration_key}" do
+        expect(Pkg::Config).to respond_to(configuration_key)
+        expect(Pkg::Config).to respond_to("#{configuration_key.to_s}=")
       end
     end
   end
 
-  describe "#config_from_hash" do
-    good_params = { :yum_host => 'foo', :pe_name => 'bar' }
+  describe '#config_from_hash' do
+    good_params = { yum_host: 'foo', pe_name: 'bar' }
     context "given a valid params hash #{good_params}" do
-      it "should set instance variable values for each param" do
+      it 'should set instance variable values for each param' do
         good_params.each do |param, value|
-          Pkg::Config.should_receive(:instance_variable_set).with("@#{param}", value)
+          expect(Pkg::Config).to receive(:instance_variable_set).with("@#{param}", value)
         end
         Pkg::Config.config_from_hash(good_params)
       end
     end
 
-    bad_params = { :foo => 'bar' }
+    bad_params = { foo: 'bar' }
     context "given an invalid params hash #{bad_params}" do
       bad_params.each do |param, value|
         it "should print a warning that param '#{param}' is not valid" do
-          Pkg::Config.should_receive(:warn).with(/No build data parameter found for '#{param}'/)
+          expect(Pkg::Config).to receive(:warn).with(/No build data parameter found for '#{param}'/)
           Pkg::Config.config_from_hash(bad_params)
         end
 
         it "should not try to set instance variable @:#{param}" do
-          Pkg::Config.should_not_receive(:instance_variable_set).with("@#{param}", value)
+          expect(Pkg::Config).to_not receive(:instance_variable_set).with("@#{param}", value)
           Pkg::Config.config_from_hash(bad_params)
         end
       end
     end
 
-    mixed_params = { :sign_tar => true, :baz => 'qux' }
-    context "given a hash with both valid and invalid params" do
-      it "should set the valid param" do
-        Pkg::Config.should_receive(:instance_variable_set).with("@sign_tar", true)
+    mixed_params = { sign_tar: true, baz: 'qux' }
+    context 'given a hash with both valid and invalid params' do
+      it 'should set the valid param' do
+        expect(Pkg::Config).to receive(:instance_variable_set).with("@sign_tar", true)
         Pkg::Config.config_from_hash(mixed_params)
       end
 
-      it "should issue a warning that the invalid param is not valid" do
-        Pkg::Config.should_receive(:warn).with(/No build data parameter found for 'baz'/)
+      it 'should issue a warning that the invalid param is not valid' do
+        expect(Pkg::Config).to receive(:warn).with(/No build data parameter found for 'baz'/)
         Pkg::Config.config_from_hash(mixed_params)
       end
 
-      it "should not try to set instance variable @:baz" do
-        Pkg::Config.should_not_receive(:instance_variable_set).with("@baz", "qux")
+      it 'should not try to set instance variable @:baz' do
+        expect(Pkg::Config).to_not receive(:instance_variable_set).with('@baz', 'qux')
         Pkg::Config.config_from_hash(mixed_params)
       end
     end
   end
 
-  describe "#params" do
-    it "should return a hash containing keys for all build parameters" do
+  describe '#params' do
+    it 'should return a hash containing keys for all build parameters' do
       params = Pkg::Config.config
-      Build_Params.each { |param| params.has_key?(param).should == true }
+      CONFIGURATION_KEYS.each { |param| expect(params.key?(param)).to be true }
     end
   end
 
-  describe "#platform_data" do
-    platform_tags = [
-      'osx-10.15-x86_64',
-      'osx-11-x86_64',
-      'ubuntu-18.04-amd64',
-      'el-6-x86_64',
-      'el-7-ppc64le',
-      'sles-12-x86_64',
+  describe '#platform_data' do
+    platform_tags = %w[
+      osx-10.15-x86_64
+      osx-11-x86_64
+      ubuntu-18.04-amd64
+      el-6-x86_64
+      el-7-ppc64le
+      sles-12-x86_64
     ]
 
-    artifacts = \
+    artifacts =
       "./artifacts/apple/10.15/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.osx10.15.dmg\n" \
       "./artifacts/apple/11/PC1/x86_64/puppet-agent-5.3.2.658.gc79ef9a-1.osx11.dmg\n" \
       "./artifacts/deb/bionic/PC1/puppet-agent_5.3.2-1bionic_amd64.deb\n" \
@@ -257,27 +257,27 @@ describe "Pkg::Config" do
       allow(Pkg::Util::Net).to receive(:check_host_ssh).and_return([])
     end
 
-    it "should return a hash mapping platform tags to paths" do
+    it 'should return a hash mapping platform tags to paths' do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(artifacts, nil)
       expect(Pkg::Config.platform_data.keys).to eql(platform_tags)
     end
 
-    it "should return nil if project isn't set" do
+    it 'should return nil if project isn\'t set' do
       allow(Pkg::Config).to receive(:project).and_return(nil)
       expect(Pkg::Config.platform_data).to be_nil
     end
 
-    it "should return nil if ref isn't set" do
+    it 'should return nil if ref isn\'t set' do
       allow(Pkg::Config).to receive(:ref).and_return(nil)
       expect(Pkg::Config.platform_data).to be_nil
     end
 
-    it "should return nil if can't connect to build server" do
+    it 'should return nil if can\'t connect to build server' do
       allow(Pkg::Util::Net).to receive(:check_host_ssh).and_return(['something'])
       expect(Pkg::Config.platform_data).to be_nil
     end
 
-    it "should not use 'f' in fedora platform tags" do
+    it 'should not use \'f\' in fedora platform tags' do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(fedora_artifacts, nil)
       data = Pkg::Config.platform_data
       expect(data).to include('fedora-36-x86_64')
@@ -287,28 +287,39 @@ describe "Pkg::Config" do
     it "should collect packages whose extname differ from package_format" do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(solaris_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data).to include('solaris-10-i386' => {:artifact => './solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz', :repo_config => nil})
-      expect(data).to include('solaris-11-sparc' => {:artifact => './solaris/11/PC1/puppet-agent@5.3.2,5.11-1.sparc.p5p', :repo_config => nil})
+      expect(data).to include(
+        'solaris-10-i386' => {
+          artifact: './solaris/10/PC1/puppet-agent-5.3.2-1.i386.pkg.gz',
+          repo_config: nil
+        }
+      )
+      expect(data).to include(
+        'solaris-11-sparc' => {
+          artifact: './solaris/11/PC1/puppet-agent@5.3.2,5.11-1.sparc.p5p',
+          repo_config: nil
+        }
+      )
     end
 
-    it "should collect versioned msis" do
+    it 'should collect versioned msis' do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(windows_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data['windows-2012-x86']).to include(:artifact => './windows/puppet-agent-5.3.2-x86.msi')
-      expect(data['windows-2012-x64']).to include(:artifact => './windows/puppet-agent-5.3.2-x64.msi')
-      expect(data['windowsfips-2012-x64']).to include(:artifact => './windowsfips/puppet-agent-5.3.2-x64.msi')
+      expect(data['windows-2012-x86']).to include(artifact: './windows/puppet-agent-5.3.2-x86.msi')
+      expect(data['windows-2012-x64']).to include(artifact: './windows/puppet-agent-5.3.2-x64.msi')
+      expect(data['windowsfips-2012-x64']).to include(artifact: './windowsfips/puppet-agent-5.3.2-x64.msi')
     end
 
-    it "should not collect debug packages" do
+    it 'should not collect debug packages' do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(buster_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data['debian-10-amd64']).to include(:artifact => './deb/buster/PC1/puppet-agent_5.3.2.658.gc79ef9a-1buster_amd64.deb')
+      expect(data['debian-10-amd64']).to include(artifact: './deb/buster/PC1/puppet-agent_5.3.2.658.gc79ef9a-1buster_amd64.deb')
     end
 
-    it "should collect packages that don't match the project name" do
-      allow(Pkg::Util::Net).to receive(:remote_execute).and_return(artifacts_not_matching_project, nil)
+    it 'should collect packages that don\'t match the project name' do
+      allow(Pkg::Util::Net).to receive(:remote_execute)
+        .and_return(artifacts_not_matching_project, nil)
       data = Pkg::Config.platform_data
-      expect(data['ubuntu-18.04-amd64']).to include(:artifact => './deb/bionic/pe-postgresql-contrib_2019.1.9.6.12-1bionic_amd64.deb')
+      expect(data['ubuntu-18.04-amd64']).to include(artifact: './deb/bionic/pe-postgresql-contrib_2019.1.9.6.12-1bionic_amd64.deb')
       expect(data['ubuntu-18.04-amd64'][:additional_artifacts].size).to eq(3)
       expect(data['ubuntu-18.04-amd64'][:additional_artifacts]).to include('./deb/bionic/pe-postgresql-devel_2019.1.9.6.12-1bionic_amd64.deb')
       expect(data['ubuntu-18.04-amd64'][:additional_artifacts]).to include('./deb/bionic/pe-postgresql-server_2019.1.9.6.12-1bionic_amd64.deb')
@@ -318,162 +329,170 @@ describe "Pkg::Config" do
     it "should use 'ppc' instead of 'power' in aix paths" do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(aix_artifacts, nil)
       data = Pkg::Config.platform_data
-      expect(data['aix-7.1-power']).to include(:artifact => './aix/7.1/PC1/ppc/puppet-agent-5.3.2-1.aix7.1.ppc.rpm')
+      expect(data['aix-7.1-power']).to include(artifact: './aix/7.1/PC1/ppc/puppet-agent-5.3.2-1.aix7.1.ppc.rpm')
     end
 
-    it "should not record an aix repo config" do
+    it 'should not record an aix repo config' do
       allow(Pkg::Util::Net).to receive(:remote_execute).and_return(aix_artifacts, nil)
       data = Pkg::Config.platform_data
       expect(data['aix-7.1-power'][:repo_config]).to be_nil
     end
   end
 
-  describe "#config_to_yaml" do
-    it "should write a valid yaml file" do
+  describe '#config_to_yaml' do
+    it 'should write a valid yaml file' do
       file = double('file')
-      File.should_receive(:open).with(anything(), 'w').and_yield(file)
-      file.should_receive(:puts).with(instance_of(String))
-      YAML.should_receive(:load_file).with(file)
+      expect(File).to receive(:open).with(anything, 'w').and_yield(file)
+      expect(file).to receive(:puts).with(instance_of(String))
+      expect(YAML).to receive(:load_file).with(file)
       expect { YAML.load_file(file) }.to_not raise_error
       Pkg::Config.config_to_yaml
     end
   end
 
-  describe "#get_binding" do
-    it "should return the binding of the Pkg::Config object" do
+  describe '#get_binding' do
+    it 'should return the binding of the Pkg::Config object' do
       # test by eval'ing using the binding before and after setting a param
       orig = Pkg::Config.apt_host
       Pkg::Config.apt_host = "foo"
-      expect(eval("@apt_host", Pkg::Config.get_binding)).to eq("foo")
+      expect(eval('@apt_host', Pkg::Config.get_binding, __FILE__, __LINE__)).to eq("foo")
       Pkg::Config.apt_host = "bar"
-      expect(eval("@apt_host", Pkg::Config.get_binding)).to eq("bar")
+      expect(eval('@apt_host', Pkg::Config.get_binding, __FILE__, __LINE__)).to eq("bar")
       Pkg::Config.apt_host = orig
     end
   end
 
-  describe "#config_from_yaml" do
-    context "given a yaml file" do
-      it "should, use it to set params" do
+  describe '#config_from_yaml' do
+    context 'given a yaml file' do
+      it 'should, use it to set params' do
         # apt_host: is set to "foo" in the fixture
         orig = Pkg::Config.apt_host
-        Pkg::Config.apt_host = "bar"
+        Pkg::Config.apt_host = 'bar'
         Pkg::Config.config_from_yaml(File.join(FIXTURES, 'config', 'ext', 'build_defaults.yaml'))
-        expect(Pkg::Config.apt_host).to eq("foo")
+        expect(Pkg::Config.apt_host).to eq('foo')
         Pkg::Config.apt_host = orig
       end
     end
   end
 
   describe "#string_to_array" do
-    ary = %W(FOO BAR ARR RAY)
-    context "given a string with spaces in it" do
-      it "should return an array containing the contents of that string" do
+    sample_array = %w[FOO BAR ARR RAY]
+    context 'given a string with spaces in it' do
+      it 'should return an array containing the contents of that string' do
         space_str = "FOO BAR ARR RAY"
-        expect(Pkg::Config.string_to_array(space_str)).to eq(ary)
+        expect(Pkg::Config.string_to_array(space_str)).to eq(sample_array)
       end
     end
 
-    context "given a string with commas in it" do
-      it "should return an array containing the contents of that string" do
-        comma_str = "FOO,BAR,ARR,RAY"
-        expect(Pkg::Config.string_to_array(comma_str)).to eq(ary)
+    context 'given a string with commas in it' do
+      it 'should return an array containing the contents of that string' do
+        comma_str = 'FOO,BAR,ARR,RAY'
+        expect(Pkg::Config.string_to_array(comma_str)).to eq(sample_array)
       end
     end
 
-    context "given a string with semicolons in it" do
-      it "should return an array containing the contents of that string" do
-        semi_str = "FOO;BAR;ARR;RAY"
-        expect(Pkg::Config.string_to_array(semi_str)).to eq(ary)
+    context 'given a string with semicolons in it' do
+      it 'should return an array containing the contents of that string' do
+        semi_str = 'FOO;BAR;ARR;RAY'
+        expect(Pkg::Config.string_to_array(semi_str)).to eq(sample_array)
       end
     end
 
-    context "given a string with multiple delimiters in it" do
+    context 'given a string with multiple delimiters in it' do
       delimiters = [',', ' ', ';']
-      mixed_str = "FOO, BAR, ARR, ; RAY"
-      mixed_arr = Pkg::Config.string_to_array(mixed_str)
+      sample_string = "FOO, BAR, ARR, ; RAY"
+      sample_array = Pkg::Config.string_to_array(sample_string)
 
-      it "should not return the delimiters as array items" do
-        expect(mixed_arr).to_not include(*delimiters)
+      it 'should not return the delimiters as array items' do
+        expect(sample_array).to_not include(*delimiters)
       end
 
-      it "should not contain empty strings" do
-        expect(mixed_arr).to_not include("\s")
+      it 'should not contain empty strings' do
+        expect(sample_array).to_not include("\s")
       end
 
-      it "should still return the expected array" do
-        expect(mixed_arr).to eq(ary)
+      it 'should still return the expected array' do
+        expect(sample_array).to eq(sample_array)
       end
     end
   end
 
-  describe "#cow_list" do
+  describe '#cow_list' do
     it "should return a list of the cows for a project" do
-      Pkg::Config.cows = "base-lucid-i386.cow base-lucid-amd64.cow base-precise-i386.cow base-precise-amd64.cow base-quantal-i386.cow base-quantal-amd64.cow base-saucy-i386.cow base-saucy-amd64.cow base-sid-i386.cow base-sid-amd64.cow base-squeeze-i386.cow base-squeeze-amd64.cow base-stable-i386.cow base-stable-amd64.cow base-testing-i386.cow base-testing-amd64.cow base-trusty-i386.cow base-trusty-amd64.cow base-unstable-i386.cow base-unstable-amd64.cow base-wheezy-i386.cow base-wheezy-amd64.cow"
-      Pkg::Config.cow_list.should eq "lucid precise quantal saucy sid squeeze stable testing trusty unstable wheezy"
+      Pkg::Config.cows = %w[
+        base-lucid-i386.cow base-lucid-amd64.cow base-precise-i386.cow
+        base-precise-amd64.cow base-quantal-i386.cow base-quantal-amd64.cow base-saucy-i386.cow
+        base-saucy-amd64.cow base-sid-i386.cow base-sid-amd64.cow base-squeeze-i386.cow
+        base-squeeze-amd64.cow base-stable-i386.cow base-stable-amd64.cow base-testing-i386.cow
+        base-testing-amd64.cow base-trusty-i386.cow base-trusty-amd64.cow base-unstable-i386.cow
+        base-unstable-amd64.cow base-wheezy-i386.cow base-wheezy-amd64.cow
+      ].join(' ')
+
+      expect(Pkg::Config.cow_list)
+        .to eq 'lucid precise quantal saucy sid squeeze stable testing trusty unstable wheezy'
     end
   end
 
-  describe "#config" do
-    context "given :format => :hash" do
-      it "should call Pkg::Config.config_to_hash" do
+  describe '#config' do
+    context 'given :format => :hash' do
+      it 'should call Pkg::Config.config_to_hash' do
         expect(Pkg::Config).to receive(:config_to_hash)
-        Pkg::Config.config(:target => nil, :format => :hash)
+        Pkg::Config.config(target: nil, format: :hash)
       end
     end
 
-    context "given :format => :yaml" do
-      it "should call Pkg::Config.config_to_yaml if given :format => :yaml" do
+    context 'given :format => :yaml' do
+      it 'should call Pkg::Config.config_to_yaml if given :format => :yaml' do
         expect(Pkg::Config).to receive(:config_to_yaml)
-        Pkg::Config.config(:target => nil, :format => :yaml)
+        Pkg::Config.config(target: nil, format: :yaml)
       end
     end
   end
 
-  describe "#issue_reassignments" do
+  describe '#issue_reassignments' do
     around do |example|
-      prev_tar_host = Pkg::Config.tar_host
+      original_tar_host = Pkg::Config.tar_host
       Pkg::Config.tar_host = nil
       example.run
-      Pkg::Config.tar_host = prev_tar_host
+      Pkg::Config.tar_host = original_tar_host
     end
 
-    it "should set tar_host to staging_server" do
-      Pkg::Config.config_from_hash({ :staging_server => 'foo' })
+    it 'should set tar_host to staging_server' do
+      Pkg::Config.config_from_hash({ staging_server: 'foo' })
       Pkg::Config.issue_reassignments
-      Pkg::Config.tar_host.should eq("foo")
+      expect(Pkg::Config.tar_host).to eq('foo')
     end
   end
 
-  describe "#config_to_hash" do
-    it "should return a hash object" do
-      hash = Pkg::Config.config_to_hash
-      hash.should be_a(Hash)
+  describe '#config_to_hash' do
+    it 'should return a hash object' do
+      expect(Pkg::Config.config_to_hash).to be_a(Hash)
     end
 
-    it "should return a hash with the current parameters" do
-      Pkg::Config.apt_host = "foo"
-      Pkg::Config.config_to_hash[:apt_host].should eq("foo")
-      Pkg::Config.apt_host = "bar"
-      Pkg::Config.config_to_hash[:apt_host].should eq("bar")
+    it 'should return a hash with the current parameters' do
+      Pkg::Config.apt_host = 'foo'
+      expect(Pkg::Config.config_to_hash[:apt_host]).to eq('foo')
+      Pkg::Config.apt_host = 'bar'
+      expect(Pkg::Config.config_to_hash[:apt_host]).to eq('bar')
     end
   end
 
-  describe "#load_default_configs" do
+  describe '#load_default_configs' do
     before(:each) do
-      @project_root = double('project_root')
+      @project_root = 'project_root'
       Pkg::Config.project_root = @project_root
       @test_project_data = File.join(Pkg::Config.project_root, 'ext', 'project_data.yaml')
       @test_build_defaults = File.join(Pkg::Config.project_root, 'ext', 'build_defaults.yaml')
     end
 
     around do |example|
-      orig = Pkg::Config.project_root
+      project_root_save = Pkg::Config.project_root
       example.run
-      Pkg::Config.project_root = orig
+      Pkg::Config.project_root = project_root_save
     end
 
-    context "given ext/build_defaults.yaml and ext/project_data.yaml are readable" do
-      it "should try to load build_defaults.yaml and project_data.yaml" do
+    context 'given ext/build_defaults.yaml and ext/project_data.yaml are readable' do
+      it 'should try to load build_defaults.yaml and project_data.yaml' do
         allow(File).to receive(:readable?).with(@test_project_data).and_return(true)
         allow(File).to receive(:readable?).with(@test_build_defaults).and_return(true)
         expect(Pkg::Config).to receive(:config_from_yaml).with(@test_project_data)
@@ -482,8 +501,8 @@ describe "Pkg::Config" do
       end
     end
 
-    context "given ext/build_defaults.yaml is readable but ext/project_data.yaml is not" do
-      it "should try to load build_defaults.yaml but not project_data.yaml" do
+    context 'given ext/build_defaults.yaml is readable but ext/project_data.yaml is not' do
+      it 'should try to load build_defaults.yaml but not project_data.yaml' do
         allow(File).to receive(:readable?).with(@test_project_data).and_return(false)
         allow(File).to receive(:readable?).with(@test_build_defaults).and_return(true)
         expect(Pkg::Config).to_not receive(:config_from_yaml).with(@test_project_data)
@@ -492,8 +511,8 @@ describe "Pkg::Config" do
       end
     end
 
-    context "given ext/build_defaults.yaml is not readable but ext/project_data.yaml is" do
-      it "should try to load build_defaults.yaml then unset project_root" do
+    context 'given ext/build_defaults.yaml is not readable but ext/project_data.yaml is' do
+      it 'should try to load build_defaults.yaml then unset project_root' do
         allow(File).to receive(:readable?).with(@test_project_data).and_return(true)
         allow(File).to receive(:readable?).with(@test_build_defaults).and_return(false)
         expect(Pkg::Config).to_not receive(:config_from_yaml).with(@test_build_defaults)
@@ -502,14 +521,14 @@ describe "Pkg::Config" do
       end
     end
 
-    context "given ext/build_defaults.yaml and ext/project_data.yaml are not readable" do
-      it "should not try to load build_defaults.yaml and project_data.yaml" do
+    context 'given ext/build_defaults.yaml and ext/project_data.yaml are not readable' do
+      it 'should not try to load build_defaults.yaml and project_data.yaml' do
         Pkg::Config.project_root = 'foo'
         expect(Pkg::Config).to_not receive(:config_from_yaml)
         Pkg::Config.load_default_configs
       end
 
-      it "should set the project root to nil" do
+      it 'should set the project root to nil' do
         Pkg::Config.project_root = 'foo'
         Pkg::Config.load_default_configs
         expect(Pkg::Config.project_root).to be_nil
@@ -517,17 +536,17 @@ describe "Pkg::Config" do
     end
   end
 
-  describe "#load_versioning" do
+  describe '#load_versioning' do
     around do |example|
-      orig = Pkg::Config.project_root
+      project_root_save = Pkg::Config.project_root
       example.run
-      Pkg::Config.project_root = orig
+      Pkg::Config.project_root = project_root_save
     end
 
     # We let the actual version determination testing happen in the version
     # tests. Here we just test that we try when we should.
-    context "When project root is nil" do
-      it "should not try to load versioning" do
+    context 'When project root is nil' do
+      it 'should not try to load versioning' do
         Pkg::Config.project_root = nil
         expect(Pkg::Util::Version).to_not receive(:git_sha_or_tag)
         Pkg::Config.load_versioning
@@ -535,38 +554,40 @@ describe "Pkg::Config" do
     end
   end
 
-  describe "#load_envvars" do
+  describe '#load_envvars' do
     # We're going to pollute the environment with this test, so afterwards we
     # explicitly set everything to nil to prevent any hazardous effects on
     # the rest of the tests.
     after(:all) do
-      reset_env(Pkg::Params::ENV_VARS.map {|hash| hash[:envvar].to_s})
+      reset_env(Pkg::Params::ENV_VARS.map { |hash| hash[:envvar].to_s })
     end
 
     Pkg::Params::ENV_VARS.each do |v|
       case v[:type]
       when :bool
         it "should set boolean value on #{v[:var]} for :type == :bool" do
-          ENV[v[:envvar].to_s] = "FOO"
-          Pkg::Util.stub(:boolean_value) {"FOO"}
+          ENV[v[:envvar].to_s] = 'FOO'
+          allow(Pkg::Util).to receive(:boolean_value).and_return('FOO')
           allow(Pkg::Config).to receive(:instance_variable_set)
-          expect(Pkg::Util).to receive(:boolean_value).with("FOO")
-          expect(Pkg::Config).to receive(:instance_variable_set).with("@#{v[:var]}", "FOO")
+          expect(Pkg::Util).to receive(:boolean_value).with('FOO')
+          expect(Pkg::Config).to receive(:instance_variable_set).with("@#{v[:var]}", 'FOO')
           Pkg::Config.load_envvars
         end
       when :array
         it "should set Pkg::Config##{v[:var]} to an Array for :type == :array" do
-          ENV[v[:envvar].to_s] = "FOO BAR ARR RAY"
-          Pkg::Config.stub(:string_to_array) {%w(FOO BAR ARR RAY)}
+          ENV[v[:envvar].to_s] = 'FOO BAR ARR RAY'
+          allow(Pkg::Config).to receive(:string_to_array).and_return(%w[FOO BAR ARR RAY])
           allow(Pkg::Config).to receive(:instance_variable_set)
-          expect(Pkg::Config).to receive(:string_to_array).with("FOO BAR ARR RAY")
-          expect(Pkg::Config).to receive(:instance_variable_set).with("@#{v[:var]}", %w(FOO BAR ARR RAY))
+          expect(Pkg::Config).to receive(:string_to_array).with('FOO BAR ARR RAY')
+          expect(Pkg::Config)
+            .to receive(:instance_variable_set)
+            .with("@#{v[:var]}", %w[FOO BAR ARR RAY])
           Pkg::Config.load_envvars
         end
       else
         it "should set Pkg::Config##{v[:var]} to ENV[#{v[:envvar].to_s}]" do
           ENV[v[:envvar].to_s] = "FOO"
-          Pkg::Util.stub(:boolean_value) {"FOO"}
+          allow(Pkg::Util).to receive(:boolean_value).and_return('FOO')
           allow(Pkg::Config).to receive(:instance_variable_set)
           expect(Pkg::Config).to receive(:instance_variable_set).with("@#{v[:var]}", "FOO")
           Pkg::Config.load_envvars

--- a/spec/lib/packaging/deb/repo_spec.rb
+++ b/spec/lib/packaging/deb/repo_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 
-describe "Pkg::Deb::Repo" do
-  let(:wget)          { "/opt/tools/bin/wget" }
-  let(:builds_server) { "saturn.puppetlabs.net" }
-  let(:project)       { "deb_repos" }
-  let(:ref)           { "1234abcd" }
+describe 'Pkg::Deb::Repo' do
+  let(:wget)          { '/opt/tools/bin/wget' }
+  let(:builds_server) { 'saturn.puppetlabs.net' }
+  let(:project)       { 'deb_repos' }
+  let(:ref)           { '1234abcd' }
   let(:base_url)      { "http://#{builds_server}/#{project}/#{ref}" }
   let(:cows)          { ["bionic", "focal", "buster", ""] }
-  let(:wget_results)  { cows.map {|cow| "#{base_url}/repos/apt/#{cow}" }.join("\n") }
+  let(:wget_results)  { cows.map { |cow| "#{base_url}/repos/apt/#{cow}" }.join("\n") }
   let(:wget_garbage)  { "\n and an index\nhttp://somethingelse.com/robots" }
-  let(:repo_configs)  { cows.reject {|cow| cow.empty?}.map {|dist| "pkg/repo_configs/deb/pl-#{project}-#{ref}-#{dist}.list" } }
+  let(:repo_configs)  do
+    cows.reject(&:empty?).map { |dist| "pkg/repo_configs/deb/pl-#{project}-#{ref}-#{dist}.list" }
+  end
 
   # Setup and tear down for the tests
   around do |example|
@@ -29,126 +31,186 @@ describe "Pkg::Deb::Repo" do
     Pkg::Config.jenkins_repo_path = orig_repo_path
   end
 
-  describe "#generate_repo_configs" do
-    it "fails if wget isn't available" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_raise(RuntimeError)
-      expect {Pkg::Deb::Repo.generate_repo_configs}.to raise_error(RuntimeError)
+  describe '#generate_repo_configs' do
+    it 'fails if wget isn\'t available' do
+      expect(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('wget', { required: true })
+        .and_raise(RuntimeError)
+      expect { Pkg::Deb::Repo.generate_repo_configs }.to raise_error(RuntimeError)
     end
 
-    it "warns if there are no deb repos available for the build" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_raise(RuntimeError)
-      Pkg::Deb::Repo.should_receive(:warn).with("No debian repos available for #{project} at #{ref}.")
+    it 'warns if there are no deb repos available for the build' do
+      expect(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('wget', { required: true })
+        .and_return(wget)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1")
+        .and_raise(RuntimeError)
+      expect(Pkg::Deb::Repo)
+        .to receive(:warn)
+        .with("No debian repos available for #{project} at #{ref}.")
       Pkg::Deb::Repo.generate_repo_configs
     end
 
-    it "writes the expected repo configs to disk" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1").and_return(wget_results + wget_garbage)
-      FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs/deb")
+    it 'writes the expected repo configs to disk' do
+      expect(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('wget', { required: true })
+        .and_return(wget)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{wget} --spider -r -l 1 --no-parent #{base_url}/repos/apt/ 2>&1")
+        .and_return(wget_results + wget_garbage)
+      expect(FileUtils).to receive(:mkdir_p).with('pkg/repo_configs/deb')
       config = []
       repo_configs.each_with_index do |repo_config, i|
         config[i] = double(File)
-        File.should_receive(:open).with(repo_config, 'w').and_yield(config[i])
-        config[i].should_receive(:puts)
+        expect(File).to receive(:open).with(repo_config, 'w').and_yield(config[i])
+        expect(config[i]).to receive(:puts)
       end
       Pkg::Deb::Repo.generate_repo_configs
     end
   end
 
-  describe "#retrieve_repo_configs" do
-    it "fails if wget isn't available" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_raise(RuntimeError)
-      expect {Pkg::Deb::Repo.generate_repo_configs}.to raise_error(RuntimeError)
+  describe '#retrieve_repo_configs' do
+    it 'fails if wget isn\'t available' do
+      expect(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('wget', { required: true })
+        .and_raise(RuntimeError)
+      expect { Pkg::Deb::Repo.generate_repo_configs }.to raise_error(RuntimeError)
     end
 
-    it "warns if there are no deb repos available for the build" do
-      Pkg::Util::Tool.should_receive(:find_tool).with("wget", {:required => true}).and_return(wget)
-      FileUtils.should_receive(:mkdir_p).with("pkg/repo_configs").and_return(true)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/deb/").and_raise(RuntimeError)
-      expect {Pkg::Deb::Repo.retrieve_repo_configs}.to raise_error(RuntimeError, /Couldn't retrieve deb apt repo configs/)
+    it 'warns if there are no deb repos available for the build' do
+      expect(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('wget', { required: true })
+        .and_return(wget)
+      expect(FileUtils)
+        .to receive(:mkdir_p)
+        .with('pkg/repo_configs')
+        .and_return(true)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/deb/")
+        .and_raise(RuntimeError)
+      expect { Pkg::Deb::Repo.retrieve_repo_configs }
+        .to raise_error(RuntimeError, /Couldn't retrieve deb apt repo configs/)
     end
   end
 
-  describe "#repo_creation_command" do
-    let(:prefix) { "thing" }
-    let(:artifact_directory) { ["/a/b/c/bionic"] }
+  describe '#repo_creation_command' do
+    let(:prefix) { 'thing' }
+    let(:artifact_directory) { ['/a/b/c/bionic'] }
 
-    it "returns a command to make repos" do
+    it 'returns a command to make repos' do
       command = Pkg::Deb::Repo.repo_creation_command(prefix, artifact_directory)
-      command.should match(/reprepro/)
-      command.should match(/#{prefix}/)
-      command.should match(/#{artifact_directory}/)
+      expect(command).to match(/reprepro/)
+      expect(command).to match(/#{prefix}/)
+      expect(command).to match(/#{artifact_directory}/)
     end
   end
 
-  describe "#create_repos" do
-    let(:command) { "/usr/bin/make some repos" }
-    let(:artifact_directory) { "/tmp/dir/thing" }
+  describe '#create_repos' do
+    let(:command) { '/usr/bin/make some repos' }
+    let(:artifact_directory) { '/tmp/dir/thing' }
     let(:pkg_directories) { ['place/to/deb/bionic', 'other/deb/focal'] }
 
-    it "generates repo configs remotely and then ships them" do
-      File.stub(:join) {artifact_directory}
-      Pkg::Repo.should_receive(:directories_that_contain_packages).and_return(pkg_directories)
-      Pkg::Repo.should_receive(:populate_repo_directory)
-      Pkg::Deb::Repo.should_receive(:repo_creation_command).and_return(command)
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, command)
-      Pkg::Deb::Repo.should_receive(:generate_repo_configs)
-      Pkg::Deb::Repo.should_receive(:ship_repo_configs)
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, "rm -f #{artifact_directory}/repos/.lock" )
+    it 'generates repo configs remotely and then ships them' do
+      allow(File).to receive(:join).and_return(artifact_directory)
+      expect(Pkg::Repo).to receive(:directories_that_contain_packages).and_return(pkg_directories)
+      expect(Pkg::Repo).to receive(:populate_repo_directory)
+      expect(Pkg::Deb::Repo).to receive(:repo_creation_command).and_return(command)
+      expect(Pkg::Util::Net)
+        .to receive(:remote_execute)
+        .with(Pkg::Config.distribution_server, command)
+      expect(Pkg::Deb::Repo).to receive(:generate_repo_configs)
+      expect(Pkg::Deb::Repo).to receive(:ship_repo_configs)
+      expect(Pkg::Util::Net)
+        .to receive(:remote_execute)
+        .with(Pkg::Config.distribution_server, "rm -f #{artifact_directory}/repos/.lock")
       Pkg::Deb::Repo.create_repos
     end
   end
 
-  describe "#ship_repo_configs" do
-    it "warns if there are no repo configs to ship" do
-      File.should_receive(:exist?).with("pkg/repo_configs/deb").and_return(true)
-      Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/deb").and_return(true)
-      Pkg::Deb::Repo.should_receive(:warn).with("No repo configs have been generated! Try pl:deb_repo_configs.")
+  describe '#ship_repo_configs' do
+    it 'warns if there are no repo configs to ship' do
+      expect(File).to receive(:exist?).with('pkg/repo_configs/deb').and_return(true)
+      expect(Pkg::Util::File)
+        .to receive(:empty_dir?)
+        .with("pkg/repo_configs/deb")
+        .and_return(true)
+      expect(Pkg::Deb::Repo)
+        .to receive(:warn)
+        .with('No repo configs have been generated! Try pl:deb_repo_configs.')
       Pkg::Deb::Repo.ship_repo_configs
     end
 
-    it "ships repo configs to the build server" do
-      File.should_receive(:exist?).with("pkg/repo_configs/deb").and_return(true)
-      Pkg::Config.jenkins_repo_path = "/a/b/c/d"
-      Pkg::Config.distribution_server = "a.host.that.wont.exist"
+    it 'ships repo configs to the build server' do
+      expect(File).to receive(:exist?).with('pkg/repo_configs/deb').and_return(true)
+      Pkg::Config.jenkins_repo_path = '/a/b/c/d'
+      Pkg::Config.distribution_server = 'a.host.that.wont.exist'
       repo_dir = "#{Pkg::Config.jenkins_repo_path}/#{Pkg::Config.project}/#{Pkg::Config.ref}/repo_configs/deb"
-      Pkg::Util::File.should_receive(:empty_dir?).with("pkg/repo_configs/deb").and_return(false)
-      Pkg::Util::RakeUtils.should_receive(:invoke_task).with("pl:fetch")
-      Pkg::Util::Net.should_receive(:remote_execute).with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
-      Pkg::Util::Execution.should_receive(:retry_on_fail).with(:times => 3)
+      expect(Pkg::Util::File)
+        .to receive(:empty_dir?)
+        .with('pkg/repo_configs/deb')
+        .and_return(false)
+      expect(Pkg::Util::RakeUtils)
+        .to receive(:invoke_task)
+        .with("pl:fetch")
+      expect(Pkg::Util::Net)
+        .to receive(:remote_execute)
+        .with(Pkg::Config.distribution_server, "mkdir -p #{repo_dir}")
+      expect(Pkg::Util::Execution)
+        .to receive(:retry_on_fail)
+        .with(times: 3)
       Pkg::Deb::Repo.ship_repo_configs
     end
   end
 
-  describe "#sign_repos" do
-    it "fails without reprepro" do
-      Pkg::Util::Tool.should_receive(:find_tool).with('reprepro', {:required => true}).and_raise(RuntimeError)
+  describe '#sign_repos' do
+    it 'fails without reprepro' do
+      expect(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('reprepro', { required: true })
+        .and_raise(RuntimeError)
       expect { Pkg::Deb::Repo.sign_repos }.to raise_error(RuntimeError)
     end
 
-    it "makes a repo for each dist" do
+    it 'makes a repo for each dist' do
       # stub out start_keychain to prevent actual keychain starts.
-      Pkg::Util::Gpg.stub(:start_keychain)
+      allow(Pkg::Util::Gpg).to receive(:start_keychain)
 
-      dists = cows.reject { |cow| cow.empty? }
+      dists = cows.reject(&:empty?)
       distfiles = {}
-      Pkg::Util::File.should_receive(:directories).with("repos/apt").and_return(dists)
+      expect(Pkg::Util::File)
+        .to receive(:directories)
+        .with('repos/apt')
+        .and_return(dists)
 
       # Let the keychain command happen if find_tool('keychain') finds it
-      keychain_command = "/usr/bin/keychain -k mine"
+      keychain_command = '/usr/bin/keychain -k mine'
       allow(Pkg::Util::Execution).to receive(:capture3) { keychain_command }
 
       # Enforce reprepro
-      reprepro_command = "/bin/reprepro"
-      Pkg::Util::Tool.should_receive(:check_tool).with("reprepro").and_return(reprepro_command)
-      Pkg::Util::Execution.should_receive(:capture3).at_least(1).times.with("#{reprepro_command} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
+      reprepro_command = '/bin/reprepro'
+      expect(Pkg::Util::Tool)
+        .to receive(:check_tool)
+        .with('reprepro')
+        .and_return(reprepro_command)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .at_least(1).times
+        .with("#{reprepro_command} -vvv --confdir ./conf --dbdir ./db --basedir ./ export")
 
       dists.each do |dist|
         distfiles[dist] = double
-        Dir.should_receive(:chdir).with("repos/apt/#{dist}").and_yield
-        File.should_receive(:open).with("conf/distributions", "w").and_yield(distfiles[dist])
-        distfiles[dist].should_receive(:puts)
+        expect(Dir).to receive(:chdir).with("repos/apt/#{dist}").and_yield
+        expect(File).to receive(:open).with('conf/distributions', 'w').and_yield(distfiles[dist])
+        expect(distfiles[dist]).to receive(:puts)
       end
 
       Pkg::Deb::Repo.sign_repos

--- a/spec/lib/packaging/deb_spec.rb
+++ b/spec/lib/packaging/deb_spec.rb
@@ -3,50 +3,53 @@ require 'spec_helper'
 require 'packaging/deb'
 
 describe 'deb.rb' do
-  describe "#set_cow_envs" do
+  describe '#set_cow_envs' do
     before(:each) do
-      reset_env(["DIST", "ARCH", "PE_VER", "BUILDMIRROR"])
+      reset_env(['DIST', 'ARCH', 'PE_VER', 'BUILDMIRROR'])
       Pkg::Config.deb_build_mirrors = nil
       Pkg::Config.build_pe = nil
       Pkg::Config.pe_version = nil
     end
 
     after(:all) do
-      reset_env(["DIST", "ARCH", "PE_VER", "BUILDMIRROR"])
+      reset_env(['DIST', 'ARCH', 'PE_VER', 'BUILDMIRROR'])
       Pkg::Config.deb_build_mirrors = nil
       Pkg::Config.build_pe = nil
       Pkg::Config.pe_version = nil
     end
 
-    it "should always set DIST and ARCH correctly" do
-      Pkg::Deb.send(:set_cow_envs, "base-wheezy-i386.cow")
-      ENV["DIST"].should eq("wheezy")
-      ENV["ARCH"].should eq("i386")
-      ENV["PE_VER"].should be_nil
-      ENV["BUILDMIRROR"].should be_nil
+    it 'should always set DIST and ARCH correctly' do
+      Pkg::Deb.send(:set_cow_envs, 'base-wheezy-i386.cow')
+      expect(ENV['DIST']).to eq('wheezy')
+      expect(ENV['ARCH']).to eq('i386')
+      expect(ENV['PE_VER']).to be nil
+      expect(ENV['BUILDMIRROR']).to be nil
     end
 
-    it "should set BUILDMIRROR if Pkg::Config.deb_build_mirrors is set" do
-      Pkg::Config.deb_build_mirrors = ["deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main", "deb http://debian.is.awesome/wait no it is not"]
-      Pkg::Deb.send(:set_cow_envs, "base-wheezy-i386.cow")
-      ENV["DIST"].should eq("wheezy")
-      ENV["ARCH"].should eq("i386")
-      ENV["PE_VER"].should be_nil
-      ENV["BUILDMIRROR"].should eq("deb http://pl-build-tools.delivery.puppetlabs.net/debian wheezy main | deb http://debian.is.awesome/wait no it is not")
+    it 'should set BUILDMIRROR if Pkg::Config.deb_build_mirrors is set' do
+      Pkg::Config.deb_build_mirrors = [
+        'deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main',
+        'deb http://debian.is.awesome/wait no it is not'
+      ]
+      Pkg::Deb.send(:set_cow_envs, 'base-wheezy-i386.cow')
+      expect(ENV['DIST']).to eq('wheezy')
+      expect(ENV['ARCH']).to eq('i386')
+      expect(ENV['PE_VER']).to be nil
+      expect(ENV['BUILDMIRROR']).to eq('deb http://pl-build-tools.delivery.puppetlabs.net/debian wheezy main | deb http://debian.is.awesome/wait no it is not')
     end
 
-    it "should set PE_VER if Pkg::Config.build_pe is truthy" do
+    it 'should set PE_VER if Pkg::Config.build_pe is truthy' do
       Pkg::Config.build_pe = true
-      Pkg::Config.pe_version = "3.2"
-      Pkg::Deb.send(:set_cow_envs, "base-wheezy-i386.cow")
-      ENV["DIST"].should eq("wheezy")
-      ENV["ARCH"].should eq("i386")
-      ENV["PE_VER"].should eq("3.2")
-      ENV["BUILDMIRROR"].should be_nil
+      Pkg::Config.pe_version = '3.2'
+      Pkg::Deb.send(:set_cow_envs, 'base-wheezy-i386.cow')
+      expect(ENV['DIST']).to eq('wheezy')
+      expect(ENV['ARCH']).to eq('i386')
+      expect(ENV['PE_VER']).to eq('3.2')
+      expect(ENV['BUILDMIRROR']).to be nil
     end
 
-    it "should fail on a badly formatted cow" do
-      expect { Pkg::Deb.send(:set_cow_envs, "wheezy-i386") }.to raise_error(RuntimeError)
+    it 'should fail on a badly formatted cow' do
+      expect { Pkg::Deb.send(:set_cow_envs, 'wheezy-i386') }.to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/lib/packaging/repo_spec.rb
+++ b/spec/lib/packaging/repo_spec.rb
@@ -1,23 +1,25 @@
 # -*- ruby -*-
 require 'spec_helper'
-describe "#Pkg::Repo" do
+
+describe '#Pkg::Repo' do
   let(:platform_repo_stub) do
     [
-      {"name"=>"el-4-i386", "repo_location"=>"repos/el/4/**/i386"},
-      {"name"=>"el-5-i386", "repo_location"=>"repos/el/5/**/i386"},
-      {"name"=>"el-6-i386", "repo_location"=>"repos/el/6/**/i386"}
+      { "name" => "el-4-i386", "repo_location" => "repos/el/4/**/i386" },
+      { "name" => "el-5-i386", "repo_location" => "repos/el/5/**/i386" },
+      { "name" => "el-6-i386", "repo_location" => "repos/el/6/**/i386" }
     ]
   end
-  describe "#create_signed_repo_archive" do
-    it "should change to the correct dir" do
-      allow(Pkg::Util::Tool).to receive(:check_tool).and_return("tarcommand")
-      allow(Pkg::Config).to receive(:project).and_return("project")
-      allow(Pkg::Util::Version).to receive(:dot_version).and_return("1.1.1")
+
+  describe '#create_signed_repo_archive' do
+    it 'should change to the correct dir' do
+      allow(Pkg::Util::Tool).to receive(:check_tool).and_return('tarcommand')
+      allow(Pkg::Config).to receive(:project).and_return('project')
+      allow(Pkg::Util::Version).to receive(:dot_version).and_return('1.1.1')
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(false)
       allow(Pkg::Util::Execution).to receive(:capture3)
 
       expect(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
-      Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "version")
+      Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')
     end
 
     it 'should use a ref if ref is specified as versioning' do
@@ -54,19 +56,23 @@ describe "#Pkg::Repo" do
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(true)
       ENV['FAIL_ON_MISSING_TARGET'] = 'true'
 
-      expect{Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')}.to raise_error(RuntimeError, 'Error: missing packages under /path')
+      expect do
+        Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')
+      end.to raise_error(RuntimeError, 'Error: missing packages under /path')
     end
 
-    it "should only warn if ENV['FAIL_ON_MISSING_TARGET'] is false and empty_dir? is true" do
-      allow(Pkg::Util::Tool).to receive(:check_tool).and_return("tarcommand")
-      allow(Pkg::Config).to receive(:project).and_return("project")
-      allow(Pkg::Util::Version).to receive(:dot_version).and_return("1.1.1")
+    it 'should only warn if ENV[\'FAIL_ON_MISSING_TARGET\'] is false and empty_dir? is true' do
+      allow(Pkg::Util::Tool).to receive(:check_tool).and_return('tarcommand')
+      allow(Pkg::Config).to receive(:project).and_return('project')
+      allow(Pkg::Util::Version).to receive(:dot_version).and_return('1.1.1')
       allow(Pkg::Util::Execution).to receive(:capture3)
-      allow(Dir).to receive(:chdir).with("pkg/project/1.1.1").and_yield
+      allow(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(true)
-      ENV['FAIL_ON_MISSING_TARGET'] = "false"
+      ENV['FAIL_ON_MISSING_TARGET'] = 'false'
 
-      expect{Pkg::Repo.create_signed_repo_archive("/path", "project-debian-6-i386", "version")}.not_to raise_error
+      expect do
+        Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')
+      end.not_to raise_error
     end
 
     it 'should invoke tar correctly' do
@@ -76,7 +82,9 @@ describe "#Pkg::Repo" do
       allow(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
       allow(Pkg::Util::File).to receive(:empty_dir?).and_return(false)
 
-      expect(Pkg::Util::Execution).to receive(:capture3).with('tarcommand --owner=0 --group=0 --create --gzip --file repos/project-debian-6-i386.tar.gz /path')
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with('tarcommand --owner=0 --group=0 --create --gzip --file repos/project-debian-6-i386.tar.gz /path')
       Pkg::Repo.create_signed_repo_archive('/path', 'project-debian-6-i386', 'version')
     end
   end
@@ -88,32 +96,38 @@ describe "#Pkg::Repo" do
       allow(Pkg::Util::Version).to receive(:dot_version).and_return('1.1.1')
       allow(Dir).to receive(:chdir).with('pkg/project/1.1.1').and_yield
 
-      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with('repos/el/4/**/i386', 'project-el-4-i386', 'version')
-      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with('repos/el/5/**/i386', 'project-el-5-i386', 'version')
-      expect(Pkg::Repo).to receive(:create_signed_repo_archive).with('repos/el/6/**/i386', 'project-el-6-i386', 'version')
+      expect(Pkg::Repo)
+        .to receive(:create_signed_repo_archive)
+        .with('repos/el/4/**/i386', 'project-el-4-i386', 'version')
+      expect(Pkg::Repo)
+        .to receive(:create_signed_repo_archive)
+        .with('repos/el/5/**/i386', 'project-el-5-i386', 'version')
+      expect(Pkg::Repo)
+        .to receive(:create_signed_repo_archive)
+        .with('repos/el/6/**/i386', 'project-el-6-i386', 'version')
 
       allow(Pkg::Util::Execution).to receive(:capture3)
       Pkg::Repo.create_all_repo_archives('project', 'version')
     end
   end
 
-  describe "#argument_required?" do
-    let(:repo_command) { "some command with __REPO_PATH__ but not repo name or anything" }
+  describe '#argument_required?' do
+    let(:repo_command) { 'some command with __REPO_PATH__ but not repo name or anything' }
     let(:required_arg) { 'repo_path' }
     let(:optional_arg) { 'repo_name' }
 
     it 'should return true if command requires arg' do
-      expect(Pkg::Repo.argument_required?(required_arg, repo_command)).to be_true
+      expect(Pkg::Repo.argument_required?(required_arg, repo_command)).to be true
     end
 
     it 'should return false if command does not need arg' do
-      expect(Pkg::Repo.argument_required?(optional_arg, repo_command)).to be_false
+      expect(Pkg::Repo.argument_required?(optional_arg, repo_command)).to be false
     end
   end
 
-  describe "#update_repo" do
+  describe '#update_repo' do
     let(:remote_host) { 'weth.delivery.puppetlabs.net' }
-    let(:repo_command) { "some command with __REPO_NAME__ and __REPO_PATH__ and stuff" }
+    let(:repo_command) { 'some command with __REPO_NAME__ and __REPO_PATH__ and stuff' }
     let(:repo_name) { 'puppet5' }
     let(:repo_path) { '/opt/repository/apt' }
     let(:apt_releases) { ['stretch', 'trusty', 'xenial'] }
@@ -124,12 +138,19 @@ describe "#Pkg::Repo" do
     end
 
     it 'should fail if required params are nil' do
-      expect{ Pkg::Repo.update_repo(remote_host, repo_command, { :repo_path => repo_path }) }.to raise_error(RuntimeError, /Missing required argument 'repo_name'/)
+      expect do
+        Pkg::Repo.update_repo(remote_host, repo_command, { repo_path: repo_path })
+      end.to raise_error(RuntimeError, /Missing required argument 'repo_name'/)
     end
 
     it 'should execute command if optional params are nil' do
-      expect(Pkg::Util::Net).to receive(:remote_execute).with(remote_host, "some command with #{repo_name} and #{repo_path} and stuff")
-      Pkg::Repo.update_repo(remote_host, repo_command, { :repo_name => repo_name, :repo_path => repo_path })
+      expect(Pkg::Util::Net)
+        .to receive(:remote_execute)
+        .with(remote_host, "some command with #{repo_name} and #{repo_path} and stuff")
+      Pkg::Repo.update_repo(remote_host, repo_command, {
+                              repo_name: repo_name,
+                              repo_path: repo_path
+                            })
     end
   end
 end

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -7,7 +7,7 @@ describe 'Pkg::Sign' do
       allow(Pkg::Config).to receive(:gpg_key).and_return('7F438280EF8D349F')
     end
 
-    describe '#signed?' do
+    describe '#has_sig?' do
       let(:rpm) { 'foo.rpm' }
       let(:el7_signed_response) do
         <<~DOC
@@ -17,7 +17,6 @@ describe 'Pkg::Sign' do
           MD5 digest: OK (d5f06ba2a9053de532326d0659ec0d11)
         DOC
       end
-
       let(:sles12_signed_response) do
         <<~DOC
           Header V4 RSA/SHA256 Signature, key ID ef8d349f: NOKEY
@@ -26,36 +25,34 @@ describe 'Pkg::Sign' do
           MD5 digest: OK (3093a09ac39bc17751f913e19ca74432)
         DOC
       end
-
       let(:unsigned_response) do
         <<~DOC
           Header SHA1 digest: OK (f9404cc95f200568c2dbb1fd24e1119e3e4a40a9)
           MD5 digest: OK (816095f3cee145091c3fa07a0915ce85)
         DOC
       end
-
       it 'returns true if rpm has been signed (el7)' do
         allow(Pkg::Sign::Rpm).to receive(:`).and_return(el7_signed_response)
-        expect(Pkg::Sign::Rpm.signed?(rpm)).to be true
+        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
       end
       it 'returns true if rpm has been signed (sles12)' do
         allow(Pkg::Sign::Rpm).to receive(:`).and_return(sles12_signed_response)
-        expect(Pkg::Sign::Rpm.signed?(rpm)).to be true
+        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be true
       end
       it 'returns false if rpm has not been signed' do
         allow(Pkg::Sign::Rpm).to receive(:`).and_return(unsigned_response)
-        expect(Pkg::Sign::Rpm.signed?(rpm)).to be false
+        expect(Pkg::Sign::Rpm.has_sig?(rpm)).to be false
       end
       it 'fails with unexpected output' do
         allow(Pkg::Sign::Rpm)
           .to receive(:`)
           .and_return('something that is definitely not a normal response')
-        expect { Pkg::Sign::Rpm.signed?(rpm) }
+        expect { Pkg::Sign::Rpm.has_sig?(rpm) }
           .to raise_error(RuntimeError, /Something went wrong checking the signature/)
       end
       it 'fails if gpg_key is not set' do
         allow(Pkg::Config).to receive(:gpg_key).and_return(nil)
-        expect { Pkg::Sign::Rpm.signed?(rpm) }
+        expect { Pkg::Sign::Rpm.has_sig?(rpm) }
           .to raise_error(RuntimeError, /You need to set `gpg_key` in your build defaults./)
       end
     end
@@ -63,59 +60,41 @@ describe 'Pkg::Sign' do
     describe '#sign_all' do
       let(:rpm_directory) { Dir.mktmpdir }
       let(:rpms_not_to_sign) do
-        ["#{rpm_directory}/aix/7.1/PC1/ppc/puppet-agent-5.5.3-1.aix7.1.ppc.rpm"]
+        %W[#{rpm_directory}/aix/7.1/PC1/ppc/puppet-agent-5.5.3-1.aix7.1.ppc.rpm]
       end
-
       let(:v3_rpms) do
-        ["#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm"]
+        %W[#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm]
       end
-
       let(:v4_rpms) do
-        ["#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm"]
+        %W[%#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm]
       end
-
       let(:rpms) { rpms_not_to_sign + v3_rpms + v4_rpms }
-
       let(:already_signed_rpms) do
-        ["#{rpm_directory}/el/6/PC1/x86_64/puppet-agent-5.5.3-1.el6.x86_64.rpm"]
+        %W[#{rpm_directory}/el/6/PC1/x86_64/puppet-agent-5.5.3-1.el6.x86_64.rpm]
       end
-
       let(:noarch_rpms) do
-        [
-          "#{rpm_directory}/el/6/puppet5/i386/puppetserver-5.3.3-1.el6.noarch.rpm",
-          "#{rpm_directory}/el/6/puppet5/x86_64/puppetserver-5.3.3-1.el6.noarch.rpm",
-          "#{rpm_directory}/el/7/puppet5/i386/puppetserver-5.3.3-1.el7.noarch.rpm",
-          "#{rpm_directory}/el/7/puppet5/x86_64/puppetserver-5.3.3-1.el7.noarch.rpm",
-          "#{rpm_directory}/sles/12/puppet5/i386/puppetserver-5.3.3-1.sles12.noarch.rpm",
-          "#{rpm_directory}/sles/12/puppet5/x86_64/puppetserver-5.3.3-1.sles12.noarch.rpm"
+        %W[
+          #{rpm_directory}/el/6/puppet5/i386/puppetserver-5.3.3-1.el6.noarch.rpm
+          #{rpm_directory}/el/6/puppet5/x86_64/puppetserver-5.3.3-1.el6.noarch.rpm
+          #{rpm_directory}/el/7/puppet5/i386/puppetserver-5.3.3-1.el7.noarch.rpm
+          #{rpm_directory}/el/7/puppet5/x86_64/puppetserver-5.3.3-1.el7.noarch.rpm
+          #{rpm_directory}/sles/12/puppet5/i386/puppetserver-5.3.3-1.sles12.noarch.rpm
+          #{rpm_directory}/sles/12/puppet5/x86_64/puppetserver-5.3.3-1.sles12.noarch.rpm
         ]
       end
-
       it 'signs both v3 and v4 rpms' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms)
         rpms.each do |rpm|
           allow(Pkg::Sign::Rpm).to receive(:signed?).and_return(false)
         end
-
-        v3_items = v3_rpms.length
-        v4_items = v4_rpms.length
-
-        expect(Pkg::Sign::Rpm)
-          .to receive(:sign)
-          .with(v3_rpms.join(' '), :v3)
-          .exactly(v3_items).times
-        expect(Pkg::Sign::Rpm)
-          .to receive(:sign)
-          .with(v4_rpms.join(' '), :v4)
-          .exactly(v4_items).times
-
+        expect(Pkg::Sign::Rpm).to receive(:sign).with(v3_rpms.join(' '), :v3)
+        expect(Pkg::Sign::Rpm).to receive(:sign).with(v4_rpms.join(' '), :v4)
         Pkg::Sign::Rpm.sign_all(rpm_directory)
       end
 
       it 'does not sign AIX rpms' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(rpms_not_to_sign)
-        allow(Pkg::Sign::Rpm).to receive(:signed?)
-        expect(Pkg::Sign::Rpm).to_not receive(:legacy_sign)
+        allow(Pkg::Sign::Rpm).to receive(:signed?).and_return(false)
         expect(Pkg::Sign::Rpm).to_not receive(:sign)
         Pkg::Sign::Rpm.sign_all(rpm_directory)
       end
@@ -133,7 +112,7 @@ describe 'Pkg::Sign' do
       it 'deletes and relinks rpms with the same basename' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return(noarch_rpms)
         allow(Pkg::Sign::Rpm).to receive(:sign)
-        allow(Pkg::Sign::Rpm).to receive(:signed?)
+        allow(Pkg::Sign::Rpm).to receive(:signed?).and_return(false)
         expect(FileUtils).to receive(:rm).exactly(noarch_rpms.count / 2).times
         expect(FileUtils).to receive(:ln).exactly(noarch_rpms.count / 2).times
         Pkg::Sign::Rpm.sign_all(rpm_directory)
@@ -141,7 +120,7 @@ describe 'Pkg::Sign' do
 
       it 'does not fail if there are no rpms to sign' do
         allow(Dir).to receive(:[]).with("#{rpm_directory}/**/*.rpm").and_return([])
-        expect(Pkg::Sign::Rpm.sign_all(rpm_directory)).to_not raise_error
+        expect { Pkg::Sign::Rpm.sign_all(rpm_directory) }.to_not raise_error
       end
     end
   end

--- a/spec/lib/packaging/tar_spec.rb
+++ b/spec/lib/packaging/tar_spec.rb
@@ -1,35 +1,36 @@
 # -*- ruby -*-
 require 'spec_helper'
 
-describe "tar.rb" do
-  let(:project) { "packaging" }
-  let(:version) { "1.2.3" }
-  let(:files)   { [ "a", "b", "c" ] }
+describe 'tar.rb' do
+  let(:project) { 'packaging' }
+  let(:version) { '1.2.3' }
+  let(:files)   { %w[a b c] }
   let(:templates) do
     [
-      "ext/redhat/spec.erb",
-      { "source" => "ext/debian/control.erb", "target" => "ext/debian/not-a-control-file" },
-      "ext/debian/changelog.erb",
-      "ext/packaging/thing.erb"
+      'ext/redhat/spec.erb',
+      { 'source' => 'ext/debian/control.erb', 'target' => 'ext/debian/not-a-control-file' },
+      'ext/debian/changelog.erb',
+      'ext/packaging/thing.erb'
     ]
   end
   let(:expanded_templates) do
     [
       "#{PROJECT_ROOT}/ext/redhat/spec.erb",
-      { "source" => "ext/debian/control.erb", "target" => "ext/debian/not-a-control-file" },
+      { 'source' => 'ext/debian/control.erb', 'target' => 'ext/debian/not-a-control-file' },
       "#{PROJECT_ROOT}/ext/debian/changelog.erb"
     ]
   end
   before(:each) do
     Pkg::Config.config_from_hash(
       {
-        :templates      => templates,
-        :project        => project,
-        :version        => version,
-        :files          => files,
-        :project_root   => PROJECT_ROOT,
-        :packaging_root => "ext/packaging"
-      })
+        templates: templates,
+        project: project,
+        version: version,
+        files: files,
+        project_root: PROJECT_ROOT,
+        packaging_root: 'ext/packaging'
+      }
+    )
   end
 
   describe '#initialize' do
@@ -51,63 +52,66 @@ describe "tar.rb" do
     end
   end
 
-  describe "#expand_templates" do
-    it "should be invoked when Pkg::Config.templates is set" do
-      Pkg::Tar.any_instance.should_receive(:expand_templates)
+  describe '#expand_templates' do
+    it 'should be invoked when Pkg::Config.templates is set' do
+      expect_any_instance_of(Pkg::Tar).to receive(:expand_templates)
       Pkg::Tar.new
     end
 
-    it "packaging templates should be filtered and paths should be expanded" do
+    it 'packaging templates should be filtered and paths should be expanded' do
       templates.each do |temp|
         if temp.is_a?(String)
-          Dir.stub(:glob).with(File.join(PROJECT_ROOT, temp)).and_return(File.join(PROJECT_ROOT, temp))
+          allow(Dir)
+            .to receive(:glob)
+            .with(File.join(PROJECT_ROOT, temp))
+            .and_return(File.join(PROJECT_ROOT, temp))
         end
       end
 
       tar = Pkg::Tar.new
       tar.templates = templates
       tar.expand_templates
-      tar.templates.should eq expanded_templates
+      expect(tar.templates).to eq(expanded_templates)
     end
   end
 
-  describe "#template" do
+  describe '#template' do
     before(:each) do
       Pkg::Config.templates = expanded_templates
     end
 
-    it "should handle hashes and strings correctly" do
-      # Set up correct stubs and expectations
+    it 'should handle hashes and strings correctly' do
       expanded_templates.each do |temp|
-        if temp.is_a?(String)
+        case temp
+        when String
           full_path_temp = File.join(PROJECT_ROOT, temp)
-          target = full_path_temp.sub(File.extname(full_path_temp), "")
-        elsif temp.is_a?(Hash)
-          full_path_temp = File.join(PROJECT_ROOT, temp["source"])
-          target = File.join(PROJECT_ROOT, temp["target"])
+          target = full_path_temp.sub(File.extname(full_path_temp), '')
+        when Hash
+          full_path_temp = File.join(PROJECT_ROOT, temp['source'])
+          target = File.join(PROJECT_ROOT, temp['target'])
         end
 
-        Dir.stub(:glob).with(full_path_temp).and_return(full_path_temp)
-        File.stub(:exist?).with(full_path_temp).and_return(true)
-        Pkg::Util::File.should_receive(:erb_file).with(full_path_temp, target, true, :binding => an_instance_of(Binding))
+        allow(Dir).to receive(:glob).with(full_path_temp).and_return(full_path_temp)
+        allow(File).to receive(:exist?).with(full_path_temp).and_return(true)
+        expect(Pkg::Util::File)
+          .to receive(:erb_file)
+          .with(full_path_temp, target, true, binding: an_instance_of(Binding))
       end
 
       Pkg::Tar.new.template
     end
 
-    it "should raise an error if the template source can't be found" do
-      # Set up correct stubs and expectations
+    it 'should raise an error if the template source can\'t be found' do
       expanded_templates.each do |temp|
-        if temp.is_a?(String)
-          full_path_temp = File.join(PROJECT_ROOT, temp)
-          target = full_path_temp.sub(File.extname(full_path_temp), "")
-        elsif temp.is_a?(Hash)
-          full_path_temp = File.join(PROJECT_ROOT, temp["source"])
-          target = File.join(PROJECT_ROOT, temp["target"])
-        end
+        full_path_temp = case temp
+                         when String
+                           File.join(PROJECT_ROOT, temp)
+                         when Hash
+                           File.join(PROJECT_ROOT, temp['source'])
+                         end
 
-        Dir.stub(:glob).with(full_path_temp).and_return(full_path_temp)
-        File.stub(:exist?).with(full_path_temp).and_return(false)
+        allow(Dir).to receive(:glob).with(full_path_temp).and_return(full_path_temp)
+        allow(File).to receive(:exist?).with(full_path_temp).and_return(false)
       end
 
       expect { Pkg::Tar.new.template }.to raise_error RuntimeError

--- a/spec/lib/packaging/util/execution_spec.rb
+++ b/spec/lib/packaging/util/execution_spec.rb
@@ -1,56 +1,56 @@
 require 'spec_helper'
 
-describe "Pkg::Util::Execution" do
-  let(:command)    { "/usr/bin/do-something-important --arg1=thing2" }
-  let(:output)     { "the command returns some really cool stuff that may be useful later" }
+describe 'Pkg::Util::Execution' do
+  let(:command) { '/usr/bin/do-something-important --arg1=thing2' }
+  let(:output) { 'the command returns some really cool stuff that may be useful later' }
 
   describe "#success?" do
-    it "should return false on failure" do
-      %x{false}
-      Pkg::Util::Execution.success?.should be_false
+    it 'should return false on failure' do
+      %x(false)
+      expect(Pkg::Util::Execution.success?).to be false
     end
 
-    it "should return true on success" do
-      %x{true}
-      Pkg::Util::Execution.success?.should be_true
+    it 'should return true on success' do
+      %x(true)
+      expect(Pkg::Util::Execution.success?).to be true
     end
 
-    it "should return false when passed an exitstatus object from a failure" do
-      %x{false}
-      Pkg::Util::Execution.success?($?).should be_false
+    it 'should return false when passed an exitstatus object from a failure' do
+      %x(false)
+      expect(Pkg::Util::Execution.success?($?)).to be false
     end
 
-    it "should return true when passed and exitstatus object from a success" do
-      %x{true}
-      Pkg::Util::Execution.success?($?).should be_true
-    end
-  end
-
-  describe "#ex" do
-    it "should raise an error if the command fails" do
-      Pkg::Util::Execution.should_receive(:`).with(command).and_return(true)
-      Pkg::Util::Execution.should_receive(:success?).and_return(false)
-      expect{ Pkg::Util::Execution.ex(command) }.to raise_error(RuntimeError)
-    end
-
-    it "should return the output of the command for success" do
-      Pkg::Util::Execution.should_receive(:`).with(command).and_return(output)
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
-      Pkg::Util::Execution.ex(command).should == output
+    it 'should return true when passed and exitstatus object from a success' do
+      %x(true)
+      expect(Pkg::Util::Execution.success?($?)).to be true
     end
   end
 
-  describe "#capture3" do
-    it "should raise an error if the command fails" do
-      Open3.should_receive(:capture3).with(command).and_return([output, '', 1])
-      Pkg::Util::Execution.should_receive(:success?).with(1).and_return(false)
-      expect{ Pkg::Util::Execution.capture3(command) }.to raise_error(RuntimeError, /#{output}/)
+  describe '#ex' do
+    it 'should raise an error if the command fails' do
+      expect(Pkg::Util::Execution).to receive(:`).with(command).and_return(true)
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(false)
+      expect { Pkg::Util::Execution.ex(command) }.to raise_error(RuntimeError)
+    end
+
+    it 'should return the output of the command for success' do
+      expect(Pkg::Util::Execution).to receive(:`).with(command).and_return(output)
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      expect(Pkg::Util::Execution.ex(command)).to eq output
+    end
+  end
+
+  describe '#capture3' do
+    it 'should raise an error if the command fails' do
+      expect(Open3).to receive(:capture3).with(command).and_return([output, '', 1])
+      expect(Pkg::Util::Execution).to receive(:success?).with(1).and_return(false)
+      expect { Pkg::Util::Execution.capture3(command) }.to raise_error(RuntimeError, /#{output}/)
     end
 
     it "should return the output of the command for success" do
-      Open3.should_receive(:capture3).with(command).and_return([output, '', 0])
-      Pkg::Util::Execution.should_receive(:success?).with(0).and_return(true)
-      Pkg::Util::Execution.capture3(command).should == [output, '', 0]
+      expect(Open3).to receive(:capture3).with(command).and_return([output, '', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).with(0).and_return(true)
+      expect(Pkg::Util::Execution.capture3(command)).to eq([output, '', 0])
     end
   end
 end

--- a/spec/lib/packaging/util/file_spec.rb
+++ b/spec/lib/packaging/util/file_spec.rb
@@ -1,112 +1,146 @@
 require 'spec_helper'
 
-describe "Pkg::Util::File" do
-  let(:source)     { "/tmp/placething.tar.gz" }
-  let(:target)     { "/tmp" }
-  let(:options)    { "--thing-for-tar" }
-  let(:tar)        { "/usr/bin/tar" }
-  let(:files)      { ["foo.rb", "foo/bar.rb"] }
-  let(:symlinks)   { ["bar.rb"] }
-  let(:dirs)       { ["foo"] }
-  let(:empty_dirs) { ["bar"] }
+describe 'Pkg::Util::File' do
+  let(:source)     { '/tmp/placething.tar.gz' }
+  let(:target)     { '/tmp' }
+  let(:options)    { '--thing-for-tar' }
+  let(:tar)        { '/usr/bin/tar' }
+  let(:files)      { ['foo.rb', 'foo/bar.rb'] }
+  let(:symlinks)   { ['bar.rb'] }
+  let(:dirs)       { ['foo'] }
+  let(:empty_dirs) { ['bar'] }
 
 
-  describe "#untar_into" do
+  describe '#untar_into' do
     before :each do
-      Pkg::Util::Tool.stub(:find_tool).with('tar', :required => true) { tar }
+      allow(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('tar', required: true)
+        .and_return(tar)
     end
 
-    it "raises an exception if the source doesn't exist" do
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}).and_raise(RuntimeError)
-      Pkg::Util::Execution.should_not_receive(:capture3)
+    it 'raises an exception if the source doesn\'t exist' do
+      expect(Pkg::Util::File)
+        .to receive(:file_exists?)
+        .with(source, { required: true })
+        .and_raise(RuntimeError)
+      expect(Pkg::Util::Execution).not_to receive(:capture3)
       expect { Pkg::Util::File.untar_into(source) }.to raise_error(RuntimeError)
     end
 
-    it "unpacks the tarball to the current directory if no target is passed" do
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar}   -xf #{source}")
+    it 'unpacks the tarball to the current directory if no target is passed' do
+      expect(Pkg::Util::File)
+        .to receive(:file_exists?)
+          .with(source, { required: true }) { true }
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{tar}   -xf #{source}")
       Pkg::Util::File.untar_into(source)
     end
 
-    it "unpacks the tarball to the current directory with options if no target is passed" do
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar} #{options}  -xf #{source}")
+    it 'unpacks the tarball to the current directory with options if no target is passed' do
+      expect(Pkg::Util::File)
+        .to receive(:file_exists?)
+          .with(source, { required: true }) { true }
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{tar} #{options}  -xf #{source}")
       Pkg::Util::File.untar_into(source, nil, options)
     end
 
-    it "unpacks the tarball into the target" do
-      File.stub(:capture3ist?).with(source) { true }
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::File.should_receive(:file_writable?).with(target) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar}  -C #{target} -xf #{source}")
+    it 'unpacks the tarball into the target' do
+      allow(File).to receive(:capture3ist?).with(source).and_return(true)
+      expect(Pkg::Util::File).to receive(:file_exists?).with(source, { required: true }) { true }
+      expect(Pkg::Util::File).to receive(:file_writable?).with(target) { true }
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{tar}  -C #{target} -xf #{source}")
       Pkg::Util::File.untar_into(source, target)
     end
 
     it "unpacks the tarball into the target with options passed" do
-      File.stub(:capture3ist?).with(source) { true }
-      Pkg::Util::File.should_receive(:file_exists?).with(source, {:required => true}) { true }
-      Pkg::Util::File.should_receive(:file_writable?).with(target) { true }
-      Pkg::Util::Execution.should_receive(:capture3).with("#{tar} #{options} -C #{target} -xf #{source}")
+      allow(File).to receive(:capture3ist?).with(source).and_return(true)
+      expect(Pkg::Util::File).to receive(:file_exists?).with(source, { required: true }) { true }
+      expect(Pkg::Util::File).to receive(:file_writable?).with(target) { true }
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{tar} #{options} -C #{target} -xf #{source}")
       Pkg::Util::File.untar_into(source, target, options)
     end
   end
 
-  describe "#files_with_ext" do
-    it "returns nothing if there are no files with that extension" do
-      Pkg::Util::File.files_with_ext("./spec/fixtures/configs/components", ".fake").should be_empty
+  describe '#files_with_ext' do
+    it 'returns nothing if there are no files with that extension' do
+      expect(Pkg::Util::File.files_with_ext('./spec/fixtures/configs/components', '.fake'))
+        .to be_empty
     end
 
-    it "returns only the files with that extension" do
-      expect(Pkg::Util::File.files_with_ext("./spec/fixtures/configs/components", ".json")).to include("./spec/fixtures/configs/components/test_file.json")
-      expect(Pkg::Util::File.files_with_ext("./spec/fixtures/configs/components", ".json")).to include("./spec/fixtures/configs/components/test_file_2.json")
+    it 'returns only the files with that extension' do
+      expect(Pkg::Util::File.files_with_ext('./spec/fixtures/configs/components', '.json'))
+        .to include('./spec/fixtures/configs/components/test_file.json')
+      expect(Pkg::Util::File.files_with_ext('./spec/fixtures/configs/components', '.json'))
+        .to include('./spec/fixtures/configs/components/test_file_2.json')
     end
   end
 
-  describe "#install_files_into_dir" do
-    it "selects the correct files to install" do
+  describe '#install_files_into_dir' do
+    it 'selects the correct files to install' do
       Pkg::Config.load_defaults
       workdir = Pkg::Util::File.mktemp
       patterns = []
 
-      # Set up a bunch of default settings for these to avoid a lot more stubbing in each section below
-      File.stub(:file?) { false }
-      File.stub(:symlink?) { false }
-      File.stub(:directory?) { false }
-      Pkg::Util::File.stub(:empty_dir?) { false }
+      allow(File).to receive(:file?).and_return(false)
+      allow(File).to receive(:symlink?).and_return(false)
+      allow(File).to receive(:directory?).and_return(false)
+      allow(Pkg::Util::File).to receive(:empty_dir?).and_return(false)
 
       # Files should have the path made and should be copied
       files.each do |file|
-        File.stub(:file?).with(file).and_return(true)
-        Dir.stub(:[]).with(file).and_return(file)
-        FileUtils.should_receive(:mkpath).with(File.dirname(File.join(workdir, file)), :verbose => false)
-        FileUtils.should_receive(:cp).with(file, File.join(workdir, file), :verbose => false, :preserve => true)
+        allow(File).to receive(:file?).with(file).and_return(true)
+        allow(Dir).to receive(:[]).with(file).and_return(file)
+        expect(FileUtils)
+          .to receive(:mkpath)
+          .with(File.dirname(File.join(workdir, file)), verbose: false)
+        expect(FileUtils)
+          .to receive(:cp)
+          .with(file, File.join(workdir, file), verbose: false, preserve: true)
         patterns << file
       end
 
       # Symlinks should have the path made and should be copied
       symlinks.each do |file|
-        File.stub(:symlink?).with(file).and_return(true)
-        Dir.stub(:[]).with(file).and_return(file)
-        FileUtils.should_receive(:mkpath).with(File.dirname(File.join(workdir, file)), :verbose => false)
-        FileUtils.should_receive(:cp).with(file, File.join(workdir, file), :verbose => false, :preserve => true)
+        allow(File).to receive(:symlink?).with(file).and_return(true)
+        allow(Dir).to receive(:[]).with(file).and_return(file)
+        expect(FileUtils)
+          .to receive(:mkpath)
+          .with(File.dirname(File.join(workdir, file)), verbose: false)
+        expect(FileUtils)
+          .to receive(:cp)
+          .with(file, File.join(workdir, file), verbose: false, preserve: true)
         patterns << file
       end
 
-      # Dirs should be added to patterns but no acted upon
+      # Dirs should be added to patterns but not acted upon
       dirs.each do |dir|
-        File.stub(:directory?).with(dir).and_return(true)
-        Dir.stub(:[]).with("#{dir}/**/*").and_return(dir)
-        FileUtils.should_not_receive(:mkpath).with(File.dirname(File.join(workdir, dir)), :verbose => false)
-        FileUtils.should_not_receive(:cp).with(dir, File.join(workdir, dir), :verbose => false, :preserve => true)
+        allow(File).to receive(:directory?).with(dir).and_return(true)
+        allow(Dir).to receive(:[]).with("#{dir}/**/*").and_return(dir)
+        expect(FileUtils)
+          .not_to receive(:mkpath)
+          .with(File.dirname(File.join(workdir, dir)), verbose: false)
+        expect(FileUtils)
+          .not_to receive(:cp)
+          .with(dir, File.join(workdir, dir), verbose: false, preserve: true)
         patterns << dir
       end
 
       # Empty dirs should have the path created and nothing copied
       empty_dirs.each do |dir|
-        Pkg::Util::File.stub(:empty_dir?).with(dir).and_return(true)
-        Dir.stub(:[]).with(dir).and_return(dir)
-        FileUtils.should_receive(:mkpath).with(File.join(workdir, dir), :verbose => false)
-        FileUtils.should_not_receive(:cp).with(dir, File.join(workdir, dir), :verbose => false, :preserve => true)
+        allow(Pkg::Util::File).to receive(:empty_dir?).with(dir).and_return(true)
+        allow(Dir).to receive(:[]).with(dir).and_return(dir)
+        expect(FileUtils)
+          .to receive(:mkpath)
+          .with(File.join(workdir, dir), verbose: false)
+        expect(FileUtils)
+          .not_to receive(:cp)
+          .with(dir, File.join(workdir, dir), verbose: false, preserve: true)
         patterns << dir
       end
 
@@ -115,25 +149,28 @@ describe "Pkg::Util::File" do
     end
   end
 
-  describe "#directories" do
-    it "returns nil if there is no directory" do
-      File.should_receive(:directory?).with("/tmp").and_return(false)
-      Pkg::Util::File.directories("/tmp").should be_nil
+  describe '#directories' do
+    it 'returns nil if there is no directory' do
+      expect(File).to receive(:directory?).with('/tmp').and_return(false)
+      expect(Pkg::Util::File.directories('/tmp')).to be_nil
     end
 
-    it "returns the empty array if there are no dirs in the directory" do
-      File.should_receive(:directory?).with("/tmp").and_return(true)
-      Dir.should_receive(:glob).with("*").and_return([])
-      Pkg::Util::File.directories("/tmp").should be_empty
+    it 'returns the empty array if there are no dirs in the directory' do
+      expect(File).to receive(:directory?).with('/tmp').and_return(true)
+      expect(Dir).to receive(:glob).with('*').and_return([])
+      expect(Pkg::Util::File.directories("/tmp")).to be_empty
     end
 
-    it "returns an array of the top level directories inside a directory" do
-      File.stub(:directory?) { false }
-      ["/tmp", "/tmp/dir", "/tmp/other_dir"].each do |dir|
-        File.should_receive(:directory?).with(dir).and_return(true)
+    it 'returns an array of the top level directories inside a directory' do
+      allow(File).to receive(:directory?).and_return(false)
+      ['/tmp', '/tmp/dir', '/tmp/other_dir'].each do |dir|
+        expect(File).to receive(:directory?).with(dir).and_return(true)
       end
-      Dir.should_receive(:glob).with("*").and_return(["/tmp/file", "/tmp/dir", "/tmp/other_dir"])
-      Pkg::Util::File.directories("/tmp").should eq(["/tmp/dir", "/tmp/other_dir"])
+      expect(Dir)
+        .to receive(:glob)
+        .with('*')
+        .and_return(['/tmp/file', '/tmp/dir', '/tmp/other_dir'])
+      expect(Pkg::Util::File.directories('/tmp')).to eq(['/tmp/dir', '/tmp/other_dir'])
     end
   end
 end

--- a/spec/lib/packaging/util/gpg_spec.rb
+++ b/spec/lib/packaging/util/gpg_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe "Pkg::Util::Gpg" do
-  let(:gpg)      { "/local/bin/gpg" }
-  let(:keychain) { "/usr/local/bin/keychain" }
-  let(:gpg_key)  { "abcd1234" }
-  let(:target_file) { "/tmp/file" }
+describe 'Pkg::Util::Gpg' do
+  let(:gpg)      { '/local/bin/gpg' }
+  let(:keychain) { '/usr/local/bin/keychain' }
+  let(:gpg_key)  { 'abcd1234' }
+  let(:target_file) { '/tmp/file' }
 
   before(:each) do
     reset_env(['RPM_GPG_AGENT'])
@@ -12,36 +12,37 @@ describe "Pkg::Util::Gpg" do
   end
 
   describe '#key' do
-    it "fails if Pkg::Config.gpg_key isn't set" do
+    it 'fails if Pkg::Config.gpg_key isn\'t set' do
       allow(Pkg::Config).to receive(:gpg_key).and_return(nil)
       expect { Pkg::Util::Gpg.key }.to raise_error(RuntimeError)
     end
-    it "fails if Pkg::Config.gpg_key is an empty string" do
+    it 'fails if Pkg::Config.gpg_key is an empty string' do
       allow(Pkg::Config).to receive(:gpg_key).and_return('')
       expect { Pkg::Util::Gpg.key }.to raise_error(RuntimeError)
     end
   end
 
   describe '#kill_keychain' do
-    it "doesn't reload the keychain if already loaded" do
+    it 'doesn\'t reload the keychain if already loaded' do
       Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", true)
-      Pkg::Util::Gpg.should_receive(:kill_keychain).never
-      Pkg::Util::Gpg.should_receive(:start_keychain).never
+
+      expect(Pkg::Util::Gpg).not_to receive(:kill_keychain)
+      expect(Pkg::Util::Gpg).not_to receive(:start_keychain)
       Pkg::Util::Gpg.load_keychain
       Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", nil)
     end
 
     it "doesn't reload the keychain if ENV['RPM_GPG_AGENT'] is set" do
       ENV['RPM_GPG_AGENT'] = 'blerg'
-      Pkg::Util::Gpg.should_receive(:kill_keychain).never
-      Pkg::Util::Gpg.should_receive(:start_keychain).never
+      expect(Pkg::Util::Gpg).not_to receive(:kill_keychain)
+      expect(Pkg::Util::Gpg).not_to receive(:start_keychain)
       Pkg::Util::Gpg.load_keychain
     end
 
     it 'kills and starts the keychain if not loaded already' do
       Pkg::Util::Gpg.instance_variable_set("@keychain_loaded", nil)
-      Pkg::Util::Gpg.should_receive(:kill_keychain).once
-      Pkg::Util::Gpg.should_receive(:start_keychain).once
+      expect(Pkg::Util::Gpg).to receive(:kill_keychain).once
+      expect(Pkg::Util::Gpg).to receive(:start_keychain).once
       Pkg::Util::Gpg.load_keychain
     end
   end
@@ -49,15 +50,19 @@ describe "Pkg::Util::Gpg" do
   describe '#sign_file' do
     it 'adds special flags if RPM_GPG_AGENT is set' do
       ENV['RPM_GPG_AGENT'] = 'blerg'
-      additional_flags = "--no-tty --use-agent"
-      Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{gpg}\s#{additional_flags}\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      additional_flags = '--no-tty --use-agent'
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('gpg').and_return(gpg)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{gpg}\s#{additional_flags}\s--armor --detach-sign -u #{gpg_key} #{target_file}")
       Pkg::Util::Gpg.sign_file(target_file)
     end
 
     it 'signs without extra flags when RPM_GPG_AGENT is not set' do
-      Pkg::Util::Tool.should_receive(:find_tool).with('gpg').and_return(gpg)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{gpg}\s\s--armor --detach-sign -u #{gpg_key} #{target_file}")
+      expect(Pkg::Util::Tool).to receive(:find_tool).with('gpg').and_return(gpg)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{gpg}\s\s--armor --detach-sign -u #{gpg_key} #{target_file}")
       Pkg::Util::Gpg.sign_file(target_file)
     end
   end

--- a/spec/lib/packaging/util/jenkins_spec.rb
+++ b/spec/lib/packaging/util/jenkins_spec.rb
@@ -1,9 +1,10 @@
 # -*- ruby -*-
 require 'spec_helper'
+require 'json'
 
 describe Pkg::Util::Jenkins do
-  let(:build_host) {"Jenkins-foo"}
-  let(:name) {"job-foo"}
+  let(:build_host) { 'Jenkins-foo' }
+  let(:name) { 'job-foo' }
   around do |example|
     old_build_host = Pkg::Config.jenkins_build_host
     Pkg::Config.jenkins_build_host = build_host
@@ -11,51 +12,77 @@ describe Pkg::Util::Jenkins do
     Pkg::Config.jenkins_build_host = old_build_host
   end
 
-  describe "#create_jenkins_job" do
-    let(:xml_file) {"bar.xml"}
+  describe '#create_jenkins_job' do
+    let(:xml_file) { 'bar.xml' }
 
-    it "should call curl_form_data with the correct arguments" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/createItem?name=#{name}", ["-H", '"Content-Type: application/xml"', "--data-binary", "@#{xml_file}"])
+    it 'should call curl_form_data with the correct arguments' do
+      expect(Pkg::Util::Net)
+        .to receive(:curl_form_data)
+        .with("http://#{build_host}/createItem?name=#{name}",
+              ['-H', '"Content-Type: application/xml"',
+               '--data-binary',
+               "@#{xml_file}"])
       Pkg::Util::Jenkins.create_jenkins_job(name, xml_file)
     end
   end
 
-  describe "#jenkins_job_exists?" do
-
-    it "should call curl_form_data with correct arguments" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
+  describe '#jenkins_job_exists?' do
+    it 'should call curl_form_data with correct arguments' do
+      expect(Pkg::Util::Net)
+        .to receive(:curl_form_data)
+        .with("http://#{build_host}/job/#{name}/config.xml",
+              ['--silent', '--fail'],
+              quiet: true)
+        .and_return(['output', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
       Pkg::Util::Jenkins.jenkins_job_exists?(name)
     end
 
-    it "should return false on job not existing" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 1])
-      Pkg::Util::Execution.should_receive(:success?).and_return(false)
-      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
+    it 'should return false on job not existing' do
+      expect(Pkg::Util::Net)
+        .to receive(:curl_form_data)
+        .with("http://#{build_host}/job/#{name}/config.xml",
+              ['--silent', '--fail'],
+              quiet: true)
+        .and_return(['output', 1])
+      expect(Pkg::Util::Execution)
+        .to receive(:success?)
+        .and_return(false)
+      expect(Pkg::Util::Jenkins.jenkins_job_exists?(name)).to be false
     end
 
-    it "should return false if curl_form_data raised a runtime error" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(false)
-      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_false
+    it 'should return false if curl_form_data raised a runtime error' do
+      expect(Pkg::Util::Net)
+        .to receive(:curl_form_data)
+        .with("http://#{build_host}/job/#{name}/config.xml",
+              ['--silent', '--fail'],
+              quiet: true)
+        .and_return(false)
+      expect(Pkg::Util::Jenkins.jenkins_job_exists?(name)).to be false
     end
 
-    it "should return true when job exists" do
-      Pkg::Util::Net.should_receive(:curl_form_data).with("http://#{build_host}/job/#{name}/config.xml", ["--silent", "--fail"], :quiet => true).and_return(['output', 0])
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
-      Pkg::Util::Jenkins.jenkins_job_exists?(name).should be_true
+    it 'should return true when job exists' do
+      expect(Pkg::Util::Net)
+        .to receive(:curl_form_data)
+        .with("http://#{build_host}/job/#{name}/config.xml",
+              ['--silent', '--fail'],
+              quiet: true)
+        .and_return(['output', 0])
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      expect(Pkg::Util::Jenkins.jenkins_job_exists?(name)).to be true
     end
   end
 
   describe '#poll_jenkins_job' do
-    let(:job_url) { "http://cat.meow/" }
+    let(:job_url) { 'http://cat.meow' }
     let(:build_url) { "#{job_url}/1" }
-    let(:result) { "SUCCESS" }
-    let(:job_hash) { {'lastBuild' => { 'url' => build_url } }}
-    let(:build_hash) { {'result' => result, 'building' => false } }
+    let(:result) { 'SUCCESS' }
+    let(:job_hash) { { 'lastBuild' => { 'url' => build_url } } }
+    let(:build_hash) { { 'result' => result, 'building' => false } }
 
     before :each do
-      subject.stub(:get_jenkins_info).with(job_url).and_return(job_hash)
-      subject.stub(:wait_for_build).with(build_url).and_return(build_hash)
+      allow(subject).to receive(:get_jenkins_info).with(job_url).and_return(job_hash)
+      allow(subject).to receive(:wait_for_build).with(build_url).and_return(build_hash)
     end
 
     context "when polling the given url" do
@@ -66,47 +93,51 @@ describe Pkg::Util::Jenkins do
   end
 
   describe '#wait_for_build' do
-    let(:job_url) { "http://cat.meow/" }
+    let(:job_url) { 'http://cat.meow' }
     let(:build_url) { "#{job_url}/1" }
-    let(:build_hash) { {'building' => false } }
+    let(:build_hash) { { 'building' => false } }
 
     context "when waiting for the given build to finish" do
       it "return the resulting build_hash when build completes successfully" do
-        subject.should_receive(:get_jenkins_info).with(job_url).and_return(build_hash)
+        expect(subject).to receive(:get_jenkins_info).with(job_url).and_return(build_hash)
         subject.wait_for_build(job_url)
       end
     end
   end
 
   describe '#get_jenkins_info' do
-    let(:url) { "http://cat.meow/" }
+    let(:url) { 'http://cat.meow' }
     let(:uri) { URI(url) }
     let(:response) { double }
-    let(:valid_json) { "{\"employees\":[
-    {\"firstName\":\"John\", \"lastName\":\"Doe\"},
-    {\"firstName\":\"Anna\", \"lastName\":\"Smith\"},
-    {\"firstName\":\"Peter\", \"lastName\":\"Jones\"} ]}" }
-
-    before :each do
-      response.stub(:body).and_return( valid_json )
-      response.stub(:code).and_return( '200' )
-      Pkg::Util::Jenkins.should_receive(:URI).and_return(uri)
+    let(:valid_json) do
+      {
+        'employees' => [
+          { 'firstName' => 'John', 'lastName' => 'Doe' },
+          { 'firstName' => 'Anna', 'lastName' => 'Smith' },
+          { 'firstName' => 'Peter', 'lastName' => 'Jones' }
+        ]
+      }.to_json
     end
 
-    context "when making HTTP GET request to given url" do
-      it "should return Hash of JSON contents when response is non-error" do
-        Net::HTTP.should_receive(:get_response).with(uri).and_return(response)
+    before :each do
+      allow(response).to receive(:body).and_return(valid_json)
+      allow(response).to receive(:code).and_return('200')
+      expect(Pkg::Util::Jenkins).to receive(:URI).and_return(uri)
+    end
+
+    context 'when making HTTP GET request to given url' do
+      it 'should return Hash of JSON contents when response is non-error' do
+        expect(Net::HTTP).to receive(:get_response).with(uri).and_return(response)
         subject.get_jenkins_info(url)
       end
 
-      it "should raise Runtime error when response is error" do
-        response.stub(:code).and_return( '400' )
-        Net::HTTP.should_receive(:get_response).with(uri).and_return(response)
-        expect{
+      it 'should raise Runtime error when response is error' do
+        allow(response).to receive(:code).and_return('400')
+        expect(Net::HTTP).to receive(:get_response).with(uri).and_return(response)
+        expect do
           subject.get_jenkins_info(url)
-        }.to raise_error(Exception, /Unable to query .*, please check that it is valid./)
+        end.to raise_error(Exception, /Unable to query .*, please check that it is valid./)
       end
     end
   end
-
 end

--- a/spec/lib/packaging/util/misc_spec.rb
+++ b/spec/lib/packaging/util/misc_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe 'Pkg::Util::Misc' do
-  context "#search_and_replace" do
+  context '#search_and_replace' do
     let(:orig_string) { "#!/bin/bash\necho '__REPO_NAME__'" }
     let(:updated_string) { "#!/bin/bash\necho 'abcdefg'" }
     let(:good_replacements) do
@@ -13,19 +13,24 @@ describe 'Pkg::Util::Misc' do
     end
 
     it 'replaces the token with the Pkg::Config variable' do
-      Pkg::Config.config_from_hash({:project => "foo", :repo_name => 'abcdefg'})
-      Pkg::Util::Misc.search_and_replace(orig_string, good_replacements).should eq(updated_string)
+      Pkg::Config.config_from_hash({ project: 'foo', repo_name: 'abcdefg' })
+      expect(Pkg::Util::Misc.search_and_replace(orig_string, good_replacements))
+        .to eq(updated_string)
     end
 
     it 'does no replacement if the Pkg::Config variable is not set' do
-      Pkg::Config.config_from_hash({:project => 'foo',})
-      Pkg::Util::Misc.search_and_replace(orig_string, good_replacements).should eq(orig_string)
+      Pkg::Config.config_from_hash({ project: 'foo' })
+      expect(Pkg::Util::Misc.search_and_replace(orig_string, good_replacements))
+        .to eq(orig_string)
     end
 
     it 'warns and continues if the Pkg::Config variable is unknown to packaging' do
-      Pkg::Config.config_from_hash({:project => 'foo',})
-      Pkg::Util::Misc.should_receive(:warn).with("replacement value for '#{warn_replacements.keys.first}' probably shouldn't be nil")
-      Pkg::Util::Misc.search_and_replace(orig_string, warn_replacements).should eq(orig_string)
+      Pkg::Config.config_from_hash({ project: 'foo' })
+      expect(Pkg::Util::Misc)
+        .to receive(:warn)
+        .with("replacement value for '#{warn_replacements.keys.first}' probably shouldn't be nil")
+      expect(Pkg::Util::Misc.search_and_replace(orig_string, warn_replacements))
+        .to eq(orig_string)
     end
   end
 end

--- a/spec/lib/packaging/util/net_spec.rb
+++ b/spec/lib/packaging/util/net_spec.rb
@@ -2,255 +2,296 @@ require 'spec_helper'
 require 'socket'
 require 'open3'
 
-describe "Pkg::Util::Net" do
-  let(:target)     { "/tmp/placething" }
-  let(:target_uri) { "http://google.com" }
-  let(:content)    { "stuff" }
-  let(:rsync)      { "/bin/rsync" }
-  let(:ssh)        { "/usr/local/bin/ssh" }
-  let(:s3cmd)      { "/usr/local/bin/s3cmd" }
+describe 'Pkg::Util::Net' do
+  let(:target)     { '/tmp/placething' }
+  let(:target_uri) { 'http://google.com' }
+  let(:content)    { 'stuff' }
+  let(:rsync)      { '/bin/rsync' }
+  let(:ssh)        { '/usr/local/bin/ssh' }
+  let(:s3cmd)      { '/usr/local/bin/s3cmd' }
 
-  describe "#fetch_uri" do
-    context "given a target directory" do
-      it "does nothing if the directory isn't writable" do
-        File.stub(:writable?).with(File.dirname(target)) { false }
-        File.should_receive(:open).never
+  describe '#fetch_uri' do
+    context 'given a target directory' do
+      it 'does nothing if the directory isn\'t writable' do
+        allow(File).to receive(:writable?).with(File.dirname(target)).and_return(false)
+        expect(File).not_to receive(:open)
         Pkg::Util::Net.fetch_uri(target_uri, target)
       end
 
-      it "writes the content of the uri to a file if directory is writable" do
-        File.should_receive(:writable?).once.with(File.dirname(target)) { true }
-        File.should_receive(:open).once.with(target, 'w')
+      it 'writes the content of the uri to a file if directory is writable' do
+        expect(File).to receive(:writable?).once.with(File.dirname(target)) { true }
+        expect(File).to receive(:open).once.with(target, 'w')
         Pkg::Util::Net.fetch_uri(target_uri, target)
       end
     end
   end
 
-  describe "hostname utils" do
-
-    describe "hostname" do
-      it "should return the hostname of the current host" do
-        Socket.stub(:gethostname) { "foo" }
-        Pkg::Util::Net.hostname.should eq("foo")
+  describe 'hostname utils' do
+    describe 'hostname' do
+      it 'should return the hostname of the current host' do
+        allow(Socket).to receive(:gethostname).and_return('foo')
+        expect(Pkg::Util::Net.hostname).to eq('foo')
       end
     end
 
-    describe "check_host" do
-      context "with required :true" do
-        it "should raise an exception if the passed host does not match the current host" do
-          Socket.stub(:gethostname) { "foo" }
-          Pkg::Util::Net.should_receive(:check_host).and_raise(RuntimeError)
-          expect{ Pkg::Util::Net.check_host("bar", :required => true) }.to raise_error(RuntimeError)
+    describe 'check_host' do
+      context 'with required :true' do
+        it 'should raise an exception if the passed host does not match the current host' do
+          allow(Socket).to receive(:gethostname).and_return('foo')
+          expect(Pkg::Util::Net).to receive(:check_host).and_raise(RuntimeError)
+          expect { Pkg::Util::Net.check_host('bar', required: true) }.to raise_error(RuntimeError)
         end
       end
 
-      context "with required :false" do
-        it "should return nil if the passed host does not match the current host" do
-          Socket.stub(:gethostname) { "foo" }
-          Pkg::Util::Net.check_host("bar", :required => false).should be_nil
+      context 'with required :false' do
+        it 'should return nil if the passed host does not match the current host' do
+          allow(Socket).to receive(:gethostname).and_return('foo')
+          expect(Pkg::Util::Net.check_host('bar', required: false)).to be_nil
         end
       end
     end
   end
 
-  describe "remote_ssh_cmd" do
-    it "should be able to call via deprecated shim" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
-      Pkg::Util::Execution.should_receive(:success?).and_return(true)
-      Pkg::Util::Net.remote_ssh_cmd("foo", "bar", true)
+  describe 'remote_ssh_cmd' do
+    it 'should be able to call via deprecated shim' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      Pkg::Util::Net.remote_ssh_cmd('foo', 'bar', true)
     end
   end
 
-  describe "remote_execute" do
-    it "should fail if ssh is not present" do
-      Pkg::Util::Tool.stub(:find_tool).with("ssh") { fail }
-      Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_raise(RuntimeError)
-      expect{ Pkg::Util::Net.remote_execute("foo", "bar") }.to raise_error(RuntimeError)
+  describe 'remote_execute' do
+    it 'should fail if ssh is not present' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('ssh').and_raise(RuntimeError)
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_raise(RuntimeError)
+      expect { Pkg::Util::Net.remote_execute('foo', 'bar') }.to raise_error(RuntimeError)
     end
 
-    it "should be able to not fail fast" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute(
-          "foo", "bar", capture_output: false, extra_options: '', fail_fast: false)
+    it 'should be able to not fail fast' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+      expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'bar'")
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      Pkg::Util::Net.remote_execute(
+        'foo', 'bar', capture_output: false, extra_options: '', fail_fast: false
+      )
     end
 
-    it "should be able to trace output" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -x;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute(
-          "foo", "bar", capture_output: false, fail_fast: false, trace: true)
+    it 'should be able to trace output' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+      expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -x;bar'")
+      expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+      Pkg::Util::Net.remote_execute(
+        'foo', 'bar', capture_output: false, fail_fast: false, trace: true
+      )
     end
 
-    context "without output captured" do
-      it "should execute a command :foo on a host :bar using Kernel" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "bar")
+    context 'without output captured' do
+      it 'should execute a command :foo on a host :bar using Kernel' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with("ssh").and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', 'bar')
       end
 
-      it "should escape single quotes in the command" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "b'ar")
+      it 'should escape single quotes in the command' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', "b'ar")
       end
 
-      it "should raise an error if ssh fails" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Kernel.should_receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(false)
-        expect{ Pkg::Util::Net.remote_execute("foo", "bar") }
+      it 'should raise an error if ssh fails' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with("ssh").and_return(ssh)
+        expect(Kernel).to receive(:system).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(false)
+        expect { Pkg::Util::Net.remote_execute('foo', 'bar') }
           .to raise_error(RuntimeError, /failed./)
       end
     end
 
-    context "with output captured" do
-      it "should execute a command :foo on a host :bar using Pkg::Util::Execution.capture3" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "bar", capture_output: true)
+    context 'with output captured' do
+      it 'should execute a command :foo on a host :bar using Pkg::Util::Execution.capture3' do
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', 'bar', capture_output: true)
       end
 
       it "should escape single quotes in the command" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(true)
-        Pkg::Util::Net.remote_execute("foo", "b'ar", capture_output: true)
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;b'\\''ar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(true)
+        Pkg::Util::Net.remote_execute('foo', "b'ar", capture_output: true)
       end
 
       it "should raise an error if ssh fails" do
-        Pkg::Util::Tool.should_receive(:check_tool).with("ssh").and_return(ssh)
-        Pkg::Util::Execution.should_receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
-        Pkg::Util::Execution.should_receive(:success?).and_return(false)
-        expect{ Pkg::Util::Net.remote_execute("foo", "bar", capture_output: true) }
+        expect(Pkg::Util::Tool).to receive(:check_tool).with('ssh').and_return(ssh)
+        expect(Pkg::Util::Execution).to receive(:capture3).with("#{ssh}  -t foo 'set -e;bar'")
+        expect(Pkg::Util::Execution).to receive(:success?).and_return(false)
+        expect { Pkg::Util::Net.remote_execute('foo', 'bar', capture_output: true) }
           .to raise_error(RuntimeError, /failed./)
       end
     end
   end
 
-  describe "#rsync_to" do
-    defaults = "--recursive --hard-links --links --verbose --omit-dir-times --no-perms --no-owner --no-group"
-    it "should fail if rsync is not present" do
-      Pkg::Util::Tool.stub(:find_tool).with("rsync") { fail }
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_raise(RuntimeError)
-      expect{ Pkg::Util::Net.rsync_to("foo", "bar", "boo") }.to raise_error(RuntimeError)
+  describe '#rsync_to' do
+    defaults = '--recursive --hard-links --links --verbose --omit-dir-times --no-perms --no-owner --no-group'
+    it 'should fail if rsync is not present' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('rsync').and_raise(RuntimeError)
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_raise(RuntimeError)
+      expect { Pkg::Util::Net.rsync_to('foo', 'bar', 'boo') }.to raise_error(RuntimeError)
     end
 
     it "should rsync 'thing' to 'foo@bar:/home/foo' with flags '#{defaults} --ignore-existing'" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --ignore-existing thing foo@bar:/home/foo", true)
-      Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{rsync} #{defaults} --ignore-existing thing foo@bar:/home/foo", true)
+      Pkg::Util::Net.rsync_to('thing', 'foo@bar', '/home/foo')
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include --ignore-existing" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} thing foo@bar:/home/foo", true)
-      Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", extra_flags: [])
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{rsync} #{defaults} thing foo@bar:/home/foo", true)
+      Pkg::Util::Net.rsync_to('thing', 'foo@bar', '/home/foo', extra_flags: [])
     end
 
     it "rsyncs 'thing' to 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag thing foo@bar:/home/foo", true)
-      Pkg::Util::Net.rsync_to("thing", "foo@bar", "/home/foo", extra_flags: ["--foo-bar", "--and-another-flag"])
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{rsync} #{defaults} --foo-bar --and-another-flag thing foo@bar:/home/foo", true)
+      Pkg::Util::Net.rsync_to('thing', 'foo@bar', '/home/foo',
+                              extra_flags: ["--foo-bar", "--and-another-flag"])
     end
   end
 
-  describe "#s3sync_to" do
-    it "should fail if s3cmd is not present" do
-      Pkg::Util::Tool.should_receive(:find_tool).with('s3cmd', :required => true).and_raise(RuntimeError)
-      Pkg::Util::Execution.should_not_receive(:capture3).with("#{s3cmd} sync  'foo' s3://bar/boo/")
-      expect{ Pkg::Util::Net.s3sync_to("foo", "bar", "boo") }.to raise_error(RuntimeError)
+  describe '#s3sync_to' do
+    it 'should fail if s3cmd is not present' do
+      expect(Pkg::Util::Tool)
+        .to receive(:find_tool)
+        .with('s3cmd', required: true)
+        .and_raise(RuntimeError)
+      expect(Pkg::Util::Execution)
+        .to_not receive(:capture3).with("#{s3cmd} sync  'foo' s3://bar/boo/")
+      expect { Pkg::Util::Net.s3sync_to('foo', 'bar', 'boo') }.to raise_error(RuntimeError)
     end
 
-    it "should fail if ~/.s3cfg is not present" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
-      Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(false)
-      expect{ Pkg::Util::Net.s3sync_to("foo", "bar", "boo") }.to raise_error(RuntimeError, /does not exist/)
+    it 'should fail if ~/.s3cfg is not present' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with("s3cmd").and_return(s3cmd)
+      expect(Pkg::Util::File)
+        .to receive(:file_exists?)
+        .with(File.join(ENV['HOME'], '.s3cfg'))
+        .and_return(false)
+      expect { Pkg::Util::Net.s3sync_to('foo', 'bar', 'boo') }
+        .to raise_error(RuntimeError, /does not exist/)
     end
 
     it "should s3 sync 'thing' to 's3://foo@bar/home/foo/' with no flags" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
-      Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{s3cmd} sync  'thing' s3://foo@bar/home/foo/")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with("s3cmd").and_return(s3cmd)
+      expect(Pkg::Util::File)
+        .to receive(:file_exists?)
+        .with(File.join(ENV['HOME'], '.s3cfg'))
+        .and_return(true)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{s3cmd} sync  'thing' s3://foo@bar/home/foo/")
       Pkg::Util::Net.s3sync_to("thing", "foo@bar", "home/foo")
     end
 
-    it "should s3 sync 'thing' to 's3://foo@bar/home/foo/' with --delete-removed and --acl-public" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("s3cmd").and_return(s3cmd)
-      Pkg::Util::File.should_receive(:file_exists?).with(File.join(ENV['HOME'], '.s3cfg')).and_return(true)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{s3cmd} sync --delete-removed --acl-public 'thing' s3://foo@bar/home/foo/")
+    it "should s3sync 'thing' to 's3://foo@bar/home/foo/' with --delete-removed and --acl-public" do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with("s3cmd").and_return(s3cmd)
+      expect(Pkg::Util::File)
+        .to receive(:file_exists?)
+        .with(File.join(ENV['HOME'], '.s3cfg'))
+        .and_return(true)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{s3cmd} sync --delete-removed --acl-public 'thing' s3://foo@bar/home/foo/")
       Pkg::Util::Net.s3sync_to("thing", "foo@bar", "home/foo", ["--delete-removed", "--acl-public"])
     end
   end
 
-  describe "#rsync_from" do
+  describe '#rsync_from' do
     defaults = "--recursive --hard-links --links --verbose --omit-dir-times --no-perms --no-owner --no-group"
-    it "should fail if rsync is not present" do
-      Pkg::Util::Tool.stub(:find_tool).with("rsync") { fail }
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_raise(RuntimeError)
-      expect{ Pkg::Util::Net.rsync_from("foo", "bar", "boo") }.to raise_error(RuntimeError)
+    it 'should fail if rsync is not present' do
+      allow(Pkg::Util::Tool).to receive(:find_tool).with('rsync').and_raise(RuntimeError)
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_raise(RuntimeError)
+      expect { Pkg::Util::Net.rsync_from('foo', 'bar', 'boo') }.to raise_error(RuntimeError)
     end
 
-    it "should not include the flags '--ignore-existing' by default" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
-      Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
+    it 'should not include the flags \'--ignore-existing\' by default' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
+      Pkg::Util::Net.rsync_from('thing', 'foo@bar', '/home/foo')
     end
 
     it "should rsync 'thing' from 'foo@bar' to '/home/foo' with flags '#{defaults}'" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
-      Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{rsync} #{defaults} foo@bar:thing /home/foo", true)
+      Pkg::Util::Net.rsync_from('thing', 'foo@bar', '/home/foo')
     end
 
     it "rsyncs 'thing' from 'foo@bar:/home/foo' with flags that don't include arbitrary flags" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("rsync").and_return(rsync)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{rsync} #{defaults} --foo-bar --and-another-flag foo@bar:thing /home/foo", true)
-      Pkg::Util::Net.rsync_from("thing", "foo@bar", "/home/foo", extra_flags: ["--foo-bar", "--and-another-flag"])
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('rsync').and_return(rsync)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{rsync} #{defaults} --foo-bar --and-another-flag foo@bar:thing /home/foo", true)
+      Pkg::Util::Net.rsync_from('thing', 'foo@bar', '/home/foo',
+                                extra_flags: ['--foo-bar', '--and-another-flag'])
     end
   end
 
   describe "#curl_form_data" do
-    let(:curl) {"/bin/curl"}
-    let(:form_data) {["name=FOO"]}
-    let(:options) { {:quiet => true} }
+    let(:curl) { '/bin/curl' }
+    let(:form_data) { ['name=FOO'] }
+    let(:options) { { quiet: true } }
 
-    it "should return false on failure" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i '#{target_uri}'").and_return(['stdout', 'stderr', 1])
-      Pkg::Util::Net.curl_form_data(target_uri).should eq(['stdout', 1])
+    it 'should return false on failure' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{curl} -i '#{target_uri}'").and_return(['stdout', 'stderr', 1])
+      expect(Pkg::Util::Net.curl_form_data(target_uri)).to eq(['stdout', 1])
     end
 
 
     it "should curl with just the uri" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i '#{target_uri}'")
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution).to receive(:capture3).with("#{curl} -i '#{target_uri}'")
       Pkg::Util::Net.curl_form_data(target_uri)
     end
 
-    it "should curl with the form data and uri" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} '#{target_uri}'")
+    it 'should curl with the form data and uri' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{curl} -i #{form_data[0]} '#{target_uri}'")
       Pkg::Util::Net.curl_form_data(target_uri, form_data)
     end
 
-    it "should curl with form data, uri, and be quiet" do
-      Pkg::Util::Tool.should_receive(:check_tool).with("curl").and_return(curl)
-      Pkg::Util::Execution.should_receive(:capture3).with("#{curl} -i #{form_data[0]} '#{target_uri}'").and_return(['stdout', 'stderr', 0])
-      Pkg::Util::Net.curl_form_data(target_uri, form_data, options).should eq(['', 0])
+    it 'should curl with form data, uri, and be quiet' do
+      expect(Pkg::Util::Tool).to receive(:check_tool).with('curl').and_return(curl)
+      expect(Pkg::Util::Execution)
+        .to receive(:capture3)
+        .with("#{curl} -i #{form_data[0]} '#{target_uri}'")
+        .and_return(['stdout', 'stderr', 0])
+      expect(Pkg::Util::Net.curl_form_data(target_uri, form_data, options)).to eq(['', 0])
     end
-
   end
 
-  describe "#print_url_info" do
-    it "should output correct formatting" do
-      Pkg::Util::Net.should_receive(:puts).with("\n////////////////////////////////////////////////////////////////////////////////\n\n
+  describe '#print_url_info' do
+    it 'should output correct formatting' do
+      expect(Pkg::Util::Net)
+        .to receive(:puts)
+        .with("\n////////////////////////////////////////////////////////////////////////////////\n\n
   Build submitted. To view your build progress, go to\n#{target_uri}\n\n
 ////////////////////////////////////////////////////////////////////////////////\n\n")
       Pkg::Util::Net.print_url_info(target_uri)

--- a/spec/lib/packaging/util/rake_utils_spec.rb
+++ b/spec/lib/packaging/util/rake_utils_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
 
-describe "Pkg::Util::RakeUtils" do
+describe 'Pkg::Util::RakeUtils' do
   let(:foo_defined?) { Rake::Task.task_defined?(:foo) }
   let(:bar_defined?) { Rake::Task.task_defined?(:bar) }
-  let(:define_foo)   { body = proc{}; Rake::Task.define_task(:foo, &body) }
-  let(:define_bar)   { body = proc{}; Rake::Task.define_task(:bar, &body) }
+  let(:define_foo) do
+    body = proc {}
+    Rake::Task.define_task(:foo, &body)
+  end
+  let(:define_bar) do
+    body = proc {}
+    Rake::Task.define_task(:bar, &body)
+  end
 
   before(:each) do
     if foo_defined?
@@ -12,21 +18,21 @@ describe "Pkg::Util::RakeUtils" do
     end
   end
 
-  describe "#task_defined?" do
-    context "given a Rake::Task task name" do
-      it "should return true if the task exists" do
-        Rake::Task.stub(:task_defined?).with(:foo) {true}
-        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be_true
+  describe '#task_defined?' do
+    context 'given a Rake::Task task name' do
+      it 'should return true if the task exists' do
+        allow(Rake::Task).to receive(:task_defined?).with(:foo).and_return(true)
+        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be true
       end
-      it "should return false if the task does not exist" do
-        Rake::Task.stub(:task_defined?).with(:foo) {false}
-        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be_false
+      it 'should return false if the task does not exist' do
+        allow(Rake::Task).to receive(:task_defined?).with(:foo).and_return(false)
+        expect(Pkg::Util::RakeUtils.task_defined?(:foo)).to be false
       end
     end
   end
 
-  describe "#get_task" do
-    it "should return a task object for a named task" do
+  describe '#get_task' do
+    it 'should return a task object for a named task' do
       foo = nil
       if !foo_defined?
         foo = define_foo
@@ -39,8 +45,8 @@ describe "Pkg::Util::RakeUtils" do
     end
   end
 
-  describe "#add_dependency" do
-    it "should add a dependency to a given rake task" do
+  describe '#add_dependency' do
+    it 'should add a dependency to a given rake task' do
       foo = nil
       bar = nil
       if !foo_defined?
@@ -58,9 +64,9 @@ describe "Pkg::Util::RakeUtils" do
     end
   end
 
-  describe "#evaluate_pre_tasks" do
-    context "Given a data file with :pre_tasks defined" do
-      it "should, for each k=>v pair, add v as a dependency to k" do
+  describe '#evaluate_pre_tasks' do
+    context 'Given a data file with :pre_tasks defined' do
+      it 'should, for each k=>v pair, add v as a dependency to k' do
         Pkg::Config.config_from_yaml(File.join(FIXTURES, 'util', 'pre_tasks.yaml'))
         expect(Pkg::Util::RakeUtils).to receive(:add_dependency)
         Pkg::Util::RakeUtils.evaluate_pre_tasks

--- a/spec/lib/packaging/util/ship_spec.rb
+++ b/spec/lib/packaging/util/ship_spec.rb
@@ -45,7 +45,6 @@ describe '#Pkg::Util::Ship' do
   # Sample data for #reorganize_packages and #ship_pkgs specs
   retrieved_packages = %w[
     pkg/deb/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb
-    pkg/el/7/puppet6/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm
     pkg/el/7/puppet6/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm
     pkg/el/7/puppet6/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm
     pkg/sles/12/puppet6/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm
@@ -64,7 +63,6 @@ describe '#Pkg::Util::Ship' do
   # Beware apple->mac transforms.
   expected_reorganized_packages = %w[
     pkg/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb
-    pkg/puppet6/el/7/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm
     pkg/puppet6/el/7/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm
     pkg/puppet6/el/7/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm
     pkg/puppet6/sles/12/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm

--- a/spec/lib/packaging/util/ship_spec.rb
+++ b/spec/lib/packaging/util/ship_spec.rb
@@ -45,6 +45,7 @@ describe '#Pkg::Util::Ship' do
   # Sample data for #reorganize_packages and #ship_pkgs specs
   retrieved_packages = %w[
     pkg/deb/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb
+    pkg/el/7/puppet6/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm
     pkg/el/7/puppet6/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm
     pkg/el/7/puppet6/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm
     pkg/sles/12/puppet6/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm
@@ -63,6 +64,7 @@ describe '#Pkg::Util::Ship' do
   # Beware apple->mac transforms.
   expected_reorganized_packages = %w[
     pkg/bionic/puppet6/puppet-agent_6.19.0-1bionic_amd64.deb
+    pkg/puppet6/el/7/aarch64/puppet-agent-6.19.0-1.el7.aarch64.rpm
     pkg/puppet6/el/7/ppc64le/puppet-agent-6.19.0-1.el7.ppc64le.rpm
     pkg/puppet6/el/7/x86_64/puppet-agent-6.19.0-1.el7.x86_64.rpm
     pkg/puppet6/sles/12/ppc64le/puppet-agent-6.19.0-1.sles12.ppc64le.rpm

--- a/spec/lib/packaging_spec.rb
+++ b/spec/lib/packaging_spec.rb
@@ -2,18 +2,16 @@ require 'spec_helper'
 
 #   We load packaging.rb once, in spec_helper, to avoid reloading the library
 #   and issuing warnings about already defined constants.
-describe "Pkg" do
-  it "should require the utilities module, Pkg::Util" do
-    Pkg::Util.should_not be_nil
+describe 'Pkg' do
+  it 'should require the utilities module, Pkg::Util' do
+    expect(Pkg::Util).to_not be_nil
   end
 
-  it  "should require the configuration module, Pkg::Config" do
-    Pkg::Config.should_not be_nil
+  it 'should require the configuration module, Pkg::Config' do
+    expect(Pkg::Config).to_not be_nil
   end
 
-  it  "should require the tar library, Pkg::Tar" do
-    Pkg::Tar.should_not be_nil
+  it 'should require the tar library, Pkg::Tar' do
+    expect(Pkg::Tar).to_not be_nil
   end
-
 end
-

--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -57,19 +57,19 @@ def make_directory_tree
     mkdir_p(val)
   end
 
-  if File.exists?('ext/osx/postflight.erb')
+  if File.exist?('ext/osx/postflight.erb')
     Pkg::Util::File.erb_file 'ext/osx/postflight.erb', "#{@working_tree['scripts']}/postinstall", false, :binding => binding
   end
 
-  if File.exists?('ext/osx/preflight.erb')
+  if File.exist?('ext/osx/preflight.erb')
     Pkg::Util::File.erb_file 'ext/osx/preflight.erb', "#{@working_tree['scripts']}/preinstall", false, :binding => binding
   end
 
-  if File.exists?('ext/osx/prototype.plist.erb')
+  if File.exist?('ext/osx/prototype.plist.erb')
     Pkg::Util::File.erb_file 'ext/osx/prototype.plist.erb', "#{@scratch}/prototype.plist", false, :binding => binding
   end
 
-  if File.exists?('ext/packaging/static_artifacts/PackageInfo.plist')
+  if File.exist?('ext/packaging/static_artifacts/PackageInfo.plist')
     cp 'ext/packaging/static_artifacts/PackageInfo.plist', "#{@scratch}/PackageInfo.plist"
   end
 end
@@ -148,13 +148,13 @@ def pack_source
 
   # Setup a preinstall script and replace variables in the files with
   # the correct paths.
-  if File.exists?("#{@working_tree['scripts']}/preinstall")
+  if File.exist?("#{@working_tree['scripts']}/preinstall")
     chmod(0755, "#{@working_tree['scripts']}/preinstall")
     sh "sudo chown root:wheel #{@working_tree['scripts']}/preinstall"
   end
 
   # Setup a postinstall from from the erb created earlier
-  if File.exists?("#{@working_tree['scripts']}/postinstall")
+  if File.exist?("#{@working_tree['scripts']}/postinstall")
     chmod(0755, "#{@working_tree['scripts']}/postinstall")
     sh "sudo chown root:wheel #{@working_tree['scripts']}/postinstall"
   end
@@ -244,8 +244,7 @@ namespace :package do
     if Pkg::Config.build_dmg
       bench = Benchmark.realtime do
         # Test for pkgbuild binary
-        fail "pkgbuild must be installed." unless \
-          File.exists?(PKGBUILD)
+        fail "pkgbuild must be installed." unless File.exist?(PKGBUILD)
 
         make_directory_tree
         pack_source

--- a/tasks/deb.rake
+++ b/tasks/deb.rake
@@ -52,7 +52,7 @@ task :prep_deb_tars, :work_dir do |t, args|
         elsif file.directory?
           mkdir_p "#{pkg_dir}/#{file}"
         elsif file.extname == '.erb'
-          Pkg::Util::File.erb_file(file, "#{pkg_dir}/#{file.sub(/\.[^\.]*$/, '')}", false, :binding => Pkg::Config.get_binding)
+          Pkg::Util::File.erb_file(file, "#{pkg_dir}/#{file.sub(/\.[^.]*$/, '')}", false, :binding => Pkg::Config.get_binding)
         else
           cp file, "#{pkg_dir}/#{file}"
         end

--- a/tasks/fetch.rake
+++ b/tasks/fetch.rake
@@ -15,8 +15,8 @@ end
 team_data_branch = Pkg::Config.team
 
 if Pkg::Config.build_pe
-  project_data_branch = 'pe-' + project_data_branch unless project_data_branch =~ /^pe-/
-  team_data_branch = 'pe-' + team_data_branch unless team_data_branch =~ /^pe-/
+  project_data_branch = "pe-#{project_data_branch}" unless project_data_branch =~ /^pe-/
+  team_data_branch = "pe-#{team_data_branch}" unless team_data_branch =~ /^pe-/
 end
 
 # The pl:fetch task pulls down two files from the build-data repo that contain additional

--- a/tasks/mock.rake
+++ b/tasks/mock.rake
@@ -158,11 +158,11 @@ def mock_template(mock_config)
   # for example, pupent-3.4-el5-i386.cfg would become pupent-el5-i386 while pupent-el7-x86_64 would remain unmodified.
   template = mock_config.sub(/([^-]*)-\d\.\d-([^-]*)-([^-]*)/, '\1-\2-\3')
   template_location = File.join(File::SEPARATOR, "etc", "mock", "#{template}.cfg.erb")
-  if File.exists?(template_location)
+  if File.exist?(template_location)
     return template, Pkg::Util::File.erb_file(template_location, nil, false, { :binding => binding })
-  else
-    return mock_config
   end
+
+  return mock_config
 end
 
 # Determine the appropriate rpm macro definitions based on the mock config name

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -75,13 +75,14 @@ namespace :pl do
       mkdir("pkg")
 
       Dir.chdir("pkg") do
-        if versioning == 'ref'
+        case versioning
+        when 'ref'
           local_target = File.join(Pkg::Config.project, Pkg::Config.ref)
-        elsif versioning == 'version'
+        when 'version'
           local_target = File.join(Pkg::Config.project, Pkg::Util::Version.dot_version)
         end
 
-        FileUtils.mkdir_p([local_target, Pkg::Config.project + "-latest"])
+        FileUtils.mkdir_p([local_target, "#{Pkg::Config.project}-latest"])
 
         # Rake task dependencies with arguments are nuts, so we just directly
         # invoke them here.  We want the signed_* directories staged as
@@ -106,7 +107,7 @@ namespace :pl do
         # names stay the same between runs. Their contents have the ref
         # stripped off and the project replaced by $project-latest. Then the
         # repos directory is a symlink to the last pushed ref's repos.
-        FileUtils.cp_r(File.join(local_target, "repo_configs"), Pkg::Config.project + "-latest", { :preserve => true })
+        FileUtils.cp_r(File.join(local_target, "repo_configs"), "#{Pkg::Config.project}-latest", { :preserve => true })
 
         # Now we need to remove the ref and replace $project with
         # $project-latest so that it will work as a pinned latest repo
@@ -114,7 +115,7 @@ namespace :pl do
         Dir.glob("#{Pkg::Config.project}-latest/repo_configs/**/*").select { |t_config| File.file?(t_config) }.each do |config|
           new_contents = File.read(config)
           new_contents.gsub!(%r{#{Pkg::Config.ref}/}, "")
-          new_contents.gsub!(%r{#{Pkg::Config.project}/}, Pkg::Config.project + "-latest/")
+          new_contents.gsub!(%r{#{Pkg::Config.project}/}, "#{Pkg::Config.project}-latest/")
           new_contents.gsub!(Pkg::Config.ref, "latest")
 
           File.open(config, "w") { |file| file.puts new_contents }
@@ -136,7 +137,7 @@ namespace :pl do
         end
 
         # Make a latest symlink for the project
-        FileUtils.ln_sf(File.join("..", local_target, "repos"), File.join(Pkg::Config.project + "-latest"), :verbose => true)
+        FileUtils.ln_sf(File.join("..", local_target, "repos"), File.join("#{Pkg::Config.project}-latest"), :verbose => true)
       end
     end
 
@@ -231,10 +232,11 @@ namespace :pl do
       versioning = args.versioning or fail ":versioning is a required argument for #{t}"
       pe_version = args.pe_version or fail ":pe_version is a required argument for #{t}"
 
-      if versioning == 'ref'
+      case versioning
+      when 'ref'
         version_string = Pkg::Config.ref
-      elsif versioning == 'version'
-        version_string =  Pkg::Util::Version.dot_version
+      when 'version'
+        version_string = Pkg::Util::Version.dot_version
       end
 
       pa_source = File.join(remote_dir, Pkg::Config.project)

--- a/tasks/rpm.rake
+++ b/tasks/rpm.rake
@@ -15,7 +15,7 @@ def prep_rpm_build_dir
   if $?.success?
     sh "tar -C #{temp} -xzf #{File.join(temp, tarball)} #{Pkg::Config.project}-#{Pkg::Config.version}/ext/redhat/#{Pkg::Config.project}.spec"
     cp("#{temp}/#{Pkg::Config.project}-#{Pkg::Config.version}/ext/redhat/#{Pkg::Config.project}.spec", "#{temp}/SPECS/")
-  elsif File.exists?("ext/redhat/#{Pkg::Config.project}.spec.erb")
+  elsif File.exist?("ext/redhat/#{Pkg::Config.project}.spec.erb")
     Pkg::Util::File.erb_file("ext/redhat/#{Pkg::Config.project}.spec.erb", "#{temp}/SPECS/#{Pkg::Config.project}.spec", nil, :binding => Pkg::Config.get_binding)
   else
     fail "Could not locate redhat spec ext/redhat/#{Pkg::Config.project}.spec or ext/redhat/#{Pkg::Config.project}.spec.erb"
@@ -30,7 +30,7 @@ def build_rpm(buildarg = "-bs")
   rpm_old_version = '--define "_source_filedigest_algorithm 1" --define "_binary_filedigest_algorithm 1" \
      --define "_binary_payload w9.gzdio" --define "_source_payload w9.gzdio" \
      --define "_default_patch_fuzz 2"'
-  args = rpm_define + ' ' + rpm_old_version
+  args = "#{rpm_define} #{rpm_old_version}"
   FileUtils.mkdir_p('pkg/srpm')
   if buildarg == '-ba'
     FileUtils.mkdir_p('pkg/rpm')
@@ -63,4 +63,3 @@ namespace :package do
     build_rpm("-ba")
   end
 end
-

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -683,7 +683,7 @@ namespace :pl do
         existing_artifacts = artifactory.artifact_paths(artifact)
         unless existing_artifacts.empty?
           warn "Uploading '#{artifact}' to Artifactory refused. Artifact already exists here: ",
-               existing_artifacts.join(', ')
+               existing_artifacts.map(&:uri).join(', ')
           next
         end
 

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -78,18 +78,16 @@ namespace :pl do
 
   desc "Sign generated debian changes files. Defaults to PL Key, pass GPG_KEY to override"
   task :sign_deb_changes, :root_dir do |_t, args|
-    begin
-      deb_dir = args.root_dir || $DEFAULT_DIRECTORY
-      change_files = Dir["#{deb_dir}/**/*.changes"]
-      unless change_files.empty?
-        Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
-        change_files.each do |file|
-          Pkg::Sign::Deb.sign_changes(file)
-        end
+    deb_dir = args.root_dir || $DEFAULT_DIRECTORY
+    change_files = Dir["#{deb_dir}/**/*.changes"]
+    unless change_files.empty?
+      Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
+      change_files.each do |file|
+        Pkg::Sign::Deb.sign_changes(file)
       end
-    ensure
-      Pkg::Util::Gpg.kill_keychain
     end
+  ensure
+    Pkg::Util::Gpg.kill_keychain
   end
 
   desc "Sign OSX packages"

--- a/tasks/z_data_dump.rake
+++ b/tasks/z_data_dump.rake
@@ -37,10 +37,11 @@ namespace :pl do
     # We want a string that is the from "@<param name>"
     if param = args.param
       getter = param.dup
-      if param[0] == ':'
+      case param[0]
+      when ':'
         getter = param[1..-1]
         param[0] = "@"
-      elsif param[0] == "@"
+      when "@"
         getter = param[1..-1]
       else
         param.insert(0, "@")
@@ -62,4 +63,3 @@ namespace :pl do
     end
   end
 end
-


### PR DESCRIPTION
To prevent 'No space left on device' errors while creating a dmg,
provide a size. This should later be enhanced to be smarter.

See: RE-15379


Please add all notable changes to the "Unreleased" section of the CHANGELOG.