### PR TITLE
(maint) delete obsolete 'apt_stage_artifacts' dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-16160) Revive sign/ips.rb so that GPG .asc generation for Solaris packages are handled
   in a single method.
 
+### Removed
+- (maint) deleted obsolete apt_stage_artifacts dependency
+
 ## [0.118.0] - 2024-04-05
 ### Added
 - (PA-4673) Added platform for RedHat 9 (Power9)

--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('rubocop')
 
-  gem.add_runtime_dependency('apt_stage_artifacts')
   gem.add_runtime_dependency('artifactory', ['~> 3'])
   gem.add_runtime_dependency('csv', ['>= 3.1.5'])
   gem.add_runtime_dependency('googleauth')


### PR DESCRIPTION
We had an effort to refactor our debian repositories. The apt_stage_artifacts gem was part of that effort. We abandoned it an its now obsolete.