### PR TITLE
(maint) Add support for AIX 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
 - (PA-4775) Add support for macOS 13 ARM 64 architecture
 - (PA-4591) Add support for macOS 13 x86-64 architecture
+- (maint) Add support for AIX 7.2
 
 ## [Unreleased]
 ### Removed

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -18,6 +18,13 @@ module Pkg
           source_package_formats: ['src.rpm'],
           repo: false,
         },
+        '7.2' => {
+          architectures: ['power'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          repo: false,
+        },
       },
 
       'debian' => {


### PR DESCRIPTION
Although we've supported AIX 7.2 as an agent platform in the past, this is the first time (in puppet8) that we will be packaging on AIX 7.2.