### PR TITLE
(RE-16628) Revert "(RE-16624) Temporarily stub OS/X signing"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (RE-16628) Unstub OS/X signing
 
 ## [0.122.1] - 2024-10-01
 ### Changed

--- a/lib/packaging/sign/dmg.rb
+++ b/lib/packaging/sign/dmg.rb
@@ -1,12 +1,7 @@
 module Pkg::Sign::Dmg
   module_function
 
-  def sign(_)
-    warn 'OSX SIGNING TEMPORARILY STUBBED. SEE RE-16623'
-    return 0
-  end
-
-  def stubbed__sign(pkg_directory = 'pkg')
+  def sign(pkg_directory = 'pkg')
     use_identity = ''
     unless Pkg::Config.osx_signing_ssh_key.nil?
       use_identity = "-i #{Pkg::Config.osx_signing_ssh_key}"


### PR DESCRIPTION
This reverts commit 3d783b7454e0269d90dcd0afec2f68e64b323957.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.