### PR TITLE
(maint) Accept ARTIFACTORY_ACCESS_TOKEN in check_authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
 ### Added
+- (maint) Accept `ARTIFACTORY_ACCESS_TOKEN` in `check_authorization` so callers can authenticate
+  with a scoped access token or reference token. `ARTIFACTORY_API_KEY` is still accepted for
+  backwards compatibility, but JFrog has deprecated API-key auth (blocked new keys in Artifactory
+  7.98) and callers should migrate.
 - (maint) Provide a mechanism, by way of a new environment variable `PACKAGING_GITREF_REPLACEMENT`,
   which allows us to not require a release tag before building product.
 

--- a/lib/packaging/artifactory.rb
+++ b/lib/packaging/artifactory.rb
@@ -134,7 +134,9 @@ module Pkg
     # Verify the correct environment variables are set in order to process
     # authorization to access the artifactory repos
     def check_authorization
-      unless (ENV['ARTIFACTORY_USERNAME'] && ENV['ARTIFACTORY_PASSWORD']) || ENV['ARTIFACTORY_API_KEY']
+      unless (ENV['ARTIFACTORY_USERNAME'] && ENV['ARTIFACTORY_PASSWORD']) ||
+             ENV['ARTIFACTORY_ACCESS_TOKEN'] ||
+             ENV['ARTIFACTORY_API_KEY']
         raise <<-DOC
   Unable to determine credentials for Artifactory. Please set one of the
   following environment variables:
@@ -143,10 +145,11 @@ module Pkg
   ARTIFACTORY_USERNAME
   ARTIFACTORY_PASSWORD
 
-  If you would like to use the API key, ensure ARTIFACTORY_USERNAME and
-  ARTIFACTORY_PASSWORD are not set, as these take precedence. Instead, please
-  set:
-  ARTIFACTORY_API_KEY
+  For scoped access token or reference token authentication, please set:
+  ARTIFACTORY_ACCESS_TOKEN
+
+  ARTIFACTORY_API_KEY is also accepted for backwards compatibility, but is
+  deprecated by JFrog and should be migrated to ARTIFACTORY_ACCESS_TOKEN.
 
   You can also set the path to a pem file with your custom certificates with:
   ARTIFACTORY_SSL_PEM_FILE

--- a/spec/lib/packaging/artifactory_spec.rb
+++ b/spec/lib/packaging/artifactory_spec.rb
@@ -200,11 +200,29 @@ describe 'artifactory.rb' do
   end
 
   describe '#check_authorization' do
+    let(:auth_env_vars) {
+      %w[ARTIFACTORY_USERNAME ARTIFACTORY_PASSWORD ARTIFACTORY_ACCESS_TOKEN ARTIFACTORY_API_KEY]
+    }
+
+    around(:each) do |example|
+      originals = auth_env_vars.each_with_object({}) { |k, h| h[k] = ENV[k] }
+      auth_env_vars.each { |k| ENV[k] = nil }
+      example.run
+      originals.each { |k, v| ENV[k] = v }
+    end
+
     it 'fails gracefully if authorization is not set' do
-      original_artifactory_api_key = ENV['ARTIFACTORY_API_KEY']
-      ENV['ARTIFACTORY_API_KEY'] = nil
       expect { artifact.deploy_package('path/to/el/7/x86_64/package.rpm') }.to raise_error
-      ENV['ARTIFACTORY_API_KEY'] = original_artifactory_api_key
+    end
+
+    it 'accepts ARTIFACTORY_ACCESS_TOKEN as an auth source' do
+      ENV['ARTIFACTORY_ACCESS_TOKEN'] = 'anaccesstokenthatdefinitelyworks'
+      expect { artifact.send(:check_authorization) }.not_to raise_error
+    end
+
+    it 'still accepts ARTIFACTORY_API_KEY for backwards compatibility' do
+      ENV['ARTIFACTORY_API_KEY'] = 'anapikeythatdefinitelyworks'
+      expect { artifact.send(:check_authorization) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Summary

- `check_authorization` in `lib/packaging/artifactory.rb` now accepts `ARTIFACTORY_ACCESS_TOKEN` alongside the existing `ARTIFACTORY_USERNAME`/`ARTIFACTORY_PASSWORD` and `ARTIFACTORY_API_KEY` variants.
- Error message updated to guide callers toward `ARTIFACTORY_ACCESS_TOKEN` and note that `ARTIFACTORY_API_KEY` is deprecated by JFrog.
- Spec extended with positive tests for both the new access-token path and the existing (deprecated) api-key path, with an `around` hook that isolates env-var state per example.

## Why

JFrog deprecated API-key authentication and blocked new API-key creation starting with **Artifactory 7.98**. The bundled `puppet-artifactory-client` SDK already accepts an access token via `ARTIFACTORY_ACCESS_TOKEN` (see `lib/artifactory/defaults.rb` / `lib/artifactory/client.rb` in that repo — the auth precedence there is username+password → access_token → api_key). But this gem's `check_authorization` only recognized the old set, so any caller that migrated to a scoped access token or reference token would hit the "Unable to determine credentials" error even though the underlying SDK would authenticate fine.

This is a prerequisite for the on-prem Artifactory upgrade to 7.146.x — we need callers to be able to run against a new access token without changing this gem's semantics for existing callers.

## Test plan

- [x] `bundle exec rspec spec/lib/packaging/artifactory_spec.rb` — 66 examples, 0 failures locally.
- [ ] CI passes.

## Notes

- `ARTIFACTORY_API_KEY` remains fully supported for backwards compatibility until existing callers migrate. No behavior change for them.
- Priority order between the three auth surfaces is delegated to the SDK, which currently prefers basic auth → access token → api key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)