### PR TITLE
(RE-16497) Add rexml as a dependency in the gemspec because it is needed by the artifactory gem.

### DIFF
--- a/packaging.gemspec
+++ b/packaging.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('google-cloud-storage')
   gem.add_runtime_dependency('rake', ['>= 12.3'])
   gem.add_runtime_dependency('release-metrics')
+  gem.add_runtime_dependency('rexml')
 
   gem.require_path = 'lib'
 


### PR DESCRIPTION
This dependency issue is causing vanagon ship jobs to fail.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
