### PR TITLE
(maint) Update kwarg syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Update keyword argument syntax in nightly repo Rake task
 
 ## [0.109.6] - 2023-04-14
 ### Changed

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -107,7 +107,7 @@ namespace :pl do
         # names stay the same between runs. Their contents have the ref
         # stripped off and the project replaced by $project-latest. Then the
         # repos directory is a symlink to the last pushed ref's repos.
-        FileUtils.cp_r(File.join(local_target, "repo_configs"), "#{Pkg::Config.project}-latest", { :preserve => true })
+        FileUtils.cp_r(File.join(local_target, "repo_configs"), "#{Pkg::Config.project}-latest", preserve: true)
 
         # Now we need to remove the ref and replace $project with
         # $project-latest so that it will work as a pinned latest repo


### PR DESCRIPTION
This commit updates FileUtils#cp_r to use modern (Ruby >= 3.0) keyword argument syntax for the preserve option.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
