### PR TITLE
(PA-5904) Update puppetlabs/packaging platform hash to include macOS …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
 - (PA-5878) Update puppetlabs/packaging platform hash to include macOS 14 (Intel)
 - (maint) Add support for Debian 12 'bookworm'
+- (PA-5904) Add support for macOS 14 ARM 64 architecture
 ### Removed
 - (maint) Remove mk_repo command because it is no longer used.
 ### Changed

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -128,7 +128,7 @@ module Pkg
           repo: false,
         },
         '14' => {
-          architectures: ['x86_64'],
+          architectures: ['x86_64', 'arm64'],
           package_format: 'dmg',
           repo: false,
         },


### PR DESCRIPTION
…14 (ARM)

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
