### PR TITLE
(RE-15419) Update internal gem host to rubygems__local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-15419) Update internal gem host to rubygems__local
 
 ## [0.109.5] - 2023-03-21
 ### Fixed

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -318,7 +318,7 @@ module Pkg::Params
               { :var => :build_data_repo,         :val => 'https://github.com/puppetlabs/build-data.git' },
               { :var => :build_date,              :val => Pkg::Util::Date.timestamp('-') },
               { :var => :release,                 :val => '1' },
-              { :var => :internal_gem_host,       :val => 'https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems' },
+              { :var => :internal_gem_host,       :val => 'https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems__local' },
               { :var => :build_tar,               :val => true },
               { :var => :dev_build,               :val => false },
               { :var => :osx_signing_cert,        :val => '$OSX_SIGNING_CERT' },


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
