### PR TITLE
(PA-4775) Add support for macOS 13 ARM64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- (PA-4775) Add support for macOS 13 ARM 64 architecture
+
+## [Unreleased]
 ### Removed
 - (PA-5031) Remove support for Mac OS 10.15 (x86_64).
 - (PA-5043) Remove Red Hat 7 (aarch64).

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -96,6 +96,11 @@ module Pkg
           package_format: 'dmg',
           repo: false,
         },
+        '13' => {
+          architectures: ['arm64'],
+          package_format: 'dmg',
+          repo: false,
+        },
       },
 
       'redhatfips' => {


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
