### PR TITLE
(RE-15382) Teardown the apt.repos.puppet.com project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -583,7 +583,7 @@ Style/For:
   Enabled: true
 
 Style/FormatString:
-  Enabled: true
+  Enabled: false
 
 Style/FormatStringToken:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-15382) Delete now-obsolete parts of apt.repos.puppet.com project.
 
 ## [0.109.7] - 2023-04-25
 ### Fixed
 - (maint) Update keyword argument syntax in nightly repo Rake task
+
 ### Changed
 - (maint) Use ruby 3.1.1 for remote bundle installs.
+
 ## [0.109.6] - 2023-04-14
 ### Changed
 - (RE-15419) Update internal gem host to rubygems__local

--- a/lib/packaging/paths.rb
+++ b/lib/packaging/paths.rb
@@ -108,19 +108,9 @@ module Pkg::Paths
     platform_name = path_data[:platform_name]
     platform_tag = path_data[:platform_tag]
 
-    repo_name = Pkg::Config.repo_name
-
     case package_format
     when 'deb'
       debian_code_name = Pkg::Platforms.get_attribute(platform_tag, :codename)
-
-      # In puppet7 and beyond, we moved the repo_name to the top to allow each
-      # puppet major release to have its own apt repo.
-      if %w[FUTURE-puppet7 FUTURE-puppet7-nightly].include? repo_name
-        return File.join(prefix, apt_repo_name(is_nonfinal), debian_code_name)
-      end
-
-      # For puppet6 and prior
       return File.join(prefix, debian_code_name, apt_repo_name(is_nonfinal))
     when 'dmg'
       return File.join(prefix, 'mac', repo_name(is_nonfinal))

--- a/lib/packaging/util.rb
+++ b/lib/packaging/util.rb
@@ -4,7 +4,6 @@ module Pkg::Util
   require 'benchmark'
   require 'base64'
   require 'io/console'
-  require 'packaging/util/apt_staging_server'
   require 'packaging/util/build_metadata'
   require 'packaging/util/date'
   require 'packaging/util/distribution_server'

--- a/lib/packaging/util/apt_staging_server.rb
+++ b/lib/packaging/util/apt_staging_server.rb
@@ -1,8 +1,0 @@
-# Utility methods for handling Apt staging server.
-
-module Pkg::Util::AptStagingServer
-  def self.send_packages(pkg_directory, apt_component = 'stable')
-    %x(apt-stage-artifacts --component=#{apt_component} #{pkg_directory})
-    fail 'APT artifact staging failed.' unless $CHILD_STATUS.success?
-  end
-end

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('artifactory', ['~> 3'])
   gem.add_runtime_dependency('csv', ['>= 3.1.5'])
+  gem.add_runtime_dependency('googleauth')
+  gem.add_runtime_dependency('google-cloud-storage')
   gem.add_runtime_dependency('rake', ['>= 12.3'])
   gem.add_runtime_dependency('release-metrics')
 

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -19,11 +19,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('rubocop')
 
-  gem.add_runtime_dependency('apt_stage_artifacts')
   gem.add_runtime_dependency('artifactory', ['~> 3'])
   gem.add_runtime_dependency('csv', ['>= 3.1.5'])
-  gem.add_runtime_dependency('googleauth')
-  gem.add_runtime_dependency('google-cloud-storage')
   gem.add_runtime_dependency('rake', ['>= 12.3'])
   gem.add_runtime_dependency('release-metrics')
 

--- a/spec/lib/packaging/artifactory_spec.rb
+++ b/spec/lib/packaging/artifactory_spec.rb
@@ -3,113 +3,154 @@ require 'spec_helper'
 require 'packaging/artifactory'
 
 describe 'artifactory.rb' do
-
   project = 'puppet-agent'
   project_version = 'ashawithlettersandnumbers'
   default_repo_name = 'testing'
   artifactory_uri = 'https://artifactory.url'
 
-  let(:platform_data) {
+  let(:platform_data) do
     {
       'el-6-x86_64' => {
-        :artifact => "./el/6/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm",
-        :repo_config => "../repo_configs/rpm/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-el-6-x86_64.repo",
-        :additional_artifacts => ["./el/6/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm"],
+        artifact: './el/6/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm',
+        repo_config: '../repo_configs/rpm/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-el-6-x86_64.repo',
+        additional_artifacts: [
+          './el/6/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm'
+        ],
       },
       'ubuntu-18.04-amd64' => {
-        :artifact => "./deb/bionic/PC1/puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb",
-        :repo_config => "../repo_configs/deb/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-bionic.list",
-        :additional_artifacts => ["./deb/bionic/PC1/puppet-agent-extras_5.3.1.34.gf65f9ef-1bionic_amd64.deb"],
+        artifact: './deb/bionic/PC1/puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb',
+        repo_config: '../repo_configs/deb/pl-puppet-agent-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-bionic.list',
+        additional_artifacts: [
+          './deb/bionic/PC1/puppet-agent-extras_5.3.1.34.gf65f9ef-1bionic_amd64.deb'
+        ],
       },
       'debian-10-amd64' => {
-        :artifact => "./deb/buster/PC1/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb",
-        :repo_config => "../repo_configs/deb/pl-puppetdb-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-buster.list",
-        :additional_artifacts => ["./deb/buster/PC1/puppetdb-termini_5.3.1.34.gf65f9ef-1buster_all.deb"],
+        artifact: './deb/buster/PC1/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb',
+        repo_config: '../repo_configs/deb/pl-puppetdb-f65f9efbb727c3d2d72d6799c0fc345a726f27b5-buster.list',
+        additional_artifacts: [
+          './deb/buster/PC1/puppetdb-termini_5.3.1.34.gf65f9ef-1buster_all.deb'
+        ],
       },
       'windows-2012-x86' => {
-        :artifact => "./windows/puppet-agent-5.3.1.34-x86.msi",
-        :repo_config => '',
-        :additional_artifacts => ["./windows/puppet-agent-extras-5.3.1.34-x86.msi"],
+        artifact: './windows/puppet-agent-5.3.1.34-x86.msi',
+        repo_config: '',
+        additional_artifacts: ['./windows/puppet-agent-extras-5.3.1.34-x86.msi'],
       },
       'windowsfips-2012-x64' => {
-        :artifact => "./windowsfips/puppet-agent-5.3.1.34-x64.msi",
-        :repo_config => '',
-        :additional_artifacts => ["./windowsfips/puppet-agent-extras-5.3.1.34-x64.msi"],
+        artifact: './windowsfips/puppet-agent-5.3.1.34-x64.msi',
+        repo_config: '',
+        additional_artifacts: ['./windowsfips/puppet-agent-extras-5.3.1.34-x64.msi'],
       },
       'osx-10.15-x86_64' => {
-        :artifact => "./apple/10.15/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg",
-        :repo_config => '',
-        :additional_artifacts => ["./apple/10.15/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.15.dmg"],
+        artifact: './apple/10.15/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg',
+        repo_config: '',
+        additional_artifacts: [
+          './apple/10.15/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.15.dmg'
+        ],
       },
       'osx-11-x86_64' => {
-        :artifact => "./apple/11/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.osx11.dmg",
-        :repo_config => '',
-        :additional_artifacts => ["./apple/11/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx11.dmg"],
+        artifact: './apple/11/PC1/x86_64/puppet-agent-5.3.1.34.gf65f9ef-1.osx11.dmg',
+        repo_config: '',
+        additional_artifacts: [
+          './apple/11/PC1/x86_64/puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx11.dmg'
+        ],
       },
       'solaris-10-sparc' => {
-        :artifact => "./solaris/10/PC1/puppet-agent-5.3.1.34.gf65f9ef-1.sparc.pkg.gz",
-        :repo_config => '',
+        artifact: './solaris/10/PC1/puppet-agent-5.3.1.34.gf65f9ef-1.sparc.pkg.gz',
+        repo_config: '',
       },
     }
-  }
+  end
 
   platform_tags = {
     'el-6-x86_64' => {
-      :toplevel_repo => 'rpm',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/el-6-x86_64",
-      :package_format => 'rpm',
-      :package_name => 'path/to/a/el/6/package/puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm',
-      :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm', 'puppet-agent-extras-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm']
+      toplevel_repo: 'rpm',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/el-6-x86_64",
+      package_format: 'rpm',
+      package_name: 'path/to/a/el/6/package/puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm',
+      all_package_names: [
+        'puppet-agent-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm',
+        'puppet-agent-extras-5.3.1.34.gf65f9ef-1.el6.x86_64.rpm'
+      ]
     },
     'ubuntu-18.04-amd64' => {
-      :toplevel_repo => 'debian__local',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/ubuntu-18.04",
-      :codename => 'bionic',
-      :arch => 'amd64',
-      :package_name => 'path/to/a/bionic/package/puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb',
-      :all_package_names => ['puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb', 'puppet-agent-extras_5.3.1.34.gf65f9ef-1bionic_amd64.deb']
+      toplevel_repo: 'debian__local',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/ubuntu-18.04",
+      codename: 'bionic',
+      arch: 'amd64',
+      package_name: 'path/to/a/bionic/package/puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb',
+      all_package_names: [
+        'puppet-agent_5.3.1.34.gf65f9ef-1bionic_amd64.deb',
+        'puppet-agent-extras_5.3.1.34.gf65f9ef-1bionic_amd64.deb'
+      ]
     },
     'debian-10-amd64' => {
-      :toplevel_repo => 'debian__local',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/debian-10",
-      :codename => 'buster',
-      :arch => 'all',
-      :package_name => 'path/to/a/buster/package/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb',
-      :all_package_names => ['puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb', 'puppetdb-termini_5.3.1.34.gf65f9ef-1buster_all.deb']
+      toplevel_repo: 'debian__local',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/debian-10",
+      codename: 'buster',
+      arch: 'all',
+      package_name: 'path/to/a/buster/package/puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb',
+      all_package_names: [
+        'puppetdb_5.3.1.34.gf65f9ef-1buster_all.deb',
+        'puppetdb-termini_5.3.1.34.gf65f9ef-1buster_all.deb'
+      ]
     },
     'windows-2012-x86' => {
-      :toplevel_repo => 'generic',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/windows-x86",
-      :package_name => 'path/to/a/windows/package/puppet-agent-5.3.1.34-x86.msi',
-      :all_package_names => ['puppet-agent-5.3.1.34-x86.msi','puppet-agent-extras-5.3.1.34-x86.msi']
+      toplevel_repo: 'generic',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/windows-x86",
+      package_name: 'path/to/a/windows/package/puppet-agent-5.3.1.34-x86.msi',
+      all_package_names: [
+        'puppet-agent-5.3.1.34-x86.msi',
+        'puppet-agent-extras-5.3.1.34-x86.msi'
+      ]
     },
     'windowsfips-2012-x64' => {
-      :toplevel_repo => 'generic',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/windowsfips-x64",
-      :package_name => 'path/to/a/windowsfips/package/puppet-agent-5.3.1.34-x64.msi',
-      :all_package_names => ['puppet-agent-5.3.1.34-x64.msi','puppet-agent-extras-5.3.1.34-x64.msi']
+      toplevel_repo: 'generic',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/windowsfips-x64",
+      package_name: 'path/to/a/windowsfips/package/puppet-agent-5.3.1.34-x64.msi',
+      all_package_names: [
+        'puppet-agent-5.3.1.34-x64.msi',
+        'puppet-agent-extras-5.3.1.34-x64.msi'
+      ]
     },
     'osx-10.15-x86_64' => {
-      :toplevel_repo => 'generic',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/osx-10.15-x86_64",
-      :package_name => 'path/to/an/osx/10.15/package/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg',
-      :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg', 'puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.15.dmg']
+      toplevel_repo: 'generic',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/osx-10.15-x86_64",
+      package_name: 'path/to/an/osx/10.15/package/puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg',
+      all_package_names: [
+        'puppet-agent-5.3.1.34.gf65f9ef-1.osx10.15.dmg',
+        'puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx10.15.dmg'
+      ]
     },
     'osx-11-x86_64' => {
-      :toplevel_repo => 'generic',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/osx-11-x86_64",
-      :package_name => 'path/to/an/osx/11/package/puppet-agent-5.3.1.34.gf65f9ef-1.osx11.dmg',
-      :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.osx11.dmg', 'puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx11.dmg']
+      toplevel_repo: 'generic',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/osx-11-x86_64",
+      package_name: 'path/to/an/osx/11/package/puppet-agent-5.3.1.34.gf65f9ef-1.osx11.dmg',
+      all_package_names: [
+        'puppet-agent-5.3.1.34.gf65f9ef-1.osx11.dmg',
+        'puppet-agent-extras-5.3.1.34.gf65f9ef-1.osx11.dmg'
+      ]
     },
     'solaris-10-sparc' => {
-      :toplevel_repo => 'generic',
-      :repo_subdirectories => "#{default_repo_name}/#{project}/#{project_version}/solaris-10-sparc",
-      :package_name => 'path/to/a/solaris/10/package/puppet-agent-5.3.1.34.gf65f9ef-1.sparc.pkg.gz',
-      :all_package_names => ['puppet-agent-5.3.1.34.gf65f9ef-1.sparc.pkg.gz']
+      toplevel_repo: 'generic',
+      repo_subdirectories: "#{default_repo_name}/#{project}/#{project_version}/solaris-10-sparc",
+      package_name: 'path/to/a/solaris/10/package/puppet-agent-5.3.1.34.gf65f9ef-1.sparc.pkg.gz',
+      all_package_names: [
+        'puppet-agent-5.3.1.34.gf65f9ef-1.sparc.pkg.gz'
+      ]
     },
   }
 
-  let(:artifact) { Pkg::ManageArtifactory.new(project, project_version, {:repo_base => default_repo_name, :artifactory_uri => artifactory_uri})}
+  let(:artifact) do
+    Pkg::ManageArtifactory.new(
+      project,
+      project_version,
+      {
+        repo_base: default_repo_name,
+        artifactory_uri:  artifactory_uri
+      }
+    )
+  end
 
   around(:each) do |example|
     original_artifactory_api_key = ENV['ARTIFACTORY_API_KEY']
@@ -121,7 +162,7 @@ describe 'artifactory.rb' do
   platform_tags.each do |platform_tag, platform_tag_data|
     describe '#location_for' do
       if platform_tag_data[:codename]
-        it 'returns the expected repo name and paths by default, prepending `pool` for debian-ish platforms' do
+        it 'returns the expected repo name, prepending `pool` for debian-ish platforms' do
           expect(artifact.location_for(platform_tag)).to match_array([
             platform_tag_data[:toplevel_repo],
             platform_tag_data[:repo_subdirectories],
@@ -146,20 +187,25 @@ describe 'artifactory.rb' do
 
     describe '#package_name' do
       it 'parses the retrieved yaml file and returns the correct package name' do
-        expect(artifact.package_name(platform_data, platform_tag)).to eq(File.basename(platform_tag_data[:package_name]))
+        expect(artifact.package_name(platform_data, platform_tag))
+          .to eq(File.basename(platform_tag_data[:package_name]))
       end
 
       it 'fails if it cannot find a valid platform name' do
         new_platform_data = platform_data
         new_platform_data.delete_if { |k| k.match(platform_tag) }
-        expect{artifact.package_name(new_platform_data, platform_tag)}.to raise_error
+        expect { artifact.package_name(new_platform_data, platform_tag) }
+          .to raise_error(RuntimeError, /Package name could not be found from loaded yaml data/)
       end
     end
 
     describe '#all_package_names' do
       it 'parses the retrieved yaml file and returns the correct package name' do
         all_package_names = artifact.all_package_names(platform_data, platform_tag)
-        all_package_names_data = [platform_tag_data[:additional_artifacts], platform_tag_data[:all_package_names]].flatten.compact
+        all_package_names_data = [
+          platform_tag_data[:additional_artifacts],
+          platform_tag_data[:all_package_names]
+        ].flatten.compact
         all_package_names.map! { |p| File.basename(p) }
         all_package_names_data.map! { |p| File.basename(p) }
         expect(all_package_names.size).to eq(all_package_names_data.size)
@@ -169,16 +215,23 @@ describe 'artifactory.rb' do
       it 'fails if it cannot find a valid platform name' do
         new_platform_data = platform_data
         new_platform_data.delete_if { |k| k.match(platform_tag) }
-        expect{artifact.package_name(new_platform_data, platform_tag)}.to raise_error
+        expect { artifact.package_name(new_platform_data, platform_tag) }
+          .to raise_error(RuntimeError, /Package name could not be found from loaded yaml data/)
       end
     end
 
     describe '#deb_list_contents' do
       it "returns the correct contents for the debian list file for #{platform_tag}" do
         if platform_tag_data[:codename]
-          expect(artifact.deb_list_contents(platform_tag)).to eq("deb #{artifactory_uri}/#{platform_tag_data[:toplevel_repo].chomp('/pool')} #{platform_tag_data[:codename]} #{platform_tag_data[:repo_subdirectories]}")
+          platform_repo = platform_tag_data[:toplevel_repo].chomp('/pool')
+          codename = platform_tag_data[:codename]
+          subdirectories = platform_tag_data[:repo_subdirectories]
+
+          expect(artifact.deb_list_contents(platform_tag))
+            .to eq("deb #{artifactory_uri}/#{platform_repo} #{codename} #{subdirectories}")
         else
-          expect{artifact.deb_list_contents(platform_tag)}.to raise_error
+          expect { artifact.deb_list_contents(platform_tag) }
+            .to raise_error(RuntimeError, /is not an apt-based system/)
         end
       end
     end
@@ -186,23 +239,33 @@ describe 'artifactory.rb' do
     describe '#rpm_repo_contents' do
       it "returns the correct contents for the rpm repo file for #{platform_tag}" do
         if platform_tag_data[:package_format] == 'rpm'
-          expect(artifact.rpm_repo_contents(platform_tag)).to include("baseurl=#{artifactory_uri}\/#{platform_tag_data[:toplevel_repo]}\/#{platform_tag_data[:repo_subdirectories]}")
+          baseurl = 'baseurl=%s/%s/%s' % [
+            artifactory_uri,
+            platform_tag_data[:toplevel_repo],
+            platform_tag_data[:repo_subdirectories]
+          ]
+          expect(artifact.rpm_repo_contents(platform_tag)).to include(baseurl)
         else
-          expect{artifact.rpm_repo_contents(platform_tag)}.to raise_error
+          expect { artifact.rpm_repo_contents(platform_tag) }
+            .to raise_error(RuntimeError, /is not a yum-based system/)
         end
       end
     end
 
     describe '#deploy_properties' do
       it "returns the correct contents for the deploy properties for #{platform_tag}" do
+        deploy_properties = artifact.deploy_properties(
+          platform_tag,
+          File.basename(platform_tag_data[:package_name])
+        )
         if platform_tag_data[:codename]
-          expect(artifact.deploy_properties(platform_tag, File.basename(platform_tag_data[:package_name]))).to include({
+          expect(deploy_properties).to include({
             'deb.distribution' => platform_tag_data[:codename],
             'deb.component' => platform_tag_data[:repo_subdirectories],
             'deb.architecture' => platform_tag_data[:arch]
           })
         else
-          expect(artifact.deploy_properties(platform_tag, File.basename(platform_tag_data[:package_name]))).not_to include({
+          expect(deploy_properties).not_to include({
             'deb.component' => platform_tag_data[:repo_subdirectories]
           })
         end
@@ -214,7 +277,8 @@ describe 'artifactory.rb' do
     it 'fails gracefully if authorization is not set' do
       original_artifactory_api_key = ENV['ARTIFACTORY_API_KEY']
       ENV['ARTIFACTORY_API_KEY'] = nil
-      expect { artifact.deploy_package('path/to/el/7/x86_64/package.rpm') }.to raise_error
+      expect { artifact.deploy_package('path/to/el/7/x86_64/package.rpm') }
+        .to raise_error(RuntimeError, /Unable to determine credentials for Artifactory/)
       ENV['ARTIFACTORY_API_KEY'] = original_artifactory_api_key
     end
   end

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -133,25 +133,6 @@ describe 'Pkg::Paths' do
           .to eq('artifacts/windows/puppet6')
       end
     end
-
-    context 'after puppet 7 apt changes' do
-      before :each do
-        allow(Pkg::Config).to receive(:repo_name).and_return('FUTURE-puppet7')
-      end
-
-      it 'should be correct for bionic' do
-        expect(Pkg::Paths.artifacts_path('ubuntu-18.04-amd64'))
-          .to eq('artifacts/FUTURE-puppet7/bionic')
-      end
-      it 'should be correct for focal' do
-        expect(Pkg::Paths.artifacts_path('ubuntu-20.04-amd64'))
-          .to eq('artifacts/FUTURE-puppet7/focal')
-      end
-      it 'should be correct for jammy' do
-        expect(Pkg::Paths.artifacts_path('ubuntu-22.04-amd64'))
-          .to eq('artifacts/FUTURE-puppet7/jammy')
-      end
-    end
   end
 
   describe '#repo_path' do
@@ -210,15 +191,16 @@ describe 'Pkg::Paths' do
     end
 
     it 'should return nonfinal_repo_name for nonfinal version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('FUTURE-puppet7')
-      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('FUTURE-puppet7-nightly')
-      expect(Pkg::Paths.apt_repo_name(true)).to eq('FUTURE-puppet7-nightly')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet7-nightly')
+      expect(Pkg::Paths.apt_repo_name(true)).to eq('puppet7-nightly')
     end
 
     it 'should fail if nonfinal_repo_name is not set for non-final version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('FUTURE-puppet7')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
-      expect { Pkg::Paths.apt_repo_name(true) }.to raise_error
+      expect { Pkg::Paths.apt_repo_name(true) }
+        .to raise_error(RuntimeError, /Nonfinal is set to true/)
     end
   end
 
@@ -242,15 +224,16 @@ describe 'Pkg::Paths' do
     end
 
     it 'should return nonfinal_repo_name for nonfinal version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('FUTURE-puppet7')
-      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('FUTURE-puppet7-nightly')
-      expect(Pkg::Paths.yum_repo_name(true)).to eq('FUTURE-puppet7-nightly')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return('puppet7-nightly')
+      expect(Pkg::Paths.yum_repo_name(true)).to eq('puppet7-nightly')
     end
 
     it 'should fail if nonfinal_repo_name is not set for non-final version' do
-      allow(Pkg::Config).to receive(:repo_name).and_return('FUTURE-puppet7')
+      allow(Pkg::Config).to receive(:repo_name).and_return('puppet7')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
-      expect { Pkg::Paths.yum_repo_name(true) }.to raise_error
+      expect { Pkg::Paths.yum_repo_name(true) }
+        .to raise_error(RuntimeError, /Nonfinal is set to true/)
     end
   end
 
@@ -324,100 +307,43 @@ describe 'Pkg::Paths' do
           .to eq('/opt/repository-nightlies/apt/pool/buster/puppet6-nightly/p/pdk')
       end
     end
-
-    context 'for puppet 7 and after' do
-      it 'returns the approprate apt repo path' do
-        allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository/apt')
-        expect(Pkg::Paths.apt_package_base_path('ubuntu-18.04-amd64', 'FUTURE-puppet7', 'puppet-agent'))
-          .to eq('/opt/repository/apt/FUTURE-puppet7/pool/bionic/p/puppet-agent')
-        expect(Pkg::Paths.apt_package_base_path('ubuntu-20.04-amd64', 'FUTURE-puppet7', 'puppet-agent'))
-          .to eq('/opt/repository/apt/FUTURE-puppet7/pool/focal/p/puppet-agent')
-        expect(Pkg::Paths.apt_package_base_path('ubuntu-22.04-amd64', 'FUTURE-puppet7', 'puppet-agent'))
-          .to eq('/opt/repository/apt/FUTURE-puppet7/pool/jammy/p/puppet-agent')
-      end
-      it 'returns the appropriate nonfinal repo path' do
-        allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository-nightlies/apt')
-        expect(Pkg::Paths.apt_package_base_path('debian-10-amd64', 'FUTURE-puppet7-nightly', 'pdk', true))
-          .to eq('/opt/repository-nightlies/apt/FUTURE-puppet7-nightly/pool/buster/p/pdk')
-      end
-    end
   end
 
   describe '#release_package_link_path' do
-    context 'for puppet 6' do
-      repo_name = 'puppet6'
-      nonfinal_repo_name = 'puppet6-nightly'
-      yum_repo_path = '/opt/repository/yum'
-      apt_repo_path = '/opt/repository/apt'
-      nonfinal_yum_repo_path = '/opt/repository-nightlies/yum'
-      nonfinal_apt_repo_path = '/opt/repository-nightlies/apt'
-      before :each do
-        allow(Pkg::Config).to receive(:repo_name).and_return(repo_name)
-        allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nonfinal_repo_name)
-        allow(Pkg::Config).to receive(:yum_repo_path).and_return(yum_repo_path)
-        allow(Pkg::Config).to receive(:apt_repo_path).and_return(apt_repo_path)
-        allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return(nonfinal_yum_repo_path)
-        allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return(nonfinal_apt_repo_path)
-      end
-      it 'returns the appropriate link path for rpm release packages' do
-        expect(Pkg::Paths.release_package_link_path('sles-12-ppc64le'))
-          .to eq("#{yum_repo_path}/#{repo_name}-release-sles-12.noarch.rpm")
-      end
-      it 'returns the appropriate link path for deb release packages' do
-        expect(Pkg::Paths.release_package_link_path('ubuntu-18.04-amd64'))
-          .to eq("#{apt_repo_path}/#{repo_name}-release-bionic.deb")
-      end
-      it 'returns the appropriate link path for nonfinal rpm release packages' do
-        expect(Pkg::Paths.release_package_link_path('el-7-x86_64', true))
-          .to eq("#{nonfinal_yum_repo_path}/#{nonfinal_repo_name}-release-el-7.noarch.rpm")
-      end
-      it 'returns the appropriate link path for nonfinal deb release packages' do
-        expect(Pkg::Paths.release_package_link_path('debian-10-amd64', true))
-          .to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-buster.deb")
-      end
-      it 'returns nil for package formats that do not have release packages' do
-        expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)
-        expect(Pkg::Paths.release_package_link_path('osx-11-x86_64')).to eq(nil)
-        expect(Pkg::Paths.release_package_link_path('windows-2012-x86')).to eq(nil)
-      end
+    repo_name = 'puppet8'
+    nonfinal_repo_name = 'puppet8-nightly'
+    yum_repo_path = '/opt/repository/yum'
+    apt_repo_path = '/opt/repository/apt'
+    nonfinal_yum_repo_path = '/opt/repository-nightlies/yum'
+    nonfinal_apt_repo_path = '/opt/repository-nightlies/apt'
+    before :each do
+      allow(Pkg::Config).to receive(:repo_name).and_return(repo_name)
+      allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nonfinal_repo_name)
+      allow(Pkg::Config).to receive(:yum_repo_path).and_return(yum_repo_path)
+      allow(Pkg::Config).to receive(:apt_repo_path).and_return(apt_repo_path)
+      allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return(nonfinal_yum_repo_path)
+      allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return(nonfinal_apt_repo_path)
     end
-
-    context 'for puppet 7' do
-      repo_name = 'FUTURE-puppet7'
-      nonfinal_repo_name = 'FUTURE-puppet7-nightly'
-      yum_repo_path = '/opt/repository/yum'
-      apt_repo_path = '/opt/repository/apt'
-      nonfinal_yum_repo_path = '/opt/repository-nightlies/yum'
-      nonfinal_apt_repo_path = '/opt/repository-nightlies/apt'
-      before :each do
-        allow(Pkg::Config).to receive(:repo_name).and_return(repo_name)
-        allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nonfinal_repo_name)
-        allow(Pkg::Config).to receive(:yum_repo_path).and_return(yum_repo_path)
-        allow(Pkg::Config).to receive(:apt_repo_path).and_return(apt_repo_path)
-        allow(Pkg::Config).to receive(:nonfinal_yum_repo_path).and_return(nonfinal_yum_repo_path)
-        allow(Pkg::Config).to receive(:nonfinal_apt_repo_path).and_return(nonfinal_apt_repo_path)
-      end
-      it 'returns the appropriate link path for rpm release packages' do
-        expect(Pkg::Paths.release_package_link_path('sles-12-ppc64le'))
-          .to eq("#{yum_repo_path}/#{repo_name}-release-sles-12.noarch.rpm")
-      end
-      it 'returns the appropriate link path for deb release packages' do
-        expect(Pkg::Paths.release_package_link_path('ubuntu-20.04-amd64'))
-          .to eq("#{apt_repo_path}/#{repo_name}-release-focal.deb")
-      end
-      it 'returns the appropriate link path for nonfinal rpm release packages' do
-        expect(Pkg::Paths.release_package_link_path('el-8-x86_64', true))
-          .to eq("#{nonfinal_yum_repo_path}/#{nonfinal_repo_name}-release-el-8.noarch.rpm")
-      end
-      it 'returns the appropriate link path for nonfinal deb release packages' do
-        expect(Pkg::Paths.release_package_link_path('debian-10-i386', true))
-          .to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-buster.deb")
-      end
-      it 'returns nil for package formats that do not have release packages' do
-        expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)
-        expect(Pkg::Paths.release_package_link_path('osx-11-x86_64')).to eq(nil)
-        expect(Pkg::Paths.release_package_link_path('windows-2012-x86')).to eq(nil)
-      end
+    it 'returns the appropriate link path for rpm release packages' do
+      expect(Pkg::Paths.release_package_link_path('sles-12-ppc64le'))
+        .to eq("#{yum_repo_path}/#{repo_name}-release-sles-12.noarch.rpm")
+    end
+    it 'returns the appropriate link path for deb release packages' do
+      expect(Pkg::Paths.release_package_link_path('ubuntu-18.04-amd64'))
+        .to eq("#{apt_repo_path}/#{repo_name}-release-bionic.deb")
+    end
+    it 'returns the appropriate link path for nonfinal rpm release packages' do
+      expect(Pkg::Paths.release_package_link_path('el-7-x86_64', true))
+        .to eq("#{nonfinal_yum_repo_path}/#{nonfinal_repo_name}-release-el-7.noarch.rpm")
+    end
+    it 'returns the appropriate link path for nonfinal deb release packages' do
+      expect(Pkg::Paths.release_package_link_path('debian-10-amd64', true))
+        .to eq("#{nonfinal_apt_repo_path}/#{nonfinal_repo_name}-release-buster.deb")
+    end
+    it 'returns nil for package formats that do not have release packages' do
+      expect(Pkg::Paths.release_package_link_path('osx-10.15-x86_64')).to eq(nil)
+      expect(Pkg::Paths.release_package_link_path('osx-11-x86_64')).to eq(nil)
+      expect(Pkg::Paths.release_package_link_path('windows-2012-x86')).to eq(nil)
     end
   end
 end

--- a/spec/lib/packaging/paths_spec.rb
+++ b/spec/lib/packaging/paths_spec.rb
@@ -52,7 +52,8 @@ describe 'Pkg::Paths' do
     ]
     failure_cases.each do |fail_path|
       it "should fail gracefully if given '#{fail_path}'" do
-        expect { Pkg::Paths.tag_from_artifact_path(fail_path) }.to raise_error
+        expect { Pkg::Paths.tag_from_artifact_path(fail_path) }
+          .to raise_error(RuntimeError, /Cannot determine tag/)
       end
     end
   end
@@ -81,7 +82,8 @@ describe 'Pkg::Paths' do
     it 'should fail if nonfinal_repo_name is not set for non-final version' do
       allow(Pkg::Config).to receive(:repo_name).and_return('puppet6')
       allow(Pkg::Config).to receive(:nonfinal_repo_name).and_return(nil)
-      expect { Pkg::Paths.repo_name(true) }.to raise_error
+      expect { Pkg::Paths.repo_name(true) }
+        .to raise_error(RuntimeError, /Nonfinal is set to true/)
     end
   end
 
@@ -213,8 +215,8 @@ describe 'Pkg::Paths' do
 
     it 'should return `Pkg::Config.yum_repo_name` if `Pkg::Config.repo_name` is not set' do
       allow(Pkg::Config).to receive(:repo_name).and_return(nil)
-      allow(Pkg::Config).to receive(:yum_repo_name).and_return('FUTURE-puppet7')
-      expect(Pkg::Paths.yum_repo_name).to eq('FUTURE-puppet7')
+      allow(Pkg::Config).to receive(:yum_repo_name).and_return('puppet7')
+      expect(Pkg::Paths.yum_repo_name).to eq('puppet7')
     end
 
     it 'should return \'products\' if nothing is set' do
@@ -294,8 +296,6 @@ describe 'Pkg::Paths' do
           .to eq('/opt/repository/apt/pool/bionic/puppet6/p/puppet-agent')
         expect(Pkg::Paths.apt_package_base_path('debian-10-amd64', 'puppet6', 'bolt-server'))
           .to eq('/opt/repository/apt/pool/buster/puppet6/b/bolt-server')
-
-
       end
       it 'returns the appropriate nonfinal repo path' do
         allow(Pkg::Paths).to receive(:remote_repo_base).and_return('/opt/repository-nightlies/apt')

--- a/spec/lib/packaging/platforms_spec.rb
+++ b/spec/lib/packaging/platforms_spec.rb
@@ -12,14 +12,14 @@ describe 'Pkg::Platforms' do
 
   describe '#formats' do
     it 'should return all package formats' do
-      fmts = ['rpm', 'deb', 'dmg', 'svr4', 'ips', 'msi']
-      expect(Pkg::Platforms.formats).to match_array(fmts)
+      package_formats = ['rpm', 'deb', 'dmg', 'svr4', 'ips', 'msi']
+      expect(Pkg::Platforms.formats).to match_array(package_formats)
     end
   end
 
   describe '#supported_platforms' do
     it 'should return all supported platforms' do
-      platforms = ['aix', 'debian', 'el', 'fedora', 'osx', 'redhatfips', 'sles', 'solaris', 'ubuntu', 'windows', 'windowsfips']
+      platforms = %w[aix debian el fedora osx redhatfips sles solaris ubuntu windows windowsfips]
       expect(Pkg::Platforms.supported_platforms).to match_array(platforms)
     end
   end
@@ -30,7 +30,8 @@ describe 'Pkg::Platforms' do
     end
 
     it 'should raise an error if given a nonexistent platform' do
-      expect{Pkg::Platforms.versions_for_platform('notaplatform') }.to raise_error
+      expect { Pkg::Platforms.versions_for_platform('notaplatform') }
+        .to raise_error(RuntimeError, /No information found/)
     end
   end
 
@@ -47,7 +48,8 @@ describe 'Pkg::Platforms' do
     end
 
     it 'should fail if given nil as a codename' do
-      expect{Pkg::Platforms.codename_to_platform_version(nil)}.to raise_error
+      expect { Pkg::Platforms.codename_to_platform_version(nil) }
+        .to raise_error(RuntimeError, /Unable to find a platform/)
     end
   end
 
@@ -59,27 +61,32 @@ describe 'Pkg::Platforms' do
 
   describe '#arches_for_codename' do
     it 'should return an array of architectures corresponding to a given codename' do
-      expect(Pkg::Platforms.arches_for_codename('bionic')).to match_array(['amd64', 'aarch64', 'ppc64el'])
+      expect(Pkg::Platforms.arches_for_codename('bionic'))
+        .to match_array(['amd64', 'aarch64', 'ppc64el'])
     end
 
     it 'should be able to include source architectures' do
-      expect(Pkg::Platforms.arches_for_codename('bionic', true)).to match_array(["amd64", "aarch64", "ppc64el", "source"])
+      expect(Pkg::Platforms.arches_for_codename('bionic', true))
+        .to match_array(["amd64", "aarch64", "ppc64el", "source"])
     end
   end
 
   describe '#codename_to_tags' do
     it 'should return an array of platform tags corresponding to a given codename' do
-      expect(Pkg::Platforms.codename_to_tags('bionic')).to match_array(['ubuntu-18.04-aarch64', 'ubuntu-18.04-amd64', "ubuntu-18.04-ppc64el"])
+      expect(Pkg::Platforms.codename_to_tags('bionic'))
+        .to match_array(['ubuntu-18.04-aarch64', 'ubuntu-18.04-amd64', "ubuntu-18.04-ppc64el"])
     end
   end
 
   describe '#arches_for_platform_version' do
     it 'should return an array of arches for a given platform and version' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '12')).to match_array(['x86_64', 'ppc64le'])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '12'))
+        .to match_array(['x86_64', 'ppc64le'])
     end
 
     it 'should be able to include source architectures' do
-      expect(Pkg::Platforms.arches_for_platform_version('sles', '12', true)).to match_array(["SRPMS", "ppc64le", "x86_64"])
+      expect(Pkg::Platforms.arches_for_platform_version('sles', '12', true))
+        .to match_array(["SRPMS", "ppc64le", "x86_64"])
     end
   end
 
@@ -87,7 +94,7 @@ describe 'Pkg::Platforms' do
     it 'should return an array of platform tags' do
       tags = Pkg::Platforms.platform_tags
       expect(tags).to be_instance_of(Array)
-      expect(tags.count).to be > 0
+      expect(tags.count).to be_positive
     end
 
     it 'should include a basic platform' do
@@ -115,7 +122,8 @@ describe 'Pkg::Platforms' do
     end
 
     it 'fails with a reasonable error when specified attribute is not defined' do
-      expect { Pkg::Platforms.get_attribute('osx-10.15-x86_64', :signature_format) }.to raise_error(/doesn't have information/)
+      expect { Pkg::Platforms.get_attribute('osx-10.15-x86_64', :signature_format) }
+        .to raise_error(/doesn't have information/)
     end
   end
 
@@ -159,19 +167,22 @@ describe 'Pkg::Platforms' do
 
     fail_cases.each do |platform_tag|
       it "fails out for #{platform_tag}" do
-        expect { Pkg::Platforms.parse_platform_tag(platform_tag)}.to raise_error
+        expect { Pkg::Platforms.parse_platform_tag(platform_tag) }
+          .to raise_error(RuntimeError, /No information found|Could not verify/)
       end
     end
   end
 
   describe '#generic_platform_tag' do
     it 'fails for unsupported platforms' do
-      expect { Pkg::Platforms.generic_platform_tag('noplatform') }.to raise_error
+      expect { Pkg::Platforms.generic_platform_tag('noplatform') }
+        .to raise_error(RuntimeError, /No information found|Could not verify/)
     end
 
     it 'returns a supported platform tag containing the supplied platform' do
       Pkg::Platforms.supported_platforms.each do |platform|
-        expect(Pkg::Platforms.platform_tags).to include(Pkg::Platforms.generic_platform_tag(platform))
+        expect(Pkg::Platforms.platform_tags)
+          .to include(Pkg::Platforms.generic_platform_tag(platform))
       end
     end
   end

--- a/spec/lib/packaging/sign_spec.rb
+++ b/spec/lib/packaging/sign_spec.rb
@@ -66,7 +66,7 @@ describe 'Pkg::Sign' do
         %W[#{rpm_directory}/sles/11/PC1/x86_64/puppet-agent-5.5.3-1.sles11.x86_64.rpm]
       end
       let(:v4_rpms) do
-        %W[%#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm]
+        %W[#{rpm_directory}/el/7/PC1/aarch64/puppet-agent-5.5.3-1.el7.aarch64.rpm]
       end
       let(:rpms) { rpms_not_to_sign + v3_rpms + v4_rpms }
       let(:already_signed_rpms) do

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -361,8 +361,7 @@ namespace :pl do
   end
 
   ##
-  ## Here's where we start 'shipping' (old terminology) or 'staging' (current terminology)
-  ## by copying local 'pkg' directories to the staging server.
+  ## Here's where we start 'shipping' by copying local 'pkg' directories to the staging server.
   ##
   ## Note, that for debs, we conflate 'staging server' with 'signing server' because we
   ## must stage in th place where we sign.
@@ -388,18 +387,6 @@ namespace :pl do
     Pkg::Util::Ship.ship_debs(
       'pkg', Pkg::Config.nonfinal_apt_repo_staging_path, chattr: false, nonfinal: true
     )
-  end
-
-  ## This is the new-style apt stager
-  desc "Stage debs to #{Pkg::Config.apt_signing_server}"
-  task stage_stable_debs: 'pl:fetch' do
-    Pkg::Util::AptStagingServer.send_packages('pkg', 'stable')
-  end
-  task stage_debs: :stage_stable_debs
-
-  desc "Stage nightly debs to #{Pkg::Config.apt_signing_server}"
-  task stage_nightly_debs: 'pl:fetch' do
-    Pkg::Util::AptStagingServer.send_packages('pkg', 'nightly')
   end
 
   desc 'Ship built gem to rubygems.org, internal Gem mirror, and public file server'


### PR DESCRIPTION
The refactoring of apt repos was cancelled. Tearing out obsolete code from it.

A number of spec examples cleaned/refactored for readibility and for setting better expectations around thrown exceptions.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.