### PR TITLE
(maint) Add PACKAGING_GITREF_REPLACEMENT envvar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- (maint) Provide a mechanism, by way of a new environment variable `PACKAGING_GITREF_REPLACEMENT`,
+  which allows us to not require a release tag before building product.
 
 ## [0.122.3] - 2024-11-28
 ### Changed

--- a/lib/packaging/config.rb
+++ b/lib/packaging/config.rb
@@ -290,18 +290,20 @@ module Pkg
       #   really belongs in the Rpm object.
 
       def load_versioning
-        if @project_root and Pkg::Util::Git.describe
-          @ref         = Pkg::Util::Git.sha_or_tag
-          @short_ref   = Pkg::Util::Git.sha_or_tag(7)
-          @version     = Pkg::Util::Version.dash_version
-          @gemversion  = Pkg::Util::Version.dot_version
-          @debversion  = Pkg::Util::Version.debversion
-          @origversion = Pkg::Util::Version.origversion
-          @rpmversion  = Pkg::Util::Version.rpmversion
-          @rpmrelease  = Pkg::Util::Version.rpmrelease
-        else
-          puts "Skipping determination of version via git describe, Pkg::Config.project_root is not set to the path of a tagged git repo."
+        unless @project_root && Pkg::Util::Git.describe
+          puts 'Skipping determination of version via git describe, Pkg::Config.project_root ' \
+               'is not set to the path of a tagged git repo.'
+          return
         end
+
+        @ref = Pkg::Util::Git.sha_or_tag
+        @short_ref = Pkg::Util::Git.sha_or_tag(7)
+        @version = Pkg::Util::Version.dash_version
+        @gemversion = Pkg::Util::Version.dot_version
+        @debversion = Pkg::Util::Version.debversion
+        @origversion = Pkg::Util::Version.origversion
+        @rpmversion = Pkg::Util::Version.rpmversion
+        @rpmrelease = Pkg::Util::Version.rpmrelease
       end
 
       ##
@@ -312,15 +314,16 @@ module Pkg
       #
       def load_envvars
         Pkg::Params::ENV_VARS.each do |v|
-          if var = ENV[v[:envvar].to_s]
-            case v[:type]
-            when :bool
-              self.instance_variable_set("@#{v[:var]}", Pkg::Util.boolean_value(var))
-            when :array
-              self.instance_variable_set("@#{v[:var]}", string_to_array(var))
-            else
-              self.instance_variable_set("@#{v[:var]}", var)
-            end
+          var = ENV[v[:envvar].to_s]
+          next unless var
+
+          case v[:type]
+          when :bool
+            self.instance_variable_set("@#{v[:var]}", Pkg::Util.boolean_value(var))
+          when :array
+            self.instance_variable_set("@#{v[:var]}", string_to_array(var))
+          else
+            self.instance_variable_set("@#{v[:var]}", var)
           end
         end
       end

--- a/lib/packaging/config/params.rb
+++ b/lib/packaging/config/params.rb
@@ -276,6 +276,7 @@ module Pkg::Params
               { :var => :project_root,            :envvar => :PROJECT_ROOT },
               { :var => :random_mockroot,         :envvar => :RANDOM_MOCKROOT, :type => :bool },
               { :var => :rc_mocks,                :envvar => :MOCK },
+              { :var => :ref,                     :envvar => :PACKAGING_GITREF_REPLACEMENT },
               { :var => :release,                 :envvar => :RELEASE },
               { :var => :repo_name,               :envvar => :REPO_NAME },
               { :var => :repo_link_target,        :envvar => :REPO_LINK_TARGET },

--- a/lib/packaging/util/windows.rb
+++ b/lib/packaging/util/windows.rb
@@ -12,7 +12,11 @@ module Pkg::Util::Windows
         packages = Dir["#{local_source_directory}/#{platform}/*"]
 
         archs.each do |arch|
-          package_version = Pkg::Util::Git.describe.tr('-', '.')
+          package_version = if ENV.key?('PACKAGING_GITREF_REPLACEMENT')
+                              ENV['PACKAGING_GITREF_REPLACEMENT']
+                            else
+                              Pkg::Util::Git.describe.tr('-', '.')
+                            end
           package_filename = File.join(
             local_source_directory, platform,
             "#{Pkg::Config.project}-#{package_version}-#{arch}.msi"

--- a/tasks/ship.rake
+++ b/tasks/ship.rake
@@ -654,6 +654,11 @@ namespace :pl do
 
       target = args.target || 'artifacts'
       local_dir = args.local_dir || 'pkg'
+
+      warn "jenkins_repo_path: #{Pkg::Config.jenkins_repo_path}"
+      warn "project: #{Pkg::Config.project}"
+      warn "ref: #{Pkg::Config.ref}"
+
       project_basedir = File.join(
         Pkg::Config.jenkins_repo_path, Pkg::Config.project, Pkg::Config.ref
       )


### PR DESCRIPTION
We want to not require a git tag to build & release a package. Allow the environment
variable PACKAGING_GITREF_REPLACEMENT to do that.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.