### PR TITLE
(PA-4591) updated platform hash to include macos13(x86_64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Added
 - (PA-4775) Add support for macOS 13 ARM 64 architecture
+- (PA-4591) Add support for macOS 13 x86-64 architecture
 
 ## [Unreleased]
 ### Removed

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -97,7 +97,7 @@ module Pkg
           repo: false,
         },
         '13' => {
-          architectures: ['arm64'],
+          architectures: ['x86_64', 'arm64'],
           package_format: 'dmg',
           repo: false,
         },


### PR DESCRIPTION
modified platform to include macos-13-x86_64 architecture