### PR TITLE
(RE-16211) Leave off signing Ips in nightlies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
 - (PA-4673) Added platform for RedHat 9 (Power9)
 
+### Fixed
+- (RE-16211) Leave off signing Ips in nightlies. We'll put the GPG-signing remediation back in
+  in a future version.
+
 ## [0.117.0] - 2024-03-26
 ### Added
 - (PA-6027) Add support for Ubuntu 24.04 noble

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -39,7 +39,8 @@ namespace :pl do
       Pkg::Rpm::Repo.sign_repos('repos')
       Pkg::Deb::Repo.sign_repos('repos', 'Apt repository for signed builds')
       Pkg::Sign::Dmg.sign('repos') unless Dir['repos/apple/**/*.dmg'].empty?
-      Pkg::Sign::Ips.sign('repos') unless Dir['repos/solaris/11/**/*.p5p'].empty?
+      ### RE-16211: we should put this back and unify with the code in sign.rake
+      # Pkg::Sign::Ips.sign('repos') unless Dir['repos/solaris/11/**/*.p5p'].empty?
       Pkg::Sign::Msi.sign('repos') unless Dir['repos/windows/**/*.msi'].empty?
     end
 


### PR DESCRIPTION
We'll put the GPG-signing remediation back in in a future version.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.