### PR TITLE
Copy amazon 7 to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- Add Amazon 2 (ARM) packaging platform
 
 ## [0.119.0] - 2024-05-06
 ### Added

--- a/lib/packaging/platforms.rb
+++ b/lib/packaging/platforms.rb
@@ -44,6 +44,14 @@ module Pkg
           signature_format: 'v4',
           repo: true,
         },
+        '2' => {
+          architectures: ['aarch64'],
+          source_architecture: 'SRPMS',
+          package_format: 'rpm',
+          source_package_formats: ['src.rpm'],
+          signature_format: 'v4',
+          repo: true,
+        },
       },
 
       'debian' => {


### PR DESCRIPTION
Add an entry in the packaging hash for Amazon 2 that is a copy of Amazon 7.
Since it's an addition, it's not a breaking change.