### PR TITLE
(RE-16160) Revive sign/ips.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-16160) Revive sign/ips.rb so that GPG .asc generation for Solaris packages are handled
+  in a single method.
 
 ## [0.118.0] - 2024-04-05
 ### Added

--- a/lib/packaging/sign.rb
+++ b/lib/packaging/sign.rb
@@ -1,6 +1,7 @@
 module Pkg::Sign
   require 'packaging/sign/deb'
   require 'packaging/sign/dmg'
+  require 'packaging/sign/ips'
   require 'packaging/sign/msi'
   require 'packaging/sign/rpm'
 end

--- a/lib/packaging/sign/ips.rb
+++ b/lib/packaging/sign/ips.rb
@@ -1,0 +1,13 @@
+module Pkg::Sign::Ips
+  module_function
+
+  def sign(ips_dir = 'pkg')
+    packages = Dir["#{ips_dir}/**/*.p5p"]
+    return if packages.empty?
+
+    Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
+    packages.each do |p5p_package|
+      Pkg::Util::Gpg.sign_file(p5p_package)
+    end
+  end
+end

--- a/tasks/nightly_repos.rake
+++ b/tasks/nightly_repos.rake
@@ -39,8 +39,7 @@ namespace :pl do
       Pkg::Rpm::Repo.sign_repos('repos')
       Pkg::Deb::Repo.sign_repos('repos', 'Apt repository for signed builds')
       Pkg::Sign::Dmg.sign('repos') unless Dir['repos/apple/**/*.dmg'].empty?
-      ### RE-16211: we should put this back and unify with the code in sign.rake
-      # Pkg::Sign::Ips.sign('repos') unless Dir['repos/solaris/11/**/*.p5p'].empty?
+      Pkg::Sign::Ips.sign('repos') unless Dir['repos/solaris/11/**/*.p5p'].empty?
       Pkg::Sign::Msi.sign('repos') unless Dir['repos/windows/**/*.msi'].empty?
     end
 

--- a/tasks/sign.rake
+++ b/tasks/sign.rake
@@ -45,13 +45,8 @@ namespace :pl do
   desc "Sign ips package, defaults to PL key, pass GPG_KEY to override"
   task :sign_ips, :root_dir do |_t, args|
     ips_dir = args.root_dir || $DEFAULT_DIRECTORY
-    packages = Dir["#{ips_dir}/**/*.p5p"]
-    next if packages.empty?
-
-    Pkg::Util::Gpg.load_keychain if Pkg::Util::Tool.find_tool('keychain')
-    packages.each do |p5p_package|
-      Pkg::Util::Gpg.sign_file p5p_package
-    end
+    next if Dir["#{ips_dir}/**/*.p5p"].empty?
+    Pkg::Sign::Ips.sign(ips_dir)
   end
 
   desc "Sign built gems, defaults to PL key, pass GPG_KEY to override or edit build_defaults"


### PR DESCRIPTION
There are two code paths for signing, one for nightly builds and one
for shipped packages. Revive sign/ips.rb so that Solaris "signing" as
it is is encapsulated in one place.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.