### PR TITLE
(RE-14716) Bring back createrepo wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-13685) Use a wrapper script, rather than inlined bash, to the 'createrepo' command
 
 ## [0.114.0] - 2024-02-07
 ### Added
@@ -14,10 +16,13 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (PA-5878) Add support for macOS 14 (Intel)
 - (PA-5551) Add support for Debian 12 'bookworm'
 - (PA-5904) Add support for macOS 14 ARM 64 architecture
+
 ### Removed
 - (maint) Remove mk_repo command because it is no longer used.
+
 ### Changed
 - (maint) some internal code cleanup to appease Rubocop
+- (RE-13865) Use a wrapper script, rather than inlined bash, to the 'createrepo' command
 
 ## [0.112.0] - 2023-11-16
 ### Added

--- a/lib/packaging/rpm/repo.rb
+++ b/lib/packaging/rpm/repo.rb
@@ -40,7 +40,25 @@ module Pkg::Rpm::Repo
       end
     end
 
+    ##
+    ## Let a wrapper script handle lock setting and pathing for the createrepo command
+    ##
     def repo_creation_command(repo_directory, artifact_paths = nil)
+      artifact_paths_argument = if artifact_paths
+                                  artifact_paths.join(' ')
+                                else
+                                  ''
+                                end
+      "/usr/local/bin/packaging-createrepo-wrapper #{repo_directory} #{artifact_paths_argument}"
+    end
+
+
+    ##
+    ## Deprecated
+    ## This was a slightly tortous way of going about this. Instead, see above.
+    ## Instead of constructing loop, let a wrapper script handle the details.
+    ##
+    def deprecated_repo_creation_command(repo_directory, artifact_paths = nil)
       cmd = "[ -d #{repo_directory} ] || exit 1 ; "
       cmd << "pushd #{repo_directory} > /dev/null && "
       cmd << 'echo "Checking for running repo creation. Will wait if detected." && '
@@ -131,14 +149,19 @@ module Pkg::Rpm::Repo
     end
 
     def retrieve_repo_configs(target = "repo_configs")
-      wget = Pkg::Util::Tool.check_tool("wget")
+      wget = Pkg::Util::Tool.check_tool('wget')
       FileUtils.mkdir_p("pkg/#{target}")
       config_url = "#{base_url}/#{target}/rpm/"
+
+      config_fetch_command = <<~CONFIG_FETCH_COMMAND.gsub(%r{\n}, ' ')
+        #{wget} --recursive --no-parent --no-host-directories --cut-dirs=3
+            "--directory-prefix=pkg/#{target} --reject='index' #{config_url}"
+      CONFIG_FETCH_COMMAND
+
       begin
-        stdout, = Pkg::Util::Execution.capture3("#{wget} -r -np -nH --cut-dirs 3 -P pkg/#{target} --reject 'index*' #{config_url}")
-        stdout
+        Pkg::Util::Execution.capture3(config_fetch_command)[0]
       rescue StandardError => e
-        fail "Couldn't retrieve rpm yum repo configs.\n#{e}"
+        fail "\"#{config_fetch_command} failed.\n#{e}"
       end
     end
 
@@ -152,27 +175,21 @@ module Pkg::Rpm::Repo
     def generate_repo_configs(source = "repos", target = "repo_configs", signed = false)
       # We have a hard requirement on wget because of all the download magicks
       # we have to do
-      #
       wget = Pkg::Util::Tool.check_tool("wget")
 
       # This is the standard path to all build artifacts on the distribution
       # server for this commit
-      #
       repo_base = "#{base_url}/#{source}/"
-
-      # First check if the artifacts directory exists
-      #
 
       # We have to do two checks here - first that there are directories with
       # repodata folders in them, and second that those same directories also
       # contain rpms
-      #
       stdout, = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 5 --no-parent #{repo_base} 2>&1")
-      stdout = stdout.split.uniq.reject { |x| x =~ /\?|index/ }.select { |x| x =~ /http:.*repodata\/$/ }
+      stdout = stdout.split.uniq.reject { |x| x =~ /\?|index/ }
+        .select { |x| x =~ /http:.*repodata\/$/ }
 
       # RPMs will always exist at the same directory level as the repodata
       # folder, which means if we go up a level we should find rpms
-      #
       yum_repos = []
       stdout.map { |x| x.chomp('repodata/') }.each do |url|
         output, = Pkg::Util::Execution.capture3("#{wget} --spider -r -l 1 --no-parent #{url} 2>&1")

--- a/spec/lib/packaging/rpm/repo_spec.rb
+++ b/spec/lib/packaging/rpm/repo_spec.rb
@@ -98,10 +98,10 @@ describe 'Pkg::Rpm::Repo' do
       expect(FileUtils).to receive(:mkdir_p).with('pkg/repo_configs').and_return(true)
       expect(Pkg::Util::Execution)
         .to receive(:capture3)
-        .with("#{wget} -r -np -nH --cut-dirs 3 -P pkg/repo_configs --reject 'index*' #{base_url}/repo_configs/rpm/")
+        .with(%r{#{wget}.*/repo_configs/rpm})
         .and_raise(RuntimeError)
       expect { Pkg::Rpm::Repo.retrieve_repo_configs }
-        .to raise_error(RuntimeError, /Couldn't retrieve rpm yum repo configs/)
+        .to raise_error(RuntimeError, %r{failed\.$})
     end
   end
 


### PR DESCRIPTION
Having installed `packaging-createrepo-wrapper` on composer-* and nonpe-repos1* this should now work unless there are other machine missing it.

Revert "(RE-15909) Revert createrepo changes"

This reverts commit 6023d6b05bebd9cd11f3c04e60704efe689b6c4b.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
