### PR TITLE
Export GEM_SOURCE to remote machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Pass GEM_SOURCE environmental variable to remote hosts.
+
 ## [0.115.0] - 2024-02-13
 ### Changed
 - (RE-13685) Reintroduce wrapper script, rather than inlined bash, to the 'createrepo' command

--- a/lib/packaging/util/net.rb
+++ b/lib/packaging/util/net.rb
@@ -393,7 +393,8 @@ module Pkg::Util::Net
       rvm_ruby_version = ENV['RVM_RUBY_VERSION'] || '3.1.1'
       export_packaging_location = "export PACKAGING_LOCATION='#{ENV['PACKAGING_LOCATION']}';" if ENV['PACKAGING_LOCATION'] && !ENV['PACKAGING_LOCATION'].empty?
       export_vanagon_location = "export VANAGON_LOCATION='#{ENV['VANAGON_LOCATION']}';" if ENV['VANAGON_LOCATION'] && !ENV['VANAGON_LOCATION'].empty?
-      "source /usr/local/rvm/scripts/rvm; rvm use ruby-#{rvm_ruby_version}; #{export_packaging_location} #{export_vanagon_location} bundle install --path .bundle/gems ;"
+      export_gem_source = "export GEM_SOURCE='#{ENV['GEM_SOURCE']}';" if ENV['GEM_SOURCE'] && !ENV['GEM_SOURCE'].empty?
+      "source /usr/local/rvm/scripts/rvm; rvm use ruby-#{rvm_ruby_version}; #{export_gem_source} #{export_packaging_location} #{export_vanagon_location} bundle install --path .bundle/gems ;"
     end
 
     # Given a BuildInstance object and a host, send its params to the host. Return


### PR DESCRIPTION
Previously, when executing a command on a remote machine, packaging exported some environmental variables such as PACKAGING_LOCATION and VANAGON_LOCATION which allowed commands run on a remote machine to maintain the same environment.

However, GEM_SOURCE was not among those exported environmental variables. If a project was using a gem not found on Rubygems--in my case, pl_fustigit hosted on Artifactory--that gem could be installed locally by using the source defined in GEM_SOURCE, but not remotely.

This commit checks whether the GEM_SOURCE environmental variable is defined and, if it is and isn't empty, exports it to a remote machine with other environmental variables.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
