### PR TITLE
(maint) Use ruby 3 for remote bundle install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.109.7] - 2023-04-25
 ### Fixed
 - (maint) Update keyword argument syntax in nightly repo Rake task
-
+### Changed
+- (maint) Use ruby 3.1.1 for remote bundle installs.
 ## [0.109.6] - 2023-04-14
 ### Changed
 - (RE-15419) Update internal gem host to rubygems__local
@@ -907,7 +910,8 @@ this is a final version.
 
 ## Versions <= 0.5.0 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.109.6...HEAD
+[Unreleased]: https://github.com/puppetlabs/packaging/compare/0.109.7...HEAD
+[0.109.7]: https://github.com/puppetlabs/packaging/compare/0.109.6...0.109.7
 [0.109.6]: https://github.com/puppetlabs/packaging/compare/0.109.5...0.109.6
 [0.109.5]: https://github.com/puppetlabs/packaging/compare/0.109.4...0.109.5
 [0.109.4]: https://github.com/puppetlabs/packaging/compare/0.109.3...0.109.4

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -390,7 +390,7 @@ module Pkg::Util::Net
     end
 
     def remote_bundle_install_command
-      rvm_ruby_version = ENV['RVM_RUBY_VERSION'] || '2.7.5'
+      rvm_ruby_version = ENV['RVM_RUBY_VERSION'] || '3.1.1'
       export_packaging_location = "export PACKAGING_LOCATION='#{ENV['PACKAGING_LOCATION']}';" if ENV['PACKAGING_LOCATION'] && !ENV['PACKAGING_LOCATION'].empty?
       export_vanagon_location = "export VANAGON_LOCATION='#{ENV['VANAGON_LOCATION']}';" if ENV['VANAGON_LOCATION'] && !ENV['VANAGON_LOCATION'].empty?
       "source /usr/local/rvm/scripts/rvm; rvm use ruby-#{rvm_ruby_version}; #{export_packaging_location} #{export_vanagon_location} bundle install --path .bundle/gems ;"


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
